### PR TITLE
logging-log4j2_configuration_file.md 오탈자 수정

### DIFF
--- a/egovframe-runtime/foundation-layer/logging-log4j2_configuration_file.md
+++ b/egovframe-runtime/foundation-layer/logging-log4j2_configuration_file.md
@@ -203,6 +203,7 @@ Log4j 2는 Console, File, RollingFile, Socket, DB 등 다양한 로그 출력 �
 | **FileAppender**       | `<File>`       | 파일에 출력           |
 | **RollingFileAppender**| `<RollingFile>`| 조건에 따라 파일에 출력 |
 | **JDBCAppender**       | `<JDBC>`       | RDB Table에 출력      |
+
 모든 Appender 요소는 상위 요소인 **&lt;Appenders&gt;** 아래에 선언한다.
 
 ```xml

--- a/egovframe-runtime/foundation-layer/logging-log4j2_configuration_file.md
+++ b/egovframe-runtime/foundation-layer/logging-log4j2_configuration_file.md
@@ -197,13 +197,12 @@ Log4j 2는 Console, File, RollingFile, Socket, DB 등 다양한 로그 출력 �
 본 페이지에서는 자주 사용되는 Console, File, RollingFile, JDBC Appender에 대해서만 설명한다.  
 출력 위치에 따라 Appender 종류와 설정 태그가 달라지며, 아래 표는 각 Appender 정의 태그와 출력 위치이다.
 
-| Appenders | 태그명 | 출력 위치 |
-| --- | --- | --- |
-| ConsoleAppneder | <Console> | 콘솔에 출력 |
-| FileAppneder | <File> | 파일에 출력 |
-| RollingFileAppneder | <RollingFile> | 조건에 따라 파일에 출력 |
-| JDBCAppender | <JDBC> | RDB Table에 출력 |
-
+| Appenders           | 태그명          | 출력 위치             |
+|---------------------|----------------|-----------------------|
+| **ConsoleAppender**    | `<Console>`    | 콘솔에 출력           |
+| **FileAppender**       | `<File>`       | 파일에 출력           |
+| **RollingFileAppender**| `<RollingFile>`| 조건에 따라 파일에 출력 |
+| **JDBCAppender**       | `<JDBC>`       | RDB Table에 출력      |
 모든 Appender 요소는 상위 요소인 **&lt;Appenders&gt;** 아래에 선언한다.
 
 ```xml


### PR DESCRIPTION
- Appender 선언과 정의 테이블의 태그명 미표기 문제를 마크다운 수정으로 해결했습니다.
- 참고 : https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:rte3:fdl:%EC%84%A4%EC%A0%95_%ED%8C%8C%EC%9D%BC%EC%9D%84_%EC%82%AC%EC%9A%A9%ED%95%98%EB%8A%94_%EB%B0%A9%EB%B2%95