### PR TITLE
[실행환경 통합 예제] 하위 메뉴 순서 및 README.md 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,15 @@
 /runtime-example                          실행환경 예제
 ├── /integrated-example                      실행환경 통합 예제
 │   └── /intro                                   개요
+│       └── /integrated-example-intro.md           통합예제 개요
+│       └── /installation.md                       설치법
+|   └── /usage                                   사용법
+│       └── /member.md                             회원 관리
+│       └── /board.md                              게시판 관리
+│       └── /category.md                           카테고리 관리
+│       └── /product.md                            품목 관리
+│       └── /bid.md                                입찰 관리
+│       └── /delivery.md                           납품 관리
 └── /individual-example                      실행환경 개별 예제
     ├── /batch-layer                             배치처리 예제
     ├── /business-logic-layer                    업무처리 예제

--- a/runtime-example/integrated-example/intro/_index.md
+++ b/runtime-example/integrated-example/intro/_index.md
@@ -1,11 +1,11 @@
 ---
-title: 통합예제 개요
-linkTitle: 통합예제 개요
-description: 통합예제 개요이다
+title: 개요
+linkTitle: 개요
+description: 실행환경 통합예제 개요이다
 url: /runtime-example/integrated-example/intro/
 menu:
     depth:
-        name: 통합예제 개요
+        name: 개요
         weight: 1
         parent: "integrated-example"
         identifier: "integrated-example-intro"

--- a/runtime-example/integrated-example/usage/_index.md
+++ b/runtime-example/integrated-example/usage/_index.md
@@ -1,12 +1,12 @@
 ---
 title: 사용법
 linkTitle: 사용법
-description: 통합예제 사용법이다
+description: 실행환경 통합예제 사용법이다
 url: /runtime-example/integrated-example/usage/
 menu:
     depth:
         name: 사용법
-        weight: 1
+        weight: 2
         parent: "integrated-example"
         identifier: "integrated-example-usage"
 ---


### PR DESCRIPTION
## 📘 PR 요약
- `[실행환경 통합 예제]` 하위 메뉴의 weigth 누락으로 순서 뒤바껴 수정
- `통합예제 개요` ➡️ `개요`로 메뉴명 변경 
- `README.md` 디렉터리 구조 부분에 작업한 `실행환경 통합예제` 하위 마크다운 정보 추가

<img width="278" height="282" alt="스크린샷 2025-09-14 오전 8 31 09" src="https://github.com/user-attachments/assets/61d9843b-7d11-4228-8f32-210f3b7db069" />


## ✏️ 변경된 내용

- [] 🆕 신규 문서 추가

- [X] ✏️ 기존 문서 보완
    - `/runtime-example/integrated-example/usage/_index.md`
    - `/runtime-example/integrated-example/intro/_index.md`
    - `README.md`

- [ ] 🗑️ 기존 문서 삭제

- [ ] 🎉 신규 문서 및 내용 창조


## ✅ 체크리스트

- [X] Push 전에 Pull을 반드시 했는지 확인
- [X] 개발환경, 실행환경, 실행환경 예제, 공통컴포넌트 디렉토리 내 변경만 포함되었는지 확인
- [X] frontmatter의 url, menu 등 검토
- [X] 오탈자 및 맞춤법 검토
- [X] 이미지 및 링크 경로 검토

## 👀 특이사항
