### PR TITLE
docs: 실행환경 예제(runtime-example) 초기 디렉토리 및 가이드 13건 작성

### DIFF
--- a/runtime-example/_index.md
+++ b/runtime-example/_index.md
@@ -1,0 +1,16 @@
+---
+title: "실행환경 예제"
+linkTitle: "실행환경 예제"
+description: "표준프레임워크 실행환경에서 제공하는 다양한 통합 및 개별 예제를 안내합니다."
+url: /runtime-example/
+menu:
+  main:
+    name: "실행환경 예제"
+    weight: 40
+    identifier: "runtime-example"
+---
+
+표준프레임워크 실행환경의 각 레이어별 기능과 이를 종합적으로 활용한 통합 예제 애플리케이션에 대한 가이드를 제공합니다.
+
+* [실행환경 통합 예제](./integrated-example/)
+* [실행환경 개별 예제](./individual-example/)

--- a/runtime-example/individual-example/_index.md
+++ b/runtime-example/individual-example/_index.md
@@ -1,0 +1,14 @@
+---
+title: "실행환경 개별 예제"
+linkTitle: "실행환경 개별 예제"
+description: "표준프레임워크 실행환경의 각 레이어(Layer)별 단일 기능에 특화된 실습 예제 가이드를 제공합니다."
+url: /runtime-example/individual-example/
+menu:
+  depth:
+    name: "실행환경 개별 예제"
+    weight: 2
+    parent: "runtime-example"
+    identifier: "individual-example"
+---
+
+각 레이어별 설정 방법과 API 활용법을 익히기 위해, 기능별로 분리된 개별 프로젝트 형태의 샘플 코드를 제공합니다.

--- a/runtime-example/individual-example/batch-layer.md
+++ b/runtime-example/individual-example/batch-layer.md
@@ -1,0 +1,19 @@
+---
+title: "배치처리 예제"
+linkTitle: "배치처리 예제"
+description: "Spring Batch 기반의 배치처리 레이어 활용 예제를 안내합니다."
+url: /runtime-example/individual-example/batch-layer/
+menu:
+  depth:
+    name: "배치처리 예제"
+    weight: 1
+    parent: "individual-example"
+---
+
+## 배치처리 개별 예제
+
+대용량 데이터의 주기적인 처리를 위해 eGovFrame 배치 레이어(Spring Batch 기반)를 사용하는 예제입니다.
+
+* **Job 설정**: XML 또는 Java Config 기반의 Job과 Step 정의
+* **ItemReader/Writer**: 파일 및 DB 연동을 위한 Reader/Writer 구현체 활용
+* **스케줄링 연동**: Quartz 또는 Spring Scheduler를 활용한 정기 실행 설정

--- a/runtime-example/individual-example/business-logic-layer.md
+++ b/runtime-example/individual-example/business-logic-layer.md
@@ -1,0 +1,15 @@
+---
+title: "업무처리 예제"
+linkTitle: "업무처리 예제"
+description: "비즈니스 로직 처리를 담당하는 업무처리 레이어 활용 예제입니다."
+url: /runtime-example/individual-example/business-logic-layer/
+menu:
+  depth:
+    name: "업무처리 예제"
+    weight: 2
+    parent: "individual-example"
+---
+
+## 업무처리 개별 예제
+
+서비스 지향 아키텍처(SOA) 구조에 맞춰 `@Service` 빈을 정의하고 비즈니스 흐름을 제어하는 예제 코드입니다. 트랜잭션 선언과 예외 처리(Exception Handling)의 모범 사례를 포함합니다.

--- a/runtime-example/individual-example/foundation-layer-core.md
+++ b/runtime-example/individual-example/foundation-layer-core.md
@@ -1,0 +1,15 @@
+---
+title: "공통기반 핵심 예제"
+linkTitle: "공통기반 핵심 예제"
+description: "Spring IoC 컨테이너와 AOP 등 프레임워크 코어 기능 활용 예제입니다."
+url: /runtime-example/individual-example/foundation-layer-core/
+menu:
+  depth:
+    name: "공통기반 핵심 예제"
+    weight: 4
+    parent: "individual-example"
+---
+
+## 공통기반 핵심 개별 예제
+
+Spring Framework의 핵심인 의존성 주입(DI)과 관점 지향 프로그래밍(AOP)의 설정 및 동작 방식을 가장 단순한 형태로 검증하는 단위 테스트 예제들입니다.

