### PR TITLE
docs: 실행환경 SWF·Crypto·MongoDB 가이드 본문 작성 (#590 재제출)

### DIFF
--- a/egovframe-runtime/business-logic-layer/swf-elements.md
+++ b/egovframe-runtime/business-logic-layer/swf-elements.md
@@ -9,3 +9,16 @@ menu:
         parent: "spring-web-flow"
         identifier: "swf-elements"
 ---
+
+## 개요
+
+Spring Web Flow(SWF)에서 제공하는 핵심 요소(Elements)들에 대해 설명한다. 웹 애플리케이션의 네비게이션 흐름을 정의하는 다양한 XML 태그와 컴포넌트들을 포함한다.
+
+## 주요 요소
+
+* **Flow (`<flow>`)**: 하나의 업무 흐름을 정의하는 최상위 요소
+* **State (`<view-state>`, `<action-state>`, `<decision-state>`, `<end-state>`)**: 흐름 내에서 특정 단계(상태)를 표현
+* **Transition (`<transition>`)**: 상태 간의 이동(이벤트 기반 라우팅)을 정의
+* **Action (`<evaluate>`, `<set>`)**: 상태 진입/진출 시 수행할 비즈니스 로직(메서드 호출, 변수 할당 등)
+
+이러한 요소들을 조합하여 복잡한 페이지 간의 상태와 데이터를 안전하게 유지하며 화면 흐름을 제어할 수 있다.

--- a/egovframe-runtime/business-logic-layer/swf-getting-started.md
+++ b/egovframe-runtime/business-logic-layer/swf-getting-started.md
@@ -9,3 +9,19 @@ menu:
         parent: "spring-web-flow"
         identifier: "swf-getting-started"
 ---
+
+## 개요
+
+Spring Web Flow(SWF)를 프로젝트에 처음 도입하고 설정하는 기초적인 방법을 설명한다.
+
+## 1. 의존성 추가
+
+프로젝트의 `pom.xml`에 Spring Web Flow 라이브러리 의존성을 추가한다.
+
+## 2. Web Flow 설정 파일 작성
+
+`DispatcherServlet` 컨텍스트 설정에 `FlowRegistry`, `FlowExecutor` 빈을 등록하고, URL 맵핑을 통해 Flow Controller가 동작하도록 구성한다.
+
+## 3. 첫 번째 Flow XML 작성
+
+가장 기본적인 화면 이동이 포함된 `flow.xml` 파일을 생성하여 `<view-state>`와 `<transition>`을 정의해 본다.

--- a/egovframe-runtime/foundation-layer/crypto.md
+++ b/egovframe-runtime/foundation-layer/crypto.md
@@ -11,4 +11,15 @@ menu:
         identifier: "crypto"
 ---
 
-Encryption/Decryption과 crypto 간소화를 crypto라는 목록에 넣기 위해 생성.
+## 개요
+
+표준프레임워크 실행환경의 Foundation Layer에서 제공하는 암호화(Crypto) 서비스에 대해 설명한다.
+
+시스템 내에서 처리되는 민감한 정보(비밀번호, 개인정보 등)를 안전하게 보호하기 위해, 단방향 해시(Hash) 알고리즘과
+양방향 대칭키/비대칭키 암호화(Encryption/Decryption) 알고리즘을 간편하게 적용할 수 있는 유틸리티 및 빈(Bean) 구조를 제공한다.
+
+## 주요 제공 방식
+
+* **ARIACryptoService**: 행정안전부 표준 암호 알고리즘인 ARIA를 손쉽게 사용할 수 있도록 추상화된 서비스
+* **Spring Security Crypto 연동**: Spring Security에서 제공하는 강력한 비밀번호 해시 엔진(Bcrypt 등)과의 호환
+* **설정 간소화**: XML이나 Java Config 기반으로 키(Key) 관리와 알고리즘 선택을 최소한의 설정으로 구현할 수 있도록 지원한다.

--- a/egovframe-runtime/persistence-layer/mongodb.md
+++ b/egovframe-runtime/persistence-layer/mongodb.md
@@ -9,3 +9,16 @@ menu:
         parent: "persistence-layer"
         identifier: "mongodb"
 ---
+
+## 개요
+
+표준프레임워크 실행환경에서 NoSQL 데이터베이스인 MongoDB를 연동하여 데이터를 다루는 방법을 제공한다. Spring Data MongoDB 모듈을 기반으로 구성된다.
+
+RDBMS와 달리 유연한 문서(Document) 지향 데이터 구조를 가지는 MongoDB와의 통합을 위해,
+도메인 클래스 매핑과 Repository 인터페이스, `MongoTemplate` 등을 활용하여 빠르고 직관적인 CRUD 연산을 지원한다.
+
+## 주요 기능
+
+* **Document 매핑**: `@Document`, `@Id` 등의 어노테이션을 사용하여 자바 객체(Entity)와 MongoDB 컬렉션을 매핑
+* **MongoTemplate**: 복잡한 쿼리, 업데이트, 집계(Aggregation) 기능을 수행할 수 있는 템플릿 클래스 지원
+* **MongoRepository**: 인터페이스 선언만으로 기본적인 CRUD 및 쿼리 메서드 자동 생성


### PR DESCRIPTION
#590에서 안내해 주신 대로, frontmatter는 변경하지 않고 가이드 본문만 다시 작성해 재제출합니다.

비어 있던 실행환경 요소기술 가이드 4건에 개요 및 주요 기능 설명을 추가했습니다.

- `business-logic-layer/swf-elements.md` — Spring Web Flow 핵심 요소 개요
- `business-logic-layer/swf-getting-started.md` — Spring Web Flow 도입/설정 기초
- `foundation-layer/crypto.md` — Foundation Layer 암호화 서비스 개요
- `persistence-layer/mongodb.md` — Spring Data MongoDB 연동 개요

### 확인
- frontmatter(url/parent/identifier/menu 등) 미변경 — 메뉴/URL 구조 영향 없음
- 4개 파일, 본문만 추가 (이전 #590의 내용 중 frontmatter 변경 없이 본문만 재작성)
