### PR TITLE
docs: 사용자지원 컴포넌트 설문조사/이용약관/트위터/부재관리 등 10건 작성

### DIFF
--- a/common-component/user-support/survey-item.md
+++ b/common-component/user-support/survey-item.md
@@ -1,11 +1,28 @@
 ---
-title: "설문항목관리"
-linkTitle: "설문항목관리"
-description: "설문항목관리"
-url: /common-component/user-support/online-participate/survey-item/
+title: "설문항목"
+linkTitle: "설문항목"
+description: "설문항목"
+url: /common-component/user-support/online-participation/survey-item/
 menu:
   depth:
-    name: "설문항목관리"
-    weight: 7
-    parent: "online-participate"
+    name: "설문항목"
+    weight: 41
+    parent: "online-participation"
 ---
+
+## 개요
+
+설문조사를 구성하는 개별 질문(문항)에 딸린 구체적인 선택지(객관식 보기 항목) 데이터를 등록하고 관리하는 하위 컴포넌트입니다.
+
+## 주요 기능
+
+* **객관식 보기 등록**: 특정 설문 문항에 대해 사용자가 선택할 수 있는 보기 항목(예: 매우 그렇다, 그렇다, 보통이다 등)을 텍스트로 등록합니다.
+* **정렬 순서 지정**: 설문 화면에 노출될 보기 항목들의 순서를 지정하여 논리적인 순서대로 나열합니다.
+
+## 데이터 구조 (테이블)
+
+* `COMTNQUSTNRIEM`: 설문 문항에 종속된 객관식 항목의 번호, 내용, 정렬 순서 등을 저장하는 테이블
+
+## 활용 방안
+
+`설문관리` 및 `설문문항` 컴포넌트와 함께 연계되어 작동하며, 5점 척도, 7점 척도 등 다양한 형태의 객관식 설문 폼을 유연하게 구성하는 데 사용됩니다.

--- a/common-component/user-support/survey-management.md
+++ b/common-component/user-support/survey-management.md
@@ -2,10 +2,28 @@
 title: "설문관리"
 linkTitle: "설문관리"
 description: "설문관리"
-url: /common-component/user-support/online-participate/survey-management/
+url: /common-component/user-support/online-participation/survey-management/
 menu:
   depth:
     name: "설문관리"
-    weight: 2
-    parent: "online-participate"
+    weight: 42
+    parent: "online-participation"
 ---
+
+## 개요
+
+특정 목적을 가진 설문조사(Survey)의 전체적인 기본 정보(마스터 정보)를 관리자가 생성하고, 진행 상태 및 기간을 통제하는 컴포넌트입니다.
+
+## 주요 기능
+
+* **설문조사 생성**: 설문 제목, 설문 목적, 안내 문구, 시작일 및 종료일 등 설문의 기본 정보를 등록합니다.
+* **템플릿 지정**: 설문 폼의 화면 디자인이나 구조를 결정하는 UI 템플릿을 선택하여 매핑합니다.
+* **통계 결과 조회**: 설문이 종료된 후, 전체 응답자 수 및 각 문항/항목별 통계 결과(그래프 등)를 집계하여 관리자 화면에 제공합니다.
+
+## 데이터 구조 (테이블)
+
+* `COMTNQUSTNRINFO`: 설문조사의 최상위 마스터 정보를 저장하는 테이블
+
+## 활용 방안
+
+정책 만족도 조사, 신규 서비스 수요 조사 등 여러 문항으로 구성된 복합적인 설문을 기획하고 배포할 때 사용하는 백오피스의 핵심 모듈입니다.

--- a/common-component/user-support/survey-question.md
+++ b/common-component/user-support/survey-question.md
@@ -1,11 +1,29 @@
 ---
-title: "설문질문관리"
-linkTitle: "설문질문관리"
-description: "설문질문관리"
-url: /common-component/user-support/online-participate/survey-question/
+title: "설문문항"
+linkTitle: "설문문항"
+description: "설문문항"
+url: /common-component/user-support/online-participation/survey-question/
 menu:
   depth:
