### PR TITLE
[chore] GitHub Actions deprecated 액션 버전 업그레이드 (v3 → v4)

### DIFF
--- a/.github/workflows/deploy-on-merge.yaml
+++ b/.github/workflows/deploy-on-merge.yaml
@@ -17,7 +17,7 @@ jobs:
     
     # Step 1. Hugo 프로젝트가 있는 hugo-project 브랜치 체크아웃
     - name: Checkout the hugo-project branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: hugo-project  # hugo 프로젝트가 위치한 브랜치
         persist-credentials: false  # GitHub 인증 문제 방지
@@ -25,7 +25,7 @@ jobs:
 
     # Step 2. main 브랜치에서 markdown 파일들만 체크아웃
     - name: Checkout the main branch for markdown files
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: main  # main 브랜치에서 파일 가져오기
         path: main-md  # 임시로 main 브랜치의 markdown 파일을 저장할 위치
@@ -38,7 +38,7 @@ jobs:
     
     # Step 4. Node.js 설치
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'  # 안정적인 최신 버전의 Node.js 설치
       

--- a/.github/workflows/deploy-on-push.yaml
+++ b/.github/workflows/deploy-on-push.yaml
@@ -13,7 +13,7 @@ jobs:
     
     # Step 1. Hugo 프로젝트가 있는 hugo-project 브랜치 체크아웃
     - name: Checkout the hugo-project branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: hugo-project  # hugo 프로젝트가 위치한 브랜치
         persist-credentials: false  # GitHub 인증 문제 방지
@@ -21,7 +21,7 @@ jobs:
 
     # Step 2. main 브랜치에서 markdown 파일들만 체크아웃
     - name: Checkout the main branch for markdown files
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: main  # main 브랜치에서 파일 가져오기
         path: main-md  # 임시로 main 브랜치의 markdown 파일을 저장할 위치
@@ -34,7 +34,7 @@ jobs:
     
     # Step 4. Node.js 설치
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'  # 안정적인 최신 버전의 Node.js 설치
       

--- a/.github/workflows/deploy-on-schedule.yaml
+++ b/.github/workflows/deploy-on-schedule.yaml
@@ -22,7 +22,7 @@ jobs:
     
     # Step 1. Hugo 프로젝트가 있는 hugo-project 브랜치 체크아웃
     - name: Checkout the hugo-project branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: hugo-project  # hugo 프로젝트가 위치한 브랜치
         persist-credentials: false  # GitHub 인증 문제 방지
@@ -30,7 +30,7 @@ jobs:
 
     # Step 2. main 브랜치에서 markdown 파일들만 체크아웃
     - name: Checkout the main branch for markdown files
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: main  # main 브랜치에서 파일 가져오기
         path: main-md  # 임시로 main 브랜치의 markdown 파일을 저장할 위치
@@ -43,7 +43,7 @@ jobs:
     
     # Step 4. Node.js 설치
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'  # 안정적인 최신 버전의 Node.js 설치
       

--- a/.github/workflows/merge-on-pr.yaml
+++ b/.github/workflows/merge-on-pr.yaml
@@ -48,7 +48,7 @@ jobs:
 
       # Step 1. Base Repository의 main 브랜치를 체크아웃
       - name: Checkout the main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main                 # 체크아웃 대상 브랜ㅊ; : main
           fetch-depth: 0            # 깊이 0 → 전체 커밋 히스토리 가져오기


### PR DESCRIPTION
## 변경 사유
배포 워크플로에서 사용하는 `actions/checkout`·`actions/setup-node`가 Node 16 런타임 기반의 v3로 고정되어 있어 GitHub Actions deprecation 경고가 발생합니다. Node 20 기반 v4로 올립니다.

## 변경 내용
- `actions/checkout@v3` → `@v4` — deploy-on-merge·deploy-on-push·deploy-on-schedule·merge-on-pr
- `actions/setup-node@v3` → `@v4` — deploy-on-merge·deploy-on-push·deploy-on-schedule
- `link-check.yml`은 이미 v4를 사용 중이라 변경 없음

## 영향 범위
- 워크플로 액션 버전만 상향했고 워크플로 로직·입력(node-version 등)은 그대로입니다. v3→v4는 하위 호환되어 빌드·배포 동작에 영향이 없습니다.
- 문서 콘텐츠(마크다운/frontmatter)는 변경하지 않았습니다.

## 체크리스트
- [x] 단일 주제만 다룸(CI 액션 버전 업그레이드)
- [x] 기존 워크플로 동작에 영향 없음
- [x] 문서 콘텐츠 변경 없음