### PR TITLE
업무처리 > SWF 시스템 설정: 개행 수정 및 링크 변경

### DIFF
--- a/egovframe-runtime/business-logic-layer/setting-system.md
+++ b/egovframe-runtime/business-logic-layer/setting-system.md
@@ -58,8 +58,7 @@ flow-registry는 아래 보는 것과 같이 설정을 할 수 있다.
 <!-- [4]ANT 패턴을 지정할 수도 있다. -->
 <webflow:flow-location-pattern value="/WEB-INF/flows/**/*-flow.xml" />
  
-<!--
-	[5]기본 앞 첨자 경로를 지정해서 위치를 조합해서 사용할 수도 있다. 
+<!-- [5]기본 앞 첨자 경로를 지정해서 위치를 조합해서 사용할 수도 있다. 
 	    Flow 정의 파일은 모듈화를 높이기 위해서 관련 있는 폴더에 각각 위치해 있는게 가장 좋다.	-->
 <webflow:flow-registry id="flowRegistry" base-path="/WEB-INF">
 	<webflow:flow-location path="/hotels/booking/booking.xml" />
@@ -81,11 +80,11 @@ flow-registry는 아래 보는 것과 같이 설정을 할 수 있다.
 
 flow-registry는 아래 보는 것과 같이 설정을 할 수 있다.
 
-flow-registry에서 flow-builder-services 는 flow를 구축하는데 사용되는 서비스나 설정 등을 커스터마이징 할 수 있다.
+flow-registry에서 flow-builder-services 는 flow를 구축하는데 사용되는 서비스나 설정 등을 커스터마이징 할 수 있다.<br/>
 지정하지 않는 경우에는 기본 서비스가 사용 된다.
 
 ```xml
-<webflow:flow-registry id="flowRegistry" 	flow-builder-services="flowBuilderServices">
+<webflow:flow-registry id="flowRegistry" flow-builder-services="flowBuilderServices">
 	<webflow:flow-location path="/WEB-INF/flows/booking/booking.xml" />
 </webflow:flow-registry>
  

--- a/egovframe-runtime/business-logic-layer/setting-system.md
+++ b/egovframe-runtime/business-logic-layer/setting-system.md
@@ -157,5 +157,5 @@ Flow 실행 당 받을 수 있는 이력 snapshot 개수 지정. snapshot을 사
 
 ## 참고자료
 
-- [Spring Web Flow reference 2.0.x](http://static.springframework.org/spring-webflow/docs/2.0.x/reference/html/index.html)
+- [Spring Web Flow Reference Guide 2.5.1](https://docs.spring.io/spring-webflow/docs/2.5.1.RELEASE/reference/html/)
 - Spring Web-Flow Framework Reference beta with Korean (by 박찬욱)


### PR DESCRIPTION
- 업무처리 > SWF 시스템 설정: 불필요한 개행 삭제, 개행 추가
- 업무처리 > SWF 시스템 설정: 링크 변경
  - 기존 링크 [https://docs.spring.io/spring-webflow/docs/2.0.x/reference/html/index.html] 사용 불가능
  - 2버전대 중 가장 최신인 2.5.1 버전 가이드 링크[https://docs.spring.io/spring-webflow/docs/2.5.1.RELEASE/reference/html/]로 교체