### PR TITLE
공통기반 핵심 > The ApplicationContext 문서 수정

### DIFF
--- a/egovframe-runtime/foundation-layer-core/ioc-container-the_applicationcontext.md
+++ b/egovframe-runtime/foundation-layer-core/ioc-container-the_applicationcontext.md
@@ -28,7 +28,7 @@
 
 ### MessageSources를 사용한 국제화(Internationalization using MessageSources)
 
- 본 장의 내용은 [Resource](https://www.egovframe.go.kr//wiki/doku.php?id=egovframework:rte:fdl:resource)를 참조한다.
+ 본 장의 내용은 [Resource](./resource.md)를 참조한다.
 
 ### Event
 


### PR DESCRIPTION
- 공통기반 핵심 > IoC Container > The ApplicationContext 문서 오류 수정 (외/내부 링크)
- 기존 가이드 링크(dokuwiki)를 변환된 markdown 내부 문서 링크로 수정 : Resource