-    name: "설문질문관리"
-    weight: 6
-    parent: "online-participate"
+    name: "설문문항"
+    weight: 43
+    parent: "online-participation"
 ---
+
+## 개요
+
+생성된 설문조사(마스터) 하위에 포함될 구체적인 개별 질문(문항)들을 등록하고, 답변 방식(객관식, 주관식 등)을 설정하는 컴포넌트입니다.
+
+## 주요 기능
+
+* **문항 등록**: 설문 참여자에게 물어볼 질문 내용(Q)을 등록합니다.
+* **답변 유형 설정**: 해당 문항에 대한 답변 방식을 객관식(단일 선택, 다중 선택) 혹은 주관식(서술형)으로 지정합니다.
+* **필수 응답 여부**: 문항별로 응답을 필수로 받을지, 선택 사항으로 둘지 설정합니다.
+
+## 데이터 구조 (테이블)
+
+* `COMTNQUSTNRQESITM`: 설문 마스터에 종속되는 개별 문항의 질문 내용, 질문 유형, 노출 순서 등을 저장하는 테이블
+
+## 활용 방안
+
+단순한 투표를 넘어, 여러 섹션과 복합적인 질문들로 이루어진 체계적인 설문지를 구성할 때 `설문관리` 및 `설문항목` 데이터와 결합되어 사용됩니다.

--- a/common-component/user-support/survey-respondent.md
+++ b/common-component/user-support/survey-respondent.md
@@ -1,11 +1,30 @@
 ---
-title: "설문응답자관리"
-linkTitle: "설문응답자관리"
-description: "설문응답자관리"
-url: /common-component/user-support/online-participate/survey-respondent/
+title: "설문응답자"
+linkTitle: "설문응답자"
+description: "설문응답자"
+url: /common-component/user-support/online-participation/survey-respondent/
 menu:
   depth:
-    name: "설문응답자관리"
-    weight: 5
-    parent: "online-participate"
+    name: "설문응답자"
+    weight: 44
+    parent: "online-participation"
 ---
+
+## 개요
+
+설문에 참여한 개별 사용자(응답자)의 인적 정보나 익명 식별 정보를 기록하고, 문항별 실제 응답 데이터와 매핑하여 관리하는 컴포넌트입니다.
+
+## 주요 기능
+
+* **응답자 정보 기록**: 설문에 참여한 사용자의 성별, 연령대, 직업 등 인구통계학적 정보를 기록합니다. (익명 설문의 경우 식별값만 기록)
+* **응답 내역 저장**: 해당 응답자가 각 문항(객관식/주관식)에 대해 어떠한 답변을 제출했는지 상세 이력을 저장합니다.
+* **중복 참여 방지**: 세션 또는 계정 정보를 활용하여 동일한 사용자가 중복으로 설문에 응답하지 못하도록 통제합니다.
+
+## 데이터 구조 (테이블)
+
+* `COMTNQUSTNRRESPONDINFO`: 설문 응답자의 기본 식별 정보 및 참여 일시를 저장하는 테이블
+* `COMTNQUSTNRRSPNSRESULT`: 각 문항에 대한 실제 답변 내용(객관식 번호 또는 서술형 텍스트)을 저장하는 테이블
+
+## 활용 방안
+
+설문 결과의 신뢰성을 확보하고, 성별/연령대별 교차 분석 등 고도화된 설문 통계를 추출하기 위한 원천 데이터 저장소로 기능합니다.

--- a/common-component/user-support/survey-template.md
+++ b/common-component/user-support/survey-template.md
@@ -1,11 +1,28 @@
 ---
-title: "설문템플릿관리"
-linkTitle: "설문템플릿관리"
-description: "설문템플릿관리"
-url: /common-component/user-support/online-participate/survey-template/
+title: "설문템플릿"
+linkTitle: "설문템플릿"
+description: "설문템플릿"
+url: /common-component/user-support/online-participation/survey-template/
 menu:
   depth:
