### PR TITLE
fix(elementary-technology): 깨진 참조 링크 15건 정정

### DIFF
--- a/common-component/elementary-technology/confirm_message.md
+++ b/common-component/elementary-technology/confirm_message.md
@@ -79,6 +79,6 @@ message = EgovMessageUtil.getConfirmMsg("param.message", new String[2] {"확인"
 
 ## 참고자료
 
-- 경고메시지 참조: [경고메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/warning_message/)
-- 에러메시지 참조: [에러메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/error_message/)
-- 정보메시지 참조: [정보메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/info_message/)
+- 경고메시지 참조: [경고메시지](./warning_message.md)
+- 에러메시지 참조: [에러메시지](./error_message.md)
+- 정보메시지 참조: [정보메시지](./info_message.md)

--- a/common-component/elementary-technology/error_message.md
+++ b/common-component/elementary-technology/error_message.md
@@ -79,6 +79,6 @@ message = EgovMessageUtil.getErrorMsg("param.message", new String[2] {"오류", 
 
 ## 참고자료
 
-- 경고메시지 참조: [경고메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/warning_message/)
-- 정보메시지 참조: [정보메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/info_message/)
-- 확인메시지 참조: [확인메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/confirm_message/)
+- 경고메시지 참조: [경고메시지](./warning_message.md)
+- 정보메시지 참조: [정보메시지](./info_message.md)
+- 확인메시지 참조: [확인메시지](./confirm_message.md)

--- a/common-component/elementary-technology/handling_cookie.md
+++ b/common-component/elementary-technology/handling_cookie.md
@@ -81,4 +81,4 @@ String safeGetParameter(HttpServletRequest request, String name) {
 ```
 
 ## 참고자료
-- 세션처리 참조: [세션처리](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/handling_session/)
+- 세션처리 참조: [세션처리](./handling_session.md)

--- a/common-component/elementary-technology/handling_session.md
+++ b/common-component/elementary-technology/handling_session.md
@@ -80,4 +80,4 @@ EgovSessionCookieUtil.removeSessionAttribute(request, "USER_NAME");
 ```
 
 ## 참고자료
-- 쿠키처리 참조: [쿠키처리](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/handling_cookie/)
+- 쿠키처리 참조: [쿠키처리](./handling_cookie.md)

--- a/common-component/elementary-technology/info_message.md
+++ b/common-component/elementary-technology/info_message.md
@@ -79,6 +79,6 @@ message = EgovMessageUtil.getInfoMsg("param.message", new String[2] {"정보", "
 
 ## 참고자료
 
-- 경고메시지 참조: [경고메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/warning_message/)
-- 에러메시지 참조: [에러메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/error_message/)
-- 확인메시지 참조: [확인메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/confirm_message/)
+- 경고메시지 참조: [경고메시지](./warning_message.md)
+- 에러메시지 참조: [에러메시지](./error_message.md)
+- 확인메시지 참조: [확인메시지](./confirm_message.md)

--- a/common-component/elementary-technology/social_login_naver_google_kakao.md
+++ b/common-component/elementary-technology/social_login_naver_google_kakao.md
@@ -208,5 +208,5 @@ public String oauthLoginCallback(@PathVariable String oauthService, Model model,
 
 ## 참고자료
 
- [Spring Social](https://projects.spring.io/spring-social/)
+ [Spring Social](https://docs.spring.io/spring-social/docs/current/reference/htmlsingle/)
 

--- a/common-component/elementary-technology/warning_message.md
+++ b/common-component/elementary-technology/warning_message.md
@@ -79,6 +79,6 @@ message = EgovMessageUtil.getWarnMsg("param.message", new String[2] {"경고", "
 
 ## 참고자료
 
-- 에러메시지 참조: [에러메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/error_message/)
-- 정보메시지 참조: [정보메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/info_message/)
-- 확인메시지 참조: [확인메시지](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/confirm_message/)
+- 에러메시지 참조: [에러메시지](./error_message.md)
+- 정보메시지 참조: [정보메시지](./info_message.md)
+- 확인메시지 참조: [확인메시지](./confirm_message.md)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

요소기술(elementary-technology) 문서의 깨진 참조 링크 15건을 정정했습니다

### 1. 내부 교차참조 링크 → 상대경로(.md)로 정정 (14건)
메시지/쿠키·세션 페이지의 "참고자료" 링크가 절대 URL(`https://egovframework.github.io/...`)로
하드코딩된 데다 섹션 세그먼트가 누락되어 404가 발생했습니다.

저장소의 다수 컨벤션(상대 `.md` 링크, 예: `security/login_session_management.md`)에 맞춰
상대경로로 통일했습니다.
- error/warning/confirm/info_message.md: 형제 메시지 링크 (12건)
- handling_cookie.md / handling_session.md: 상호 참조 (2건)

### 2. 외부 링크 (1건)
- social_login_naver_google_kakao.md: 종료된 Spring Social 링크
  (`projects.spring.io/spring-social`, 404)를 공식 레퍼런스 문서로 교체

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->



## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다. (수정 전 404 / 수정 후 정상 확인)
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

- 수정한 링크는 모두 수정 전 404를 확인했고, 상대경로 전환 후 정상 연결을 확인했습니다.
