### PR TITLE
전자관인출력 가이드 변환

### DIFF
--- a/common-component/elementary-technology/print_digital_seal.md
+++ b/common-component/elementary-technology/print_digital_seal.md
@@ -1,0 +1,46 @@
+---
+  title: 전자관인출력
+  linkTitle: 전자관인출력
+  description: "기관코드, 관인구분을 받아 해당 관인이미지를 출력하는 기능을 제공한다."
+  url: /common-component/elementary-technology/print_digital_seal/
+  menu:
+    depth:
+      name: 전자관인출력
+      weight: 3
+      parent: "print"
+      identifier: "print_digital_seal"
+---
+
+
+
+# 요소기술 - 전자관인 출력
+
+## 개요
+
+ 기관코드, 관인구분을 받아 해당 관인이미지를 출력하는 기능을 제공한다.
+
+## 설명
+
+ 입력된 URL의 해당 관인이미지를 출력한다.
+
+##### 관련소스
+
+| 유형 | 대상소스 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Controller | egovframework.com.utl.pao.web.EgovErncslController.java | 전자관인 출력 controller |  |
+| VO | egovframework.com.utl.pao.service.PrntngOutptVO.java | 전자관인 VO |  |
+| Controller | egovframework.com.utl.pao.web.EgovPrntngOutptController.java | 테스트용 controller |  |
+| Service | egovframework.com.utl.pao.service.EgovPrntngOutpt.java | 테스트용 인터페이스 |  |
+| ServiceImpl | egovframework.com.utl.pao.service.impl.EgovPrntngOutptImpl.java | 테스트용 구현 |  |
+| DAO | egovframework.com.utl.pao.service.impl.PrntngOutptDAO.java | 테스트용 데이터 처리 |  |
+| JSP | /WEB-INF/jsp/egovframework/cmm/utl/EgovErncslOutpt.jsp | 테스트 페이지 |  |
+
+## 사용방법
+
+```html
+<%@page import="egovframework.com.utl.pao.service.EgovPrntngOutpt"  %>
+ 
+<img src="/utl/pao/EgovErncsl.do?sOrgCode=<%=sOrgCode%>&sErncslSe=<%=sErncslSe%>">
+```
+
+ 관인정보에 확인에 필요한 sOrgCode : 기관코드, sErncslSe : 관인구분으로 해당관인을 직접 출력한다.


### PR DESCRIPTION

## 📘 PR 요약
- [전자관인출력](https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:전자관인출력) 가이드 변환
- 기관코드, 관인구분을 받아 해당 관인이미지를 출력하는 기능을 제공한다.

## ✏️ 변경된 내용

- [X] 🆕 신규 문서 추가
    - common-component/elementary-technology/print_digital_seal.md

## ✅ 체크리스트
- [X] Push 전에 Pull을 반드시 했는지 확인
- [X] 개발환경, 실행환경, 실행환경 예제, 공통컴포넌트 디렉토리 내 변경만 포함되었는지 확인
- [X] frontmatter의 url, menu 등 검토
- [X] 오탈자 및 맞춤법 검토
- [X] 이미지 및 링크 경로 검토

## 👀 특이사항
- N/A

