### PR TITLE
센터컷 가이드 구조의 사진이 이상하게 보이는 문제 수정

### DIFF
--- a/egovframe-runtime/batch-layer/batch-centercut-intro.md
+++ b/egovframe-runtime/batch-layer/batch-centercut-intro.md
@@ -8,7 +8,8 @@
 
 * Unordered List Item기본적으로 센터컷의 구조는 큐(Queue)를 이용하는 부분을 제외하고는 배치 프로그램과 유사하다.
 * Unordered List Item처음 ItemReader를 사용하여 데이터를 읽고 큐에 넣은 Center-Cut Reading Step과, 읽어온 데이터를 가공 후 QueueSender를 통해 Queue에 넣는 구조이다.
-![centercut-explain1](images/centercut-explain1.png)
+
+  ![centercut-explain1](images/centercut-explain1.png)
 * Center-Cut Process Step은 큐에서 들어온 데이터를 읽고 처리 모듈(Busineess Proc)를 활용하여 데이터를 처리하는 구조이다.
 ![centercut-queueproc1](images/centercut-queueproc1.png)
 


### PR DESCRIPTION
센터컷 가이드 구조의 사진이 이상하게 보이는 문제 수정

- 변경 전
<img width="631" alt="image" src="https://github.com/user-attachments/assets/2ecd8397-332c-4095-8dbb-543702fd5c68">

- 변경 후
<img width="1565" alt="image" src="https://github.com/user-attachments/assets/895501a5-cc71-4946-a657-64f395d311b2">