--- a/runtime-example/individual-example/foundation-layer.md
+++ b/runtime-example/individual-example/foundation-layer.md
@@ -1,0 +1,15 @@
+---
+title: "공통기반 예제"
+linkTitle: "공통기반 예제"
+description: "암호화, 로깅 등 공통기반 유틸리티 활용 예제를 다룹니다."
+url: /runtime-example/individual-example/foundation-layer/
+menu:
+  depth:
+    name: "공통기반 예제"
+    weight: 3
+    parent: "individual-example"
+---
+
+## 공통기반 개별 예제
+
+시스템 전반에서 반복적으로 사용되는 Foundation Layer 모듈(ID 생성, 메시지 소스, 캐시 등)의 단독 사용 예제를 제공합니다.

--- a/runtime-example/individual-example/integration-layer/_index.md
+++ b/runtime-example/individual-example/integration-layer/_index.md
@@ -1,0 +1,14 @@
+---
+title: "연계통합 예제"
+linkTitle: "연계통합 예제"
+description: "외부 시스템과의 데이터 연동 및 클라우드 메시지 스트리밍 등 연계통합 레이어의 기능을 검증하는 예제입니다."
+url: /runtime-example/individual-example/integration-layer/
+menu:
+  depth:
+    name: "연계통합 예제"
+    weight: 5
+    parent: "individual-example"
+    identifier: "individual-integration-layer"
+---
+
+RESTful API, Web Service, Cloud Data Stream 등 연계통합 레이어의 주요 기능을 활용하는 개별 예제들을 다룹니다.

--- a/runtime-example/individual-example/integration-layer/cloud-data-stream.md
+++ b/runtime-example/individual-example/integration-layer/cloud-data-stream.md
@@ -1,0 +1,15 @@
+---
+title: "Cloud Data Stream"
+linkTitle: "Cloud Data Stream"
+description: "마이크로서비스 환경에서 비동기 메시징 처리를 위한 Cloud Data Stream 연동 예제입니다."
+url: /runtime-example/individual-example/integration-layer/cloud-data-stream/
+menu:
+  depth:
+    name: "Cloud Data Stream"
+    weight: 1
+    parent: "individual-integration-layer"
+---
+
+## Cloud Data Stream 예제
+
+Spring Cloud Stream 기반으로 Kafka 또는 RabbitMQ와 같은 메시지 브로커와 연동하여 발행/구독(Publish/Subscribe) 아키텍처를 구현하는 예제 프로젝트를 가이드합니다.

--- a/runtime-example/individual-example/persistence-layer.md
+++ b/runtime-example/individual-example/persistence-layer.md
@@ -1,0 +1,15 @@
+---
+title: "데이터처리 예제"
+linkTitle: "데이터처리 예제"
+description: "MyBatis, JPA 기반의 DB 연동 데이터처리 레이어 예제입니다."
+url: /runtime-example/individual-example/persistence-layer/
+menu:
+  depth:
+    name: "데이터처리 예제"
+    weight: 6
+    parent: "individual-example"
+---
+
+## 데이터처리 개별 예제
+
+표준프레임워크에서 지원하는 RDBMS(MyBatis, Hibernate JPA) 및 NoSQL(MongoDB) 연동을 다루는 퍼시스턴스 레이어의 쿼리 맵핑 및 페이징 처리 예제입니다.

--- a/runtime-example/individual-example/presentation-layer.md
+++ b/runtime-example/individual-example/presentation-layer.md
@@ -1,0 +1,15 @@
+---
+title: "화면처리 예제"
+linkTitle: "화면처리 예제"
+description: "Spring MVC 기반 웹 요청 및 화면 렌더링 예제입니다."
+url: /runtime-example/individual-example/presentation-layer/
+menu:
+  depth:
+    name: "화면처리 예제"
+    weight: 7
+    parent: "individual-example"
+---
+
+## 화면처리 개별 예제
+
+사용자의 HTTP 요청을 매핑하여 컨트롤러 로직을 수행하고, JSP 또는 HTML로 화면을 응답하는 Presentation Layer(웹 계층)의 기능별 샘플 코드입니다.

