### PR TITLE
docs(statistics-reporting): 통계 문서 스케줄링 설정 v5.0 소스 기준 현행화

### DIFF
--- a/common-component/statistics-reporting/post-statistics.md
+++ b/common-component/statistics-reporting/post-statistics.md
@@ -92,7 +92,7 @@ public class EgovBbsStatsScheduling {
 }
 ```
 
-- 작업 수행 Bean 설정(ssrc/main/resources/egovframework/spring/com/context-scheduling-sts-bst.xml)
+- 작업 수행 Bean 설정(src/main/resources/egovframework/spring/com/scheduling/context-scheduling-sts-bst.xml)
 
 ```xml
 <bean id="bbsStats" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
@@ -102,22 +102,22 @@ public class EgovBbsStatsScheduling {
 </bean>
 ```
 
-- 트리거 Bean 설정(ssrc/main/resources/egovframework/spring/com/context-scheduling-sts-bst.xml)
+- 트리거 Bean 설정(src/main/resources/egovframework/spring/com/scheduling/context-scheduling-sts-bst.xml)
 
 ```xml
-<bean id="bbsStatsTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+<bean id="bbsStatsTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
     <property name="jobDetail" ref="bbsStats" />
     <!-- 시작하고 2분후에 실행한다. (milisecond) -->
     <property name="startDelay" value="120000" />
-    <!-- 매 12시간마다 실행한다. (milisecond) -->
-    <property name="repeatInterval" value="43200000" />
+    <!-- 매 24시간마다 실행한다. (milisecond) -->
+    <property name="repeatInterval" value="86400000" />
 </bean>
 ```
 
-- 스케줄러 Bean 설정 (ssrc/main/resources/egovframework/spring/com/context-scheduling-sts-bst.xml)
+- 스케줄러 Bean 설정 (src/main/resources/egovframework/spring/com/scheduling/context-scheduling-sts-bst.xml)
 
 ```xml
-<bean id="statsSummaryScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+<bean id="bbsStatsSummaryScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
     <property name="triggers">
         <list>
             <ref bean="bbsStatsTrigger" />

--- a/common-component/statistics-reporting/user-statistics.md
+++ b/common-component/statistics-reporting/user-statistics.md
@@ -92,7 +92,7 @@ public class EgovUserStatsScheduling {
 }
 ```
 
-- 작업 수행 Bean 설정(src/main/resources/egovframework/spring/com/context-scheduling-sts-ust.xml)
+- 작업 수행 Bean 설정(src/main/resources/egovframework/spring/com/scheduling/context-scheduling-sts-ust.xml)
 
 ```xml
 <bean id="userStats" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
@@ -102,10 +102,10 @@ public class EgovUserStatsScheduling {
 </bean>
 ```
 
-- 트리거 Bean 설정(src/main/resources/egovframework/spring/com/context-scheduling-sts-ust.xml)
+- 트리거 Bean 설정(src/main/resources/egovframework/spring/com/scheduling/context-scheduling-sts-ust.xml)
 
 ```xml
-<bean id="userStatsTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+<bean id="userStatsTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
     <property name="jobDetail" ref="userStats" />
     <!-- 시작하고 2분후에 실행한다. (milisecond) -->
     <property name="startDelay" value="120000" />
@@ -114,10 +114,10 @@ public class EgovUserStatsScheduling {
 </bean>
 ```
 
-- 스케줄러 Bean 설정(src/main/resources/egovframework/spring/com/context-scheduling-sts-ust.xml)
+- 스케줄러 Bean 설정(src/main/resources/egovframework/spring/com/scheduling/context-scheduling-sts-ust.xml)
 
 ```xml
-<bean id="statsSummaryScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+<bean id="userStatsSummaryScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
     <property name="triggers">
         <list>
             <ref bean="userStatsTrigger" />


### PR DESCRIPTION

## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

게시물 통계와 사용자 통계 문서의 스케줄링 설정이 v3.x~v4.0 위키에서 이관된
구버전 내용이라, 현행 v5.0 공통컴포넌트 소스와 어긋나 있어 바로잡았습니다.

**post-statistics.md**
- 트리거 클래스 'SimpleTriggerBean' → 'SimpleTriggerFactoryBean' (Spring 4.0+ 버전으로 대응)
- 설정파일 경로 `ssrc` 오타 수정 + 누락된 `scheduling/` 하위폴더 보정
- 스케줄러 bean id 'statsSummaryScheduler' → 'bbsStatsSummaryScheduler'
- 반복주기 `43200000`(12h) → `86400000`(24h) (주석도 함께 정정했습니다)

**user-statistics.md**
- 트리거 클래스 'SimpleTriggerBean' → 'SimpleTriggerFactoryBean'
- 설정파일 경로에 누락된 `scheduling/` 하위폴더 보정
- 스케줄러 bean id 'statsSummaryScheduler' → 'userStatsSummaryScheduler'

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->



## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

- [context-scheduling-sts-bst.xml](https://github.com/eGovFramework/egovframe-common-components/blob/main/src/main/resources/egovframework/spring/com/scheduling/context-scheduling-sts-bst.xml)
- [context-scheduling-sts-ust.xml](https://github.com/eGovFramework/egovframe-common-components/blob/main/src/main/resources/egovframework/spring/com/scheduling/context-scheduling-sts-ust.xml)

위 소스에서 `SimpleTriggerFactoryBean`, `com/scheduling/` 경로,
`bbsStatsSummaryScheduler`/`userStatsSummaryScheduler` bean id,
게시물 통계 24시간(86400000) 주기를 확인했습니다.