-    name: "설문템플릿관리"
-    weight: 4
-    parent: "online-participate"
+    name: "설문템플릿"
+    weight: 45
+    parent: "online-participation"
 ---
+
+## 개요
+
+설문조사 화면이 사용자에게 노출될 때 적용될 디자인 양식(UI 레이아웃, 컬러셋 등)을 사전에 템플릿 형태로 등록해 두고 선택하여 사용할 수 있게 하는 컴포넌트입니다.
+
+## 주요 기능
+
+* **템플릿 파일 매핑**: JSP 파일이나 HTML 템플릿 경로를 DB에 등록하여, 설문 폼 화면을 렌더링할 때 참고할 기준 파일로 삼습니다.
+* **템플릿 정보 관리**: 템플릿 명칭, 설명, 템플릿의 미리보기 이미지 등을 등록하여 관리자가 설문 생성 시 디자인을 직관적으로 선택할 수 있게 돕습니다.
+
+## 데이터 구조 (테이블)
+
+* `COMTNQUSTNRTMPLAT`: 템플릿 ID, 템플릿 명칭, 화면 렌더링을 위한 물리적 파일 경로 등을 저장하는 테이블
+
+## 활용 방안
+
+사용자 친화적인 디자인이 중요한 마케팅 설문, 엄숙한 분위기의 사내 평가 설문 등 조사 목적에 따라 최적화된 설문 화면 디자인을 유연하게 교체하는 데 사용됩니다.

--- a/common-component/user-support/survey.md
+++ b/common-component/user-support/survey.md
@@ -2,10 +2,24 @@
 title: "설문조사"
 linkTitle: "설문조사"
 description: "설문조사"
-url: /common-component/user-support/online-participate/survey/
+url: /common-component/user-support/online-participation/survey/
 menu:
   depth:
     name: "설문조사"
-    weight: 3
-    parent: "online-participate"
+    weight: 46
+    parent: "online-participation"
 ---
+
+## 개요
+
+일반 사용자(Front-end)가 진행 중인 설문조사 목록을 확인하고, 템플릿 기반으로 렌더링된 다문항 설문 폼 화면에 접근하여 답변을 제출할 수 있는 진입점 컴포넌트입니다.
+
+## 주요 기능
+
+* **진행 중인 설문 조회**: 현재 참여 가능한 설문조사 목록과 안내(설문 목적, 기간 등)를 제공합니다.
+* **설문 응답 제출**: 사용자가 객관식, 주관식 문항에 응답을 기입하고 최종 제출하여 데이터를 서버로 전송합니다.
+* **설문 결과 공개**: 관리자가 결과 공개를 허용한 설문의 경우, 종료 후 사용자에게도 통계 결과를 보여줍니다.
+
+## 활용 방안
+
+웹사이트 메뉴 중 '참여마당', '설문조사' 등의 공개된 메뉴로 구성되며, 앞서 구성한 설문 마스터, 문항, 항목 데이터를 기반으로 실제 응답 트랜잭션을 처리하는 창구 역할을 합니다.

--- a/common-component/user-support/terms-manage.md
+++ b/common-component/user-support/terms-manage.md
@@ -1,11 +1,29 @@
 ---
-title: "약관관리"
-linkTitle: "약관관리"
-description: "약관관리"
-url: /common-component/user-support/terms-manage/
+title: "이용약관관리"
+linkTitle: "이용약관관리"
+description: "이용약관관리"
+url: /common-component/user-support/information-provided/terms-manage/
 menu:
   depth:
-    weight: 3
-    parent: "user-support"
-    identifier: "terms-manage"
+    name: "이용약관관리"
+    weight: 47
+    parent: "information-provided"
 ---