--- a/runtime-example/integrated-example/_index.md
+++ b/runtime-example/integrated-example/_index.md
@@ -1,0 +1,14 @@
+---
+title: "실행환경 통합 예제"
+linkTitle: "실행환경 통합 예제"
+description: "표준프레임워크 실행환경 통합 예제 애플리케이션의 개요와 사용법을 설명합니다."
+url: /runtime-example/integrated-example/
+menu:
+  depth:
+    name: "실행환경 통합 예제"
+    weight: 1
+    parent: "runtime-example"
+    identifier: "integrated-example"
+---
+
+표준프레임워크 실행환경 통합 예제 애플리케이션의 개요와 사용법을 설명합니다.

--- a/runtime-example/integrated-example/intro.md
+++ b/runtime-example/integrated-example/intro.md
@@ -1,0 +1,22 @@
+---
+title: "개요"
+linkTitle: "개요"
+description: "실행환경 통합 예제의 목적과 아키텍처 개요를 설명합니다."
+url: /runtime-example/integrated-example/intro/
+menu:
+  depth:
+    name: "개요"
+    weight: 1
+    parent: "integrated-example"
+---
+
+## 개요
+
+실행환경 통합 예제는 eGovFrame의 핵심 기능들이 어떻게 상호작용하는지 보여주기 위해 만들어진 참조 모델입니다.
+
+## 아키텍처 구성
+
+* **Presentation Layer**: Spring MVC 기반 웹 요청 처리 및 화면 응답
+* **Business Logic Layer**: Spring Web Flow 및 서비스 컴포넌트 로직
+* **Persistence Layer**: MyBatis 또는 JPA를 이용한 데이터베이스 접근
+* **Foundation Layer**: 로깅, 보안, 암호화 등 공통 기반 유틸리티 적용

--- a/runtime-example/integrated-example/usage.md
+++ b/runtime-example/integrated-example/usage.md
@@ -1,0 +1,18 @@
+---
+title: "사용법"
+linkTitle: "사용법"
+description: "실행환경 통합 예제를 개발 환경에서 임포트하고 실행하는 방법을 안내합니다."
+url: /runtime-example/integrated-example/usage/
+menu:
+  depth:
+    name: "사용법"
+    weight: 2
+    parent: "integrated-example"
+---
+
+## 통합 예제 실행 방법
+
+1. **프로젝트 임포트**: Eclipse(eGovFrame IDE) 또는 IntelliJ에서 메이븐(Maven) 프로젝트로 임포트합니다.
+2. **DB 설정**: 내장형 HSQL 또는 로컬 MySQL 등에 맞게 `context-datasource.xml`을 수정합니다.
+3. **서버 기동**: Tomcat 등의 웹 WAS 서버를 구성하여 프로젝트를 배포하고 기동합니다.
+4. **기능 테스트**: 제공되는 로그인 화면이나 게시판 목록 화면 등에 접근하여 트랜잭션이 정상적으로 처리되는지 확인합니다.


### PR DESCRIPTION
## 개요

README에 명시되어 있으나 그동안 생성되지 않았던 `runtime-example` (실행환경 예제) 파트의 디렉토리 구조와 초기 마크다운 가이드(Stub) 문서들을 모두 작성했습니다.

## 작업 내용

- **통합 예제 (`integrated-example`)**
  - `intro.md` (개요)
  - `usage.md` (사용법)
- **개별 예제 (`individual-example`)**
  - `batch-layer.md`
  - `business-logic-layer.md`
  - `foundation-layer.md`
  - `foundation-layer-core.md`
  - `integration-layer/cloud-data-stream.md`
  - `persistence-layer.md`
  - `presentation-layer.md`
- **각 계층별 `_index.md`** 4건 추가

`markdownlint-cli2` 검증을 모두 통과했습니다.