### PR TITLE
일부 문서 가독성 개선

### DIFF
--- a/common-component/user-authentication/access-policy.md
+++ b/common-component/user-authentication/access-policy.md
@@ -32,7 +32,7 @@ menu:
 
  로그인정책관리 패키지는 요소기술의 공통(cmm) 패키지와 로그인 패키지에 대해서 직접적인 함수적 참조 관계를 가진다. 하지만, 컴포넌트 배포 시 오류 없이 실행되기 위하여 패키지 간의 참조관계에 따라 패키지와 포맷/날짜/계산, 메일연동 인터페이스, 시스템 패키지와 함께 배포 파일을 구성한다.
 
-- 패키지 간 참조 관계 : [사용자디렉토리/통합인증 Package Dependency](https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:com:v2:init_pkg_dependency#사용자디렉토리_통합인증)
+- 패키지 간 참조 관계 : [사용자디렉토리/통합인증 Package Dependency](../intro/package-reference.md)
 
 ### 관련소스
 
@@ -105,8 +105,7 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /uat/uap/selectLoginPolicyList.do | selectLoginPolicyList | “loginPolicyDAO.selectLoginPolicyList”, |
-|  |  |  | “loginPolicyDAO.selectLoginPolicyListTotCnt” |
+| 목록조회 | /uat/uap/selectLoginPolicyList.do | selectLoginPolicyList | “loginPolicyDAO.selectLoginPolicyList”, <br> “loginPolicyDAO.selectLoginPolicyListTotCnt” |
 
  ![로그인정책 목록조회](./images/uia-loginpolicyimg1.jpg)
 

--- a/common-component/user-authentication/login.md
+++ b/common-component/user-authentication/login.md
@@ -9,7 +9,6 @@ menu:
     parent: "user-authentication"
     identifier: "login"
 ---
-
 # 일반 로그인 서비스
 
 ## 개요
@@ -18,9 +17,9 @@ menu:
 
 - 기능흐름
 
-| 기능명 | 기능 흐름 |
-| --- | --- |
-| 일반 로그인 | 아이디/비밀번호 입력 → 로그인 요청 → *****권한조회*****  → *****세션설정*****  → *****로그인로그 생성*****  → *****권한별 메뉴설정*****  → 권한별 화면로딩 |
+| 기능명      | 기능 흐름                                                                                                                                                                                                               |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 일반 로그인 | 아이디/비밀번호 입력 → 로그인 요청 →*****권한조회*****  → *****세션설정*****  → *****로그인로그 생성*****  → *****권한별 메뉴설정*****  → 권한별 화면로딩 |
 
 - 로그인 컴포넌트 사용시 보안 고려사항
 
@@ -38,27 +37,27 @@ menu:
 
 ### 관련소스
 
-| 유형 | 대상소스명 | 비고 |
-| --- | --- | --- |
-| Controller | egovframework.com.uat.uia.web.EgovLoginController.java | 일반 로그인을 처리하는 컨트롤러 클래스 |
-| Service | egovframework.com.uat.uia.service.EgovLoginService.java | 일반 로그인을 처리하는 비즈니스 인터페이스 클래스 |
-| ServiceImpl | egovframework.com.uat.uia.service.impl.EgovLoginServiceImpl.java | 일반 로그인을 처리하는 비즈니스 구현 클래스 |
-| VO | egovframework.com.cmm.SessionVO.java | 세션을 위한 VO 클래스 |
-| VO | egovframework.com.cmm.LoginVO.java | 로그인을 위한 VO 클래스 |
-| DAO | egovframework.com.uat.uia.service.impl.LoginDAO.java | 일반 로그인을 처리하는 DAO 클래스 |
-| JSP | WEB\_INF/jsp/egovframework/com/uat/uia/EgovLoginUsr.jsp | Login 인증 JSP 페이지 |
-| JSP | WEB\_INF/jsp/egovframework/com/uat/uia/EgovIdPasswordSearch.jsp | 아이디/비밀번호 찾기를 위한 JSP 페이지 |
-| JSP | WEB\_INF/jsp/egovframework/com/uat/uia/EgovIdPasswordResult.jsp | 아이디/비밀번호 찾기 결과 JSP 페이지 |
-| Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_mysql.xml | 일반 로그인을위한 MySQL용 Query XML |
-| Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_oracle.xml | 일반 로그인을 위한 Oracle용 Query XML |
-| Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_tibero.xml | 일반 로그인을 위한 Tibero용 Query XML |
-| Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_altibase.xml | 일반 로그인을 위한 Altibase용 Query XML |
-| Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_cubrid.xml | 일반 로그인을 위한 Cubrid용 Query XML |
-| Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_maria.xml | 일반 로그인을 위한 Maria용 Query XML |
-| Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_postgres.xml | 일반 로그인을 위한 Postgres용 Query XML |
-| Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_goldilocks.xml | 일반 로그인을 위한 Goldilocks용 Query XML |
-| Message properties | resources/egovframework/message/com/message-common\_ko.properties | 일반 로그인을 위한 Message properties(한글) |
-| Message properties | resources/egovframework/message/com/message-common\_en.properties | 일반 로그인을 위한 Message properties(영문) |
+| 유형               | 대상소스명                                                                   | 비고                                              |
+| ------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------- |
+| Controller         | egovframework.com.uat.uia.web.EgovLoginController.java                       | 일반 로그인을 처리하는 컨트롤러 클래스            |
+| Service            | egovframework.com.uat.uia.service.EgovLoginService.java                      | 일반 로그인을 처리하는 비즈니스 인터페이스 클래스 |
+| ServiceImpl        | egovframework.com.uat.uia.service.impl.EgovLoginServiceImpl.java             | 일반 로그인을 처리하는 비즈니스 구현 클래스       |
+| VO                 | egovframework.com.cmm.SessionVO.java                                         | 세션을 위한 VO 클래스                             |
+| VO                 | egovframework.com.cmm.LoginVO.java                                           | 로그인을 위한 VO 클래스                           |
+| DAO                | egovframework.com.uat.uia.service.impl.LoginDAO.java                         | 일반 로그인을 처리하는 DAO 클래스                 |
+| JSP                | WEB\_INF/jsp/egovframework/com/uat/uia/EgovLoginUsr.jsp                      | Login 인증 JSP 페이지                             |
+| JSP                | WEB\_INF/jsp/egovframework/com/uat/uia/EgovIdPasswordSearch.jsp              | 아이디/비밀번호 찾기를 위한 JSP 페이지            |
+| JSP                | WEB\_INF/jsp/egovframework/com/uat/uia/EgovIdPasswordResult.jsp              | 아이디/비밀번호 찾기 결과 JSP 페이지              |
+| Query XML          | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_mysql.xml      | 일반 로그인을위한 MySQL용 Query XML               |
+| Query XML          | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_oracle.xml     | 일반 로그인을 위한 Oracle용 Query XML             |
+| Query XML          | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_tibero.xml     | 일반 로그인을 위한 Tibero용 Query XML             |
+| Query XML          | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_altibase.xml   | 일반 로그인을 위한 Altibase용 Query XML           |
+| Query XML          | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_cubrid.xml     | 일반 로그인을 위한 Cubrid용 Query XML             |
+| Query XML          | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_maria.xml      | 일반 로그인을 위한 Maria용 Query XML              |
+| Query XML          | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_postgres.xml   | 일반 로그인을 위한 Postgres용 Query XML           |
+| Query XML          | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_goldilocks.xml | 일반 로그인을 위한 Goldilocks용 Query XML         |
+| Message properties | resources/egovframework/message/com/message-common\_ko.properties            | 일반 로그인을 위한 Message properties(한글)       |
+| Message properties | resources/egovframework/message/com/message-common\_en.properties            | 일반 로그인을 위한 Message properties(영문)       |
 
 ### 클래스다이어그램
 
@@ -66,15 +65,11 @@ menu:
 
 ### 관련테이블
 
-| 테이블명 | 테이블명(영문) | 비고 |
-| --- | --- | --- |
-| 일반회원 | COMTNGNRLMBER | 일반회원 정보를 관리한다.  
-주민등록번호(IHIDNUM) 컬럼이 존재하나 데이터 저장 및 조회 로직에서는 제외되어 있으므로  
-필요시 **암호화**하여 구현해야 함 |
-| 기업회원 | COMTNENTRPRSMBER | 기업회원 정보를 관리한다.  
-신청인주민등록번호(APPLCNT\_IHIDNUM) 컬럼이 존재하나 데이터 저장 및 조회 로직에서는 제외되어 있으므로,  
-필요시 **암호화**하여 구현해야 함 |
-| 업무사용자 | COMTNEMPLYRINFO | 업무사용자 정보를 관리한다. |
+| 테이블명   | 테이블명(영문)   | 비고                                                                                                                                                                                     |
+| ---------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 일반회원   | COMTNGNRLMBER    | 일반회원 정보를 관리한다. <br> 주민등록번호(IHIDNUM) 컬럼이 존재하나 데이터 저장 및 조회 로직에서는 제외되어 있으므로 <br> 필요시 **암호화**하여 구현해야 함                |
+| 기업회원   | COMTNENTRPRSMBER | 기업회원 정보를 관리한다. <br> 신청인주민등록번호(APPLCNT_IHIDNUM) 컬럼이 존재하나 데이터 저장 및 조회 로직에서는 제외되어 있으므로, <br> 필요시 **암호화**하여 구현해야 함 |
+| 업무사용자 | COMTNEMPLYRINFO  | 업무사용자 정보를 관리한다.                                                                                                                                                              |
 
 ### 환경설정
 
@@ -82,7 +77,7 @@ menu:
 
 #### 로그인 성공 후 이동 페이지 설정
 
- 로그인이 성공적으로 수행되었을 경우 이후 이동할 페이지에 대한 설정은 globals.properties 파일의 lobals.MainPage 프러퍼티 값을 통해 설정할수 있다. 아래와 같이 설정할 수 있으며 사용자가 로그인에 성공한 경우 /EgovContent.do 페이지로 이동하게 된다.
+ 로그인이 성공적으로 수행되었을 경우 이후 이동할 페이지에 대한 설정은 globals.properties 파일의 `lobals.MainPage` 프러퍼티 값을 통해 설정할수 있다. 아래와 같이 설정할 수 있으며 사용자가 로그인에 성공한 경우 /EgovContent.do 페이지로 이동하게 된다.
 
 ```bash
 # MainPage Setting
@@ -91,11 +86,11 @@ Globals.MainPage = /EgovContent.do
 
 #### 세션방식 설정
 
- 1) context-egovuserdetailshelper.xml 수정 : 아래와 같이 egovUserDetailsSessionService빈 설정의 주석을 해제한 후 egovUserDetailsHelper 빈의 egovUserDetailsService 프러퍼티에 egovUserDetailsSessionService빈을 등록하면 된다.  
-\- beans의 profile속성은 Spring f/w ver 3.1부터 추가되었으며, Spring Container에서 bean적용이 달리 적용되도록 하는데 쓰인다.  
-Bean Definition Profiles - [bean_definition_profiles](https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:rte2:fdl:ioc_container:bean_definition_profiles)  
-\- 그리고 globals.properties에서 Globals.Auth = session 이나 Globals.Auth = security 를 통해서 사용자의 로그인시 인증방식을 세션방식 또는 Spring security 방식으로 결정할 수 있다.  
-Server Security 설정 간소화 - [xmlschema](https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:rte3:fdl:server_security:xmlschema)
+1) context-egovuserdetailshelper.xml 수정 : 아래와 같이 `egovUserDetailsSessionService`빈 설정의 주석을 해제한 후 `egovUserDetailsHelper` 빈의 `egovUserDetailsService` 프러퍼티에 `egovUserDetailsSessionService`빈을 등록하면 된다.
+   \- beans의 profile속성은 Spring f/w ver 3.1부터 추가되었으며, Spring Container에서 bean적용이 달리 적용되도록 하는데 쓰인다.
+   Bean Definition Profiles - [bean_definition_profiles](https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:rte2:fdl:ioc_container:bean_definition_profiles)
+   \- 그리고 globals.properties에서 `Globals.Auth = session` 이나 `Globals.Auth = security` 를 통해서 사용자의 로그인시 인증방식을 세션방식 또는 Spring security 방식으로 결정할 수 있다.
+   Server Security 설정 간소화 - [xmlschema](https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:rte3:fdl:server_security:xmlschema)
 
 ```xml
 <beans profile="session">  
@@ -119,13 +114,13 @@ Server Security 설정 간소화 - [xmlschema](https://www.egovframe.go.kr/wiki/
 	return "egovframework/com/uat/uia/EgovLoginUsr";
 ```
 
- 2) web.xml 수정 : 수정사항 없이 디폴트 설정대로 사용하면 된다.(아래의 스프링 시큐리티 관련 설정이 모두 주석이 되어 있는 상태)
+2) web.xml 수정 : 수정사항 없이 디폴트 설정대로 사용하면 된다.(아래의 스프링 시큐리티 관련 설정이 모두 주석이 되어 있는 상태)
 
 #### 스프링 시큐리티 프레임워크를 이용하는 설정
 
- 스프링 시큐리티관련 설정이 반드시 포함되어야 한다. ******context-security.xml*** *** 파일은 src/main/resources/egovframework/spring/com 폴더 아래 위치해야 한다.
+ 스프링 시큐리티관련 설정이 반드시 포함되어야 한다. **context-security.xml** 파일은 src/main/resources/egovframework/spring/com 폴더 아래 위치해야 한다.
 
- 1) context-egovuserdetailshelper.xml 수정 : 아래와 같이 egovUserDetailsSecurityService 빈 설정의 주석을 해제한 후 egovUserDetailsHelper 빈의 egovUserDetailsService 프러퍼티에 egovUserDetailsSecurityService 빈을 등록하면 된다.
+1) context-egovuserdetailshelper.xml 수정 : 아래와 같이 `egovUserDetailsSecurityService` 빈 설정의 주석을 해제한 후 `egovUserDetailsHelper` 빈의 `egovUserDetailsService` 프러퍼티에 `egovUserDetailsSecurityService` 빈을 등록하면 된다.
 
 ```xml
 <beans profile="security">  
@@ -141,11 +136,11 @@ Server Security 설정 간소화 - [xmlschema](https://www.egovframe.go.kr/wiki/
 </beans>
 ```
 
- 2) web.xml 수정 : 아래 설정 부분의 주석을 해제 하면 된다. EgovSpringSecurityLoginFilter 필터의 경우 로그인 인증이 실패할 경우 사용자에게 되돌려지 화면을 파라미터로 입력받고 있다. loginURL 파라미터값에 로그인 실패시에 리턴될 url경로를 입력하면 된다.
+2) web.xml 수정 : 아래 설정 부분의 주석을 해제 하면 된다. `EgovSpringSecurityLoginFilter` 필터의 경우 로그인 인증이 실패할 경우 사용자에게 되돌려지 화면을 파라미터로 입력받고 있다. `loginURL` 파라미터값에 로그인 실패시에 리턴될 url경로를 입력하면 된다.
 
 ### 인증방식 변경 및 확장
 
- 세션 및 스프링 시큐리티 이외의 방식을 사용해서 인증방식을 사용하려는 경우 EgovUserDetailsService 인터페이스를 구현해서 사용할 수 있다.
+ 세션 및 스프링 시큐리티 이외의 방식을 사용해서 인증방식을 사용하려는 경우 `EgovUserDetailsService` 인터페이스를 구현해서 사용할 수 있다.
 
 ```java
 package egovframework.com.cmm.service;
@@ -167,18 +162,18 @@ public interface EgovUserDetailsService {
  
 	/**
 	 * 인증된 사용자 여부를 체크한다.
-	 * @return Boolean - 인증된 사용자 여부(TRUE / FALSE)	
+	 * @return Boolean - 인증된 사용자 여부(TRUE / FALSE)
 	 */
 	public [Boolean](http://www.google.com/search?hl=en&q=allinurl%3Aboolean+java.sun.com&btnI=I%27m%20Feeling%20Lucky) isAuthenticated(); 
  
 }
 ```
 
- EgovUserDetailsService 구현 클래스를 적용하기 위해서는 먼저 EgovUserDetailsService 구현 클래스를 빈으로 등록 시킨후 egovUserDetailsHelper 빈 설정시에 egovUserDetailsService 프러퍼티 값에 EgovUserDetailsService 구현 클래스를 매핑해야 한다.
+ `EgovUserDetailsService` 구현 클래스를 적용하기 위해서는 먼저 `EgovUserDetailsService` 구현 클래스를 빈으로 등록 시킨후 `egovUserDetailsHelper` 빈 설정시에 `egovUserDetailsService` 프러퍼티 값에 `EgovUserDetailsService` 구현 클래스를 매핑해야 한다.
 
 ### 세션을 이용한 인증 구현 예
 
- getAuthenticatedUser() 메서드는 인증된 사용자 정보를 가지고 있는 VO 객체를 반환한다. 공통컴포넌트에서는 모든 사용자 정보를 egovframework.com.cmm.LoginVO 클래스를 이용해서 활용 하므로 egovframework.com.cmm.LoginVO 객체를 반환하도록 메서드를 구현하면 된다. 아래의 예제는 스프링 프레임워크를 활용하여 세션에서 loginVO 객체를 얻어 반환하는 예제이다.
+ `getAuthenticatedUser()` 메서드는 인증된 사용자 정보를 가지고 있는 VO 객체를 반환한다. 공통컴포넌트에서는 모든 사용자 정보를 `egovframework.com.cmm.LoginVO` 클래스를 이용해서 활용 하므로 `egovframework.com.cmm.LoginVO` 객체를 반환하도록 메서드를 구현하면 된다. 아래의 예제는 스프링 프레임워크를 활용하여 세션에서 loginVO 객체를 얻어 반환하는 예제이다.
 
 ```java
 public Object getAuthenticatedUser() {
@@ -188,7 +183,7 @@ public Object getAuthenticatedUser() {
 }
 ```
 
- getAuthorities() 메서드는 사용자가 가지고 있는 권한을 List 객체에 담아 반환한다. 권한 관리 패키지에서 사용할 수 있는 권한 정보를 List에 담아 반환하면 되며 아래의 예제는 임의적으로 권한 정보를 List에 넣어 반환하고 있다.
+ `getAuthorities()` 메서드는 사용자가 가지고 있는 권한을 List 객체에 담아 반환한다. 권한 관리 패키지에서 사용할 수 있는 권한 정보를 List에 담아 반환하면 되며 아래의 예제는 임의적으로 권한 정보를 List에 넣어 반환하고 있다.
 
 ```java
 public List<String> getAuthorities() {
@@ -206,7 +201,7 @@ public List<String> getAuthorities() {
 }
 ```
 
- isAuthenticated()메서드는 현재 사용자가 인증된 사용자인지 점검하기 위해 사용된다. 아래의 예제는 세션에 loginVO 값이 있는지 체크를 통해 인증여부를 검사하고 있다.
+ `isAuthenticated()`메서드는 현재 사용자가 인증된 사용자인지 점검하기 위해 사용된다. 아래의 예제는 세션에 `loginVO` 값이 있는지 체크를 통해 인증여부를 검사하고 있다.
 
 ```java
 public [Boolean](http://www.google.com/search?hl=en&q=allinurl%3Aboolean+java.sun.com&btnI=I%27m%20Feeling%20Lucky) isAuthenticated() {
@@ -229,7 +224,7 @@ public [Boolean](http://www.google.com/search?hl=en&q=allinurl%3Aboolean+java.su
 }
 ```
 
- \* 참조 : 세션을 이용해 인증 서비스를 구현한 공통컴포넌트의 egovframework.com.cmm.service.impl.EgovUserDetailsSessionServiceImpl 클래스
+ \* 참조 : 세션을 이용해 인증 서비스를 구현한 공통컴포넌트의 `egovframework.com.cmm.service.impl.EgovUserDetailsSessionServiceImpl` 클래스
 
 ## 관련기능
 
@@ -237,7 +232,7 @@ public [Boolean](http://www.google.com/search?hl=en&q=allinurl%3Aboolean+java.su
 
 #### 비즈니스 규칙
 
- 일반 로그인은 아이디와 비밀번호를 가지고 사용자 구분별 사용자정보를 조회한다.  
+ 일반 로그인은 아이디와 비밀번호를 가지고 사용자 구분별 사용자정보를 조회한다.
 조회된 사용자 정보를 통해 로그인 로그를 생성한다.
 
 #### 관련코드
@@ -246,10 +241,10 @@ public [Boolean](http://www.google.com/search?hl=en&q=allinurl%3Aboolean+java.su
 
 #### 관련화면 및 수행매뉴얼
 
-| Action | URL | Controller method | SQL Namespace | SQL QueryID |
-| --- | --- | --- | --- | --- |
-| 로그인화면 | /uat/uia/egovLoginUsr.do | loginUsrView |  |  |
-| 일반로그인 | /uat/uia/actionLogin.do | actionLogin | “LoginUsr” | “actionCrtfctLogin” |
+| Action     | URL                      | Controller method | SQL Namespace | SQL QueryID           |
+| ---------- | ------------------------ | ----------------- | ------------- | --------------------- |
+| 로그인화면 | /uat/uia/egovLoginUsr.do | loginUsrView      |               |                       |
+| 일반로그인 | /uat/uia/actionLogin.do  | actionLogin       | “LoginUsr”  | “actionCrtfctLogin” |
 
  ![image](./images/uat-egovloginusr.jpg)
 
@@ -263,9 +258,9 @@ public [Boolean](http://www.google.com/search?hl=en&q=allinurl%3Aboolean+java.su
 
  ※ 제공되는 초기 데이터에는 테스트용 사용자 정보가 포함되어 있다.(*****대소문자*****  유의)
 
-| 구분 | ID | PW | 비고 |
-| --- | --- | --- | --- |
-| 일반사용자 | USER | rhdxhd12 | 영문으로 공통12 |
+| 구분       | ID         | PW       | 비고            |
+| ---------- | ---------- | -------- | --------------- |
+| 일반사용자 | USER       | rhdxhd12 | 영문으로 공통12 |
 | 기업사용자 | ENTERPRISE | rhdxhd12 | 영문으로 공통12 |
-| 업무사용자 | TEST1 | rhdxhd12 | 영문으로 공통12 |
-|  | webmaster | rhdxhd12 | 영문으로 공통12 |
+| 업무사용자 | TEST1      | rhdxhd12 | 영문으로 공통12 |
+|            | webmaster  | rhdxhd12 | 영문으로 공통12 |

--- a/egovframe-development/test-tool/excel-test-report-detail.md
+++ b/egovframe-development/test-tool/excel-test-report-detail.md
@@ -99,26 +99,26 @@ JUnit TestCase를 자동화하게 되면 결과를 남기게 되는데, [Test Re
 
 | 구분                                        | 입력 파라미터                           | 설명                                                                                       | Default                           |
 | ------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------- |
-| XML로부터 테스트 결과 정보를 갖기 위한 정보 | JUnitReportParser parser                | JUnit XML Parser                                                                           | N/A                               |
-| XML로부터 테스트 결과 정보를 갖기 위한 정보 | List `<File>` xmlReportFileList       | JUnit Test XML 파일 Full Path 목록                                                         | 없으면 오류 처리                  |
-| XML로부터 테스트 결과 정보를 갖기 위한 정보 | List `<ReportTestSuite>` testSuites   | Test Suite Lists                                                                           | N/A                               |
-| 엑셀 파일 생성을 위해 필요한 정보           | File templatePath                       | Excel 리포트의 템플릿 리포트 파일의 Full Path                                              | "/template-junit.xls"의 파일 객체 |
-| 엑셀 파일 생성을 위해 필요한 정보           | File outputDirectory                    | Excel 파일이 작성될 디렉토리 위치                                                          | 없으면 오류 처리                  |
-| 엑셀 파일 생성을 위해 필요한 정보           | String outputName                       | Excel 리포트 파일명                                                                        | "egovtest-junit.xls"              |
-| POI 엑셀 파일 정보                          | HSSFWorkbook book                       | POI 엑셀 파일 정보                                                                         | N/A                               |
-| 템플릿 엑셀 파일의 각 헤더 위치 정보        | int[] summaryPosInfos                   | Summary 헤더 위치 정보                                                                     | { 0, 0, 3 }                       |
-| 템플릿 엑셀 파일의 각 헤더 위치 정보        | int[] packagePosInfos                   | Package 헤더 위치 정보                                                                     | { 0, 0, 7 }                       |
-| 템플릿 엑셀 파일의 각 헤더 위치 정보        | int[] listsPosInfos                     | TestCase Lists 헤더 위치 정보                                                              | { 1, 0, 3 }                       |
-| 상수                                        | IDX_SHEET = 0, IDX_COL = 1, IDX_ROW = 2 | 템플릿 엑셀 파일의 헤더 위치 정보를 담고 있는 Array의 인덱스 상수. sheet, column, row 순서 |                                   |
+| XML로부터 테스트 결과 정보를 갖기 위한 정보 | `JUnitReportParser parser`                | JUnit XML Parser                                                                           | N/A                               |
+| XML로부터 테스트 결과 정보를 갖기 위한 정보 | `List <File> xmlReportFileList`       | JUnit Test XML 파일 Full Path 목록                                                         | 없으면 오류 처리                  |
+| XML로부터 테스트 결과 정보를 갖기 위한 정보 | `List <ReportTestSuite> testSuites`   | Test Suite Lists                                                                           | N/A                               |
+| 엑셀 파일 생성을 위해 필요한 정보           | `File templatePath`                       | Excel 리포트의 템플릿 리포트 파일의 Full Path                                              | "/template-junit.xls"의 파일 객체 |
+| 엑셀 파일 생성을 위해 필요한 정보           | `File outputDirectory`                    | Excel 파일이 작성될 디렉토리 위치                                                          | 없으면 오류 처리                  |
+| 엑셀 파일 생성을 위해 필요한 정보           | `String outputName`                       | Excel 리포트 파일명                                                                        | "egovtest-junit.xls"              |
+| POI 엑셀 파일 정보                          | `HSSFWorkbook book`                       | POI 엑셀 파일 정보                                                                         | N/A                               |
+| 템플릿 엑셀 파일의 각 헤더 위치 정보        | `int[] summaryPosInfos`                   | Summary 헤더 위치 정보                                                                     | { 0, 0, 3 }                       |
+| 템플릿 엑셀 파일의 각 헤더 위치 정보        | `int[] packagePosInfos`                   | Package 헤더 위치 정보                                                                     | { 0, 0, 7 }                       |
+| 템플릿 엑셀 파일의 각 헤더 위치 정보        | `int[] listsPosInfos`                     | TestCase Lists 헤더 위치 정보                                                              | { 1, 0, 3 }                       |
+| 상수                                        | `IDX_SHEET = 0, IDX_COL = 1, IDX_ROW = 2` | 템플릿 엑셀 파일의 헤더 위치 정보를 담고 있는 Array의 인덱스 상수. sheet, column, row 순서 |                                   |
 
 #### Constructor
 
 생성자에서 입력 받아야 하는 정보는 다음과 같다.
 
-* List `<File>` xmlReportFileList : JUnit Test XML 파일의 Full Path List
-* File templatePath : 템플릿 엑셀 파일 객체
-* File outputDirectory : 파일 생성 위치 객체
-* String outputName : 생성될 엑셀 파일 명
+* `List <File> xmlReportFileList` : JUnit Test XML 파일의 Full Path List
+* `File templatePath` : 템플릿 엑셀 파일 객체
+* `File outputDirectory` : 파일 생성 위치 객체
+* `String outputName` : 생성될 엑셀 파일 명
 
 생성자에서 입력 받아야 하는 정보는 다음과 같다.
 


### PR DESCRIPTION
## 📘 PR 요약

- 공통컴포넌트 > 사용자디렉토리/통합인증 > 로그인정책관리 가독성 및 내부링크 수정
- 공통컴포넌트 > 사용자디렉토리/통합인증 > 일반로그인 가독성 등 수정
- PR #432 피드백 중 백틱 반영

## ✏️ 변경된 내용

(수정한 문서 또는 이미지가 무엇인지 적어주시기 바랍니다.)
([X]에서 X는 대문자여야 합니다.)

- [ ] 🆕 신규 문서 추가
    - (표준프레임워크 wiki 가이드에는 있지만 Github egovframe-docs에는 없는 문서 )

- [X] ✏️ 기존 문서 보완
    - (Github egovframe-docs에 이미 있는 문서의 내용을 표준프레임워크 wiki에 맞게 편집)

- [ ] 🗑️ 기존 문서 삭제
    - (Github egovframe-docs에 있는 문서를 삭제하는 행위는 되도록이면 지양해주시기 바라며, Issues 탭에 문의로 남겨주시기 바랍니다.)

- [ ] 🎉 신규 문서 및 내용 창조
    - (표준프레임워크 wiki 가이드와 Github egovframe-docs 양 쪽에 모두 없는 문서 또는 내용)


## ✅ 체크리스트

- [x] Push 전에 Pull을 반드시 했는지 확인
- [x] 개발환경, 실행환경, 실행환경 예제, 공통컴포넌트 디렉토리 내 변경만 포함되었는지 확인
- [x] frontmatter의 url, menu 등 검토
- [x] 오탈자 및 맞춤법 검토
- [x] 이미지 및 링크 경로 검토

## 👀 특이사항

md의 *이태릭체* 문법이 웹페이지상 반영이 안되고 있는 듯 합니다.
기존 wiki 에서 이태릭체가 어떤 기능을 하고 있는지 정확히 추정은 안되나, 일부 기존 생성문서 내 이태릭체 사용한 흔적이 있어 리포팅 드립니다.

감사합니다.