### PR TITLE
README.md 파일의 오타 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@
     - [실행환경 개발가이드](https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:rte4.3)
   - [실행환경 예제 개발가이드](https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:rte:ex:개발프레임워크_실행환경_예제)
 - 문서 파일과 관련 리소스는 다음과 같은 디렉토리 구조를 따릅니다.
-- 모든 _index.md 파일과 아래 코드블럭에서 표시된 MD파일은 identifier 값을 갖고 있습니다(egovframe-runtime 제외). 프론트매터의 url, parent 등을 작성할 때 아래 디렉토리 구조를 찹고 부탁드립니다.
+- 모든 _index.md 파일과 아래 코드블럭에서 표시된 MD파일은 identifier 값을 갖고 있습니다(egovframe-runtime 제외). 프론트매터의 url, parent 등을 작성할 때 아래 디렉토리 구조를 참고 부탁드립니다.
 
 ```
 /common-component                 #공통컴포넌트
@@ -103,7 +103,7 @@
     /schedule.md                      #일정관리
     /sms.md                           #문자메세지
   /digital-asset-management         #디지털 자산관리
-    /kowledge-map.md                  #지식맵
+    /knowledge-map.md                  #지식맵
   /elementary-technology            #요소기술
     /calendar.md                      #달력
     /cookie-session.md                #쿠키/세션
@@ -114,7 +114,7 @@
     /new-components-v3.2.md           #신규 컴포넌트(v3.2)
     /print.md                         #인쇄/출력
     /system.md                        #시스템
-    /webeditorm.md                    #웹에디터
+    /webeditor.md                    #웹에디터
   /intro                            #개요
   /security                         #보안
     /authority-management.md          #권한관리


### PR DESCRIPTION
## 📘 PR 요약

README.md 파일의 디렉토리 구조 설명 부분에서 실제 파일명과 일치하지 않는 오타를 수정하였습니다.

## ✏️ 변경된 내용

- [] 🆕 신규 문서 추가
    - (표준프레임워크 wiki 가이드에는 있지만 Github egovframe-docs에는 없는 문서 )

- [X] ✏️ 기존 문서 보완
    - (Github egovframe-docs에 이미 있는 문서의 내용을 표준프레임워크 wiki에 맞게 편집)
    -  README.md 

- [ ] 🗑️ 기존 문서 삭제
    - (Github egovframe-docs에 있는 문서를 삭제하는 행위는 되도록이면 지양해주시기 바라며, Issues 탭에 문의로 남겨주시기 바랍니다.)

- [ ] 🎉 신규 문서 및 내용 창조
    - (표준프레임워크 wiki 가이드와 Github egovframe-docs 양 쪽에 모두 없는 문서 또는 내용)


## ✅ 체크리스트

- [X] Push 전에 Pull을 반드시 했는지 확인
- [X] 개발환경, 실행환경, 실행환경 예제, 공통컴포넌트 디렉토리 내 변경만 포함되었는지 확인
- [X] frontmatter의 url, menu 등 검토
- [X] 오탈자 및 맞춤법 검토
- [X] 이미지 및 링크 경로 검토

## 👀 특이사항

