### PR TITLE
Log4j2 문서 깨진 링크 수정

### DIFF
--- a/egovframe-runtime/foundation-layer/logging-log4j2.md
+++ b/egovframe-runtime/foundation-layer/logging-log4j2.md
@@ -257,6 +257,6 @@ Log4j 2에서는 설정 태그들이 직관적이고 간단하게 변경되었�
 
 #### 참고자료
 
-[Migration to Log4j 2](http://logging.apachttp://logging.apache.org/log4j/2.x/manual/migration.html)  
+[Migration to Log4j 2](https://logging.apache.org/log4j/2.x/manual/migration.html) 
 [Log4j 2 API Documentation](http://logging.apache.org/log4j/2.x/log4j-api/apidocs/index.html)  
 [Log4j 2 Implementation Documentation](http://logging.apache.org/log4j/2.x/log4j-core/apidocs/index.html)


### PR DESCRIPTION
## 📘 PR 요약
`logging-log4j2.md` 문서 내 깨진 Migration 링크를 수정하여, 링크 클릭 시 정상적으로 Log4j2 Migration 문서 페이지가 열리도록 개선

## ✏️ 변경된 내용

- [ ] 🆕 신규 문서 추가  
    - 없음  
- [X] ✏️ 기존 문서 보완  
    - logging-log4j2.md (깨진 Migration 링크 수정)  
- [ ] 🗑️ 기존 문서 삭제  
    - 없음  
- [ ] 🎉 신규 문서 및 내용 창조  
    - 없음  

## 🔗 변경 전/후 링크
- **Before**: `http://logging.apachttp://logging.apache.org/log4j/2.x/manual/migration.html`  
- **After**:  `https://logging.apache.org/log4j/2.x/manual/migration.html`  

## ✅ 체크리스트

- [X] Push 전에 Pull을 반드시 했는지 확인  
- [X] 개발환경, 실행환경, 실행환경 예제, 공통컴포넌트 디렉토리 내 변경만 포함되었는지 확인  
- [X] frontmatter의 url, menu 등 검토  
- [X] 오탈자 및 맞춤법 검토  
- [X] 이미지 및 링크 경로 검토  

## 👀 특이사항

- Migration 링크 정상 접속 확인 완료