+
+## 개요
+
+시스템 회원이 서비스 이용 전 필수적으로 동의해야 하는 '서비스 이용 약관'의 제정 및 개정 이력을 관리하고, 약관 본문을 에디터로 작성하여 제공하는 관리자 컴포넌트입니다.
+
+## 주요 기능
+
+* **약관 내용 등록 및 수정**: 텍스트 에디터를 통해 서비스 이용약관 조항, 목적, 이용 규정 등의 본문을 등록합니다.
+* **버전 관리**: 관련 법령 개정 등으로 인해 약관이 변경될 경우, 기존 버전을 남겨두고 새로운 버전의 약관을 추가하여 적용 일자를 관리합니다.
+* **이용자 고지**: 프론트 화면의 약관 팝업이나 회원가입 폼과 연동하여 현재 유효한 최신 버전의 약관을 노출합니다.
+
+## 데이터 구조 (테이블)
+
+* `COMTNSTPLATINFO`: 약관 종류, 적용 일자, 약관 본문(HTML 등)을 저장하는 테이블
+
+## 활용 방안
+
+B2C 또는 대국민 서비스 구축 시, 법적인 분쟁을 방지하기 위해 사용자의 동의를 구하는 법적 고지 문서(Terms of Service)를 DB화하여 체계적으로 운영하는 데 활용됩니다.

--- a/common-component/user-support/terms-management.md
+++ b/common-component/user-support/terms-management.md
@@ -1,11 +1,29 @@
 ---
-title: "약관관리"
-linkTitle: "약관관리"
-description: "약관관리"
-url: /common-component/user-support/terms-manage/terms-management/
+title: "약관동의관리"
+linkTitle: "약관동의관리"
+description: "약관동의관리"
+url: /common-component/user-support/information-provided/terms-management/
 menu:
   depth:
-    name: "약관관리"
-    weight: 1
-    parent: "terms-manage"
+    name: "약관동의관리"
+    weight: 48
+    parent: "information-provided"
 ---
+
+## 개요
+
+회원 가입이나 특정 서비스 신청 시 제공되는 이용약관, 개인정보 취급방침 등 여러 가지 규정에 대해 사용자가 필수적/선택적으로 동의한 내역을 기록하고 조회하는 컴포넌트입니다.
+
+## 주요 기능
+
+* **동의 내역 기록**: 사용자가 어느 버전의 약관에 언제 동의(또는 거부)했는지 이력을 타임스탬프와 함께 저장합니다.
+* **동의 철회/변경**: 선택형 약관(예: 마케팅 수신 동의 등)에 대해 사용자가 추후에 마이페이지에서 동의 여부를 변경할 수 있도록 처리합니다.
+* **약관 갱신 알림**: 새로운 버전의 필수 약관이 적용되었을 때, 기존 사용자에게 재동의를 받기 위한 식별 데이터를 제공합니다.
+
+## 데이터 구조 (테이블)
+
+* `COMTNEMPLYRINFO` (또는 별도 동의 이력 테이블): 회원 정보 테이블의 특정 플래그 값이나, 약관 동의 이력 테이블을 통해 사용자의 동의 여부와 시간을 관리합니다.
+
+## 활용 방안
+
+개인정보보호법 등 관련 법률 준수를 위해 회원들의 마케팅 수신 동의, 제3자 정보 제공 동의 이력을 명확한 데이터로 남겨 관리할 때 필수적으로 쓰이는 기능입니다.

--- a/common-component/user-support/twitter-integration.md
+++ b/common-component/user-support/twitter-integration.md
@@ -1,11 +1,29 @@
 ---
-title: "Twitter연동"
-linkTitle: "Twitter연동"
-description: "Twitter연동"
+title: "트위터연동"
+linkTitle: "트위터연동"
+description: "트위터연동"
 url: /common-component/user-support/information-provided/twitter-integration/
 menu:
   depth:
-    name: "Twitter연동"
-    weight: 19
+    name: "트위터연동"
+    weight: 49
     parent: "information-provided"
 ---
