### PR TITLE
연계통합 > WebService 문서 수정

### DIFF
--- a/egovframe-runtime/integration-layer/webservice.md
+++ b/egovframe-runtime/integration-layer/webservice.md
@@ -22,7 +22,7 @@ WebService는 Web Service 구현하기 위해서 [Apache CXF](https://cxf.apache
 
 ## 설명
 
-WebService는 [Integration Service](https://github.com/eGovFramework/egovframe-docs/blob/contribution/egovframe-runtime/integration-layer/integration-service.md) 표준에 따라 구현한 Library이므로, 본 장에서는 API 등의 사용 방식은 설명하지 않는다. 본 장은 WebService 만을 위한 추가적인 설정 정보를 설명하고, 설정 방법을 가이드한다.
+WebService는 [Integration Service](./integration-service.md) 표준에 따라 구현한 Library이므로, 본 장에서는 API 등의 사용 방식은 설명하지 않는다. 본 장은 WebService 만을 위한 추가적인 설정 정보를 설명하고, 설정 방법을 가이드한다.
 
 ### Metadata
 
@@ -399,7 +399,7 @@ WebService를 위한 기본적인 설정이 포함된 “context-webservice.xml�
 
 ### Client 모듈 개발
 
-WebService Client 모듈은 Web Service로 공개된 Integration 서비스 표준에 따라 호출하는 모듈로서, 본 장은 설정 방식을 설명한다. (호출 방식은 [연계 서비스 API](https://github.com/eGovFramework/egovframe-docs/blob/contribution/egovframe-runtime/integration-layer/integration-service-api.md)를 참조한다.)<br/>
+WebService Client 모듈은 Web Service로 공개된 Integration 서비스 표준에 따라 호출하는 모듈로서, 본 장은 설정 방식을 설명한다. (호출 방식은 [연계 서비스 API](./integration-service-api.md)를 참조한다.)<br/>
 Client 모듈을 설정하기 위해서는 다음 과정이 필요하다.
 
 1. [Metadata WEB_SERVICE_CLIENT 설정 추가](#metadata-web_service_client-설정-추가)
@@ -645,6 +645,6 @@ WebLogic 9.2 버전은 J2EE 1.4까지만 지원하므로, JAX-WS 2.0을 지원�
 
 ## 참고자료
 
-- [Integration Service](https://github.com/eGovFramework/egovframe-docs/blob/contribution/egovframe-runtime/integration-layer/integration-service.md)
+- [Integration Service](./integration-service.md)
 - https://cxf.apache.org
 


### PR DESCRIPTION
- 연계통합 > WebService 문서 링크 수정 (내/외부 링크)
- 내부 문서(Markdown) 링크는 절대 경로가 아닌 상대 경로로 수정 : 연계 서비스 API, Integration Service  (절대 경로 사용 시 가이드를 정적 콘텐츠로 배포시 링크가 동작하지 않음)
- (참고) [전자정부 표준프레임워크 가이드](https://github.com/eGovFramework/egovframe-docs)
  - 외부 링크는 절대 경로를 사용하고, 내부 링크는 상대 경로를 사용합니다