### PR TITLE
데이터처리 > iBatis 문서 수정

### DIFF
--- a/egovframe-runtime/foundation-layer/file-handling.md
+++ b/egovframe-runtime/foundation-layer/file-handling.md
@@ -2,9 +2,9 @@
 
 ## 개요
 
-[File Handling Service](https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:rte2:fdl:file_handling) 를 적용해서 Excel 다운로드 하기 위한 Excel 정보를 설정한다.
+[File Handling Service](./file-handling.md) 를 적용해서 Excel 다운로드 하기 위한 Excel 정보를 설정한다.
 
-[Excel](https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:rte2:fdl:excel) Service에 적용되어 있다.
+[Excel](./excel-service.md) Service에 적용되어 있다.
 
 ## 설명
 

--- a/egovframe-runtime/persistence-layer/data-access.md
+++ b/egovframe-runtime/persistence-layer/data-access.md
@@ -16,13 +16,13 @@
 
 #### 세부 사항 설명
 
-- [iBATIS Configuration](https://www.egovframe.go.kr//wiki/doku.php?id=egovframework:rte3.5:psl:dataaccess:ibatis_configuration)
-- [Spring iBATIS Integration](https://www.egovframe.go.kr//wiki/doku.php?id=egovframework:rte3.5:psl:dataaccess:spring_ibatis_integration)
-- [Data Type](https://www.egovframe.go.kr//wiki/doku.php?id=egovframework:rte3.5:psl:dataaccess:data_type)
-- [parameterMap](https://www.egovframe.go.kr//wiki/doku.php?id=egovframework:rte3.5:psl:dataaccess:parametermap)
-- [Inline parameters](https://www.egovframe.go.kr//wiki/doku.php?id=egovframework:rte3.5:psl:dataaccess:inline_parameters)
-- [resultMap](https://www.egovframe.go.kr//wiki/doku.php?id=egovframework:rte3.5:psl:dataaccess:resultmap)
-- [Dynamic SQL](https://www.egovframe.go.kr//wiki/doku.php?id=egovframework:rte3.5:psl:dataaccess:dynamic_sql)
+- [iBATIS Configuration](./dataaccess-ibatis_configuration.md)
+- [Spring iBATIS Integration](./dataaccess-spring_ibatis_integration.md)
+- [Data Type](./dataaccess-data_type.md)
+- [parameterMap](./dataaccess-parametermap.md)
+- [Inline parameters](./dataaccess-inline_parameters.md)
+- [resultMap](./dataaccess-resultmap.md)
+- [Dynamic SQL](./dataaccess-dynamic_sql.md)
 
  iBATIS Data Mapper API 는 XML을 사용하여 SQL 문에 대한 객체 맵핑을 간편하게 기술할 수 있도록 지원하며, 자바빈즈 객체와 Map 구현체, 다양한 원시 래퍼 타입(String, Integer..) 등을 PreparedStatement 의 파라메터나 ResultSet에 대한 결과 객체로 쉽게 맵핑해준다.
 
@@ -395,6 +395,6 @@ public class BasicDataAccessTest {
 ## 참고 자료
 
 - [http://ibatis.apache.org](http://ibatis.apache.org)
-- [iBATIS-SqlMaps-2 Developer Guide](http://svn.apache.org/repos/asf/ibatis/trunk/java/ibatis-2/ibatis-2-docs/en/iBATIS-SqlMaps-2_en.pdf)
-- [iBATIS-SqlMaps-2 개발자 가이드 (이동국님 번역)](http://kldp.net/frs/download.php/5035/iBATIS-SqlMaps-2_ko.pdf)
+- [iBATIS-SqlMaps-2 Developer Guide](https://ibatis.apache.org/docs/java/pdf/iBATIS-SqlMaps-2_en.pdf)
+- [iBATIS-SqlMaps-2 개발자 가이드 (이동국님 번역)](https://ibatis.apache.org/docs/java/pdf/iBATIS-SqlMaps-2_ko.pdf)
 - [Spring Framework - Reference Documentation](http://static.springframework.org/spring/docs/2.5.6/reference/orm.html#orm-ibatis)


### PR DESCRIPTION
- 데이터처리 > iBatis(Data Access 서비스) 문서 링크, 참고자료 링크 수정 
- 기존 가이드 링크(dokuwiki)를 변환된 markdown 내부 문서 링크로 수정 
  - iBATIS Configuration, Spring iBATIS Integration, Data Type, parameterMap, Inline parameters, resultMap, Dynamic SQL
- 참고자료 링크 오류(404, 503) 수정 
  - iBATIS-SqlMaps-2 Developer Guide, iBATIS-SqlMaps-2 개발자 가이드 (이동국님 번역)