+
+## 개요
+
+웹사이트의 게시글이나 공지, 이벤트 내용 등을 트위터(Twitter, X)로 내보내기(공유) 하거나, 공식 트위터 계정의 최근 타임라인 피드를 메인 화면에 연동하여 노출하는 컴포넌트입니다.
+
+## 주요 기능
+
+* **소셜 공유 기능**: 시스템 콘텐츠 URL과 제목을 조합하여 사용자가 본인의 트위터 계정으로 손쉽게 리트윗/공유할 수 있는 소셜 위젯 기능을 제공합니다.
+* **API 연동 인증**: Twitter API 연동에 필요한 OAuth 기반 인증 및 토큰 처리 로직을 포함합니다.
+* **타임라인 조회**: 기관/기업 공식 트위터 계정의 최신 트윗 목록을 가져와서 시스템 내 화면(포털 메인 등)에 렌더링합니다.
+
+## 데이터 구조 (테이블)
+
+(일반적으로 별도의 데이터를 적재하기보다는 Twitter 연동 API 설정값 및 토큰을 속성이나 환경변수로 관리합니다)
+
+## 활용 방안
+
+기관의 신속한 정책 홍보, 국민과의 실시간 소통 채널로 활용되며, 사이트 방문자에게 생동감 있는 외부 소셜 피드를 제공하여 정보의 도달률을 높입니다.

--- a/common-component/user-support/user-absence.md
+++ b/common-component/user-support/user-absence.md
@@ -2,10 +2,28 @@
 title: "사용자부재관리"
 linkTitle: "사용자부재관리"
 description: "사용자부재관리"
-url: /common-component/user-support/information-provided/user-absence/
+url: /common-component/user-support/collaboration/user-absence/
 menu:
   depth:
     name: "사용자부재관리"
-    weight: 13
-    parent: "information-provided"
+    weight: 50
+    parent: "user-support"
 ---
+
+## 개요
+
+사내 임직원이 휴가, 외근, 출장 등으로 인해 자리를 비우는 부재(Absence) 상태를 시스템에 등록하여, 다른 동료들이 부재 현황과 연락처 등을 확인할 수 있도록 돕는 컴포넌트입니다.
+
+## 주요 기능
+
+* **부재 정보 등록**: 부재 기간(시작일시~종료일시), 부재 사유(연차, 출장 등), 대리 업무자 지정, 비상 연락처 정보를 등록합니다.
+* **업무 대행자 연계**: 결재 시스템(전자결재)이나 쪽지 시스템과 연동하여, 부재 기간 동안 들어오는 업무를 대행자에게 자동으로 위임하거나 알림을 보냅니다.
+* **부재 현황 공유**: 그룹웨어 메신저 조직도나 사내 게시판에서 해당 임직원의 이름 옆에 부재 중 표시(아이콘 등)를 노출합니다.
+
+## 데이터 구조 (테이블)
+
+* `COMTNUSERABSNCE`: 사용자 ID, 부재 시작/종료일시, 부재 유형, 대행자 ID 등을 저장하는 테이블
+
+## 활용 방안
+
+협업 환경에서 담당자 부재로 인한 업무 지연을 방지하고, 조직원 간 원활한 커뮤니케이션과 신속한 업무 대체 처리를 지원하기 위해 필수적인 사내 기능입니다.


### PR DESCRIPTION
## 개요

공통컴포넌트의 사용자지원 및 온라인참여 분류에 속하는 10종의 컴포넌트 가이드 문서를 작성했습니다.

## 작업 내용

- 설문항목 (`survey-item.md`)
- 설문관리 (`survey-management.md`)
- 설문문항 (`survey-question.md`)
- 설문응답자 (`survey-respondent.md`)
- 설문템플릿 (`survey-template.md`)
- 설문조사 (`survey.md`)
- 이용약관관리 (`terms-manage.md`)
- 약관동의관리 (`terms-management.md`)
- 트위터연동 (`twitter-integration.md`)
- 사용자부재관리 (`user-absence.md`)

`markdownlint-cli2` 검증을 통과했습니다.