### PR TITLE
docs: 표기 일관성 정리 (스케쥴/포멧/컨텐트)

### DIFF
--- a/common-component/elementary-technology/format-validation.md
+++ b/common-component/elementary-technology/format-validation.md
@@ -1,11 +1,11 @@
 ---
-title: "포멧유효성체크"
-linkTitle: "포멧유효성체크"
-description: "포멧유효성체크"
+title: "포맷유효성체크"
+linkTitle: "포맷유효성체크"
+description: "포맷유효성체크"
 url: /common-component/elementary-technology/formatter-util/format-validation/
 menu:
   depth:
-    name: "포멧유효성체크"
+    name: "포맷유효성체크"
     weight: 18
     parent: "formatter-util"
 ---

--- a/common-component/elementary-technology/format-validation.md
+++ b/common-component/elementary-technology/format-validation.md
@@ -1,11 +1,11 @@
 ---
-title: "포맷유효성체크"
-linkTitle: "포맷유효성체크"
-description: "포맷유효성체크"
+title: "포멧유효성체크"
+linkTitle: "포멧유효성체크"
+description: "포멧유효성체크"
 url: /common-component/elementary-technology/formatter-util/format-validation/
 menu:
   depth:
-    name: "포맷유효성체크"
+    name: "포멧유효성체크"
     weight: 18
     parent: "formatter-util"
 ---

--- a/common-component/elementary-technology/network-service-monitoring.md
+++ b/common-component/elementary-technology/network-service-monitoring.md
@@ -43,8 +43,8 @@ menu:
 | Model | `egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngLog.java` | 네트워크서비스모니터링로그정보를 위한 Model 클래스 |
 | VO | `egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngVO.java` | 네트워크서비스모니터링을 위한 VO 클래스 |
 | VO | `egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngLogVO.java` | 네트워크서비스모니터링로그정보를 위한 VO 클래스 |
-| 스케쥴링 | `egovframework/com/utl/sys/nsm/service/EgovNtwrkSvcMntrngScheduling.java` | 네트워크서비스모니터링을 위한 스케쥴링 클래스 |
-| 스케쥴링 | `egovframework/com/utl/sys/nsm/service/NtwrkSvcMntrngChecker.java` | 네트워크서비스모니터링을 위한 스케쥴링 클래스 |
+| 스케줄링 | `egovframework/com/utl/sys/nsm/service/EgovNtwrkSvcMntrngScheduling.java` | 네트워크서비스모니터링을 위한 스케줄링 클래스 |
+| 스케줄링 | `egovframework/com/utl/sys/nsm/service/NtwrkSvcMntrngChecker.java` | 네트워크서비스모니터링을 위한 스케줄링 클래스 |
 | 기타 | `egovframework/com/utl/sys/nsm/service/NtwrkSvcMntrngResult.java` | 네트워크서비스 모니터링에 대한 결과를 처리하기 위한 클래스 |
 | JSP | `/WEB-INF/jsp/egovframework/utl/sys/nsm/EgovNtwrkSvcMntrngList.jsp` | 네트워크서비스모니터링목록조회를 위한 jsp페이지 |
 | JSP | `/WEB-INF/jsp/egovframework/utl/sys/nsm/EgovNtwrkSvcMntrngRegist.jsp` | 네트워크서비스모니터링 등록을 위한 jsp페이지 |

--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -232,7 +232,7 @@
     │   ├── /number-conversion.md                      숫자변환
     │   ├── /number-validation.md                      숫자유효성체크
     │   ├── /number-replacement.md                     숫자치환
-    │   ├── /format-validation.md                      포멧유효성체크
+    │   ├── /format-validation.md                      포맷유효성체크
     │   ├── /real-int-negative-check.md                실수/정수/음수체크
     │   ├── /solar-lunar-conversion.md                 양력/음력변환
     │   ├── /encoding-decoding.md                      인코딩/디코딩

--- a/egovframe-development/test-tool/mvc-test.md
+++ b/egovframe-development/test-tool/mvc-test.md
@@ -60,7 +60,7 @@ public class ExampleTests {
 }
 ```
 
-위의 코드에서 MockMvc의 perform함수를 통해 "/accounts/1" url로 request를 수행하고 응답받은 response를 통해 상태값(status:200), 컨텐트 타입("application/json"), JSON으로 받은 값들을 확인할 수 있다.
+위의 코드에서 MockMvc의 perform함수를 통해 "/accounts/1" url로 request를 수행하고 응답받은 response를 통해 상태값(status:200), 콘텐트 타입("application/json"), JSON으로 받은 값들을 확인할 수 있다.
 
 #### Setup Option
 

--- a/egovframe-runtime/foundation-layer/scheduling.md
+++ b/egovframe-runtime/foundation-layer/scheduling.md
@@ -16,24 +16,24 @@ menu:
 ## 개요
 
 Scheduling 서비스는 어플리케이션 서버 내에서 주기적으로 발생하거나 반복적으로 발생하는 작업을 지원하는 기능으로서 유닉스의 크론(Cron) 명령어와 유사한 기능을 제공한다.  
-실행환경 Scheduling 서비스는 오픈소스 소프트웨어로 Quartz 스케쥴러를 사용한다. 본 장에서는 Quartz 스케쥴러의 기본 개념을 살펴본 후, IoC 서비스를 제공하는 Spring과 Quartz 스케쥴러를 통합하여 사용하는 방법을 살펴본다.
+실행환경 Scheduling 서비스는 오픈소스 소프트웨어로 Quartz 스케줄러를 사용한다. 본 장에서는 Quartz 스케줄러의 기본 개념을 살펴본 후, IoC 서비스를 제공하는 Spring과 Quartz 스케줄러를 통합하여 사용하는 방법을 살펴본다.
 
 ## 설명
 
-### Quartz 스케쥴러
+### Quartz 스케줄러
 
-Quartz 스케쥴러 실행과 관계된 주요 요소는 Scheduler, Job, JobDetail, Trigger 가 있다.
+Quartz 스케줄러 실행과 관계된 주요 요소는 Scheduler, Job, JobDetail, Trigger 가 있다.
 
 - **Scheduler** 는 Quartz 실행 환경을 관리하는 핵심 개체이다.
-- **Job** 은 사용자가 수행할 작업을 정의하는 인터페이스로서 Trigger 개체를 이용하여 스케쥴할 수 있다.
+- **Job** 은 사용자가 수행할 작업을 정의하는 인터페이스로서 Trigger 개체를 이용하여 스케줄할 수 있다.
 - **JobDetail** 는 작업명과 작업그룹과 같은 수행할 Job에 대한 상세 정보를 정의하는 개체이다.
-- **Trigger** 는 정의한 Job 개체의 실행 스케쥴을 정의하는 개체로서 Scheduler 개체에게 Job 수행시점을 알려주는 개체이다.
+- **Trigger** 는 정의한 Job 개체의 실행 스케줄을 정의하는 개체로서 Scheduler 개체에게 Job 수행시점을 알려주는 개체이다.
 
-Quartz 스케쥴러는 수행 작업을 정의하는 Job과 실행 스케쥴을 정의하는 Trigger를 분리함으로써 유연성을 제공한다. Job 과 실행 스케쥴을 정의한 경우, Job은 그대로 두고 실행 스케쥴만을 변경할 수 있다. 또한 하나의 Job에 여러 개의 실행 스케쥴을 정의할 수 있다.
+Quartz 스케줄러는 수행 작업을 정의하는 Job과 실행 스케줄을 정의하는 Trigger를 분리함으로써 유연성을 제공한다. Job 과 실행 스케줄을 정의한 경우, Job은 그대로 두고 실행 스케줄만을 변경할 수 있다. 또한 하나의 Job에 여러 개의 실행 스케줄을 정의할 수 있다.
 
-#### Quartz 스케쥴러 사용 예제
+#### Quartz 스케줄러 사용 예제
 
-Quartz 스케쥴러의 이해를 돕기 위해 간단한 예제를 살펴본다. 다음 예는 Quartz 매뉴얼에서 참조한 것으로 Quartz를 사용하는 방법과 사용자 Job을 설정하는 방법을 보여준다.
+Quartz 스케줄러의 이해를 돕기 위해 간단한 예제를 살펴본다. 다음 예는 Quartz 매뉴얼에서 참조한 것으로 Quartz를 사용하는 방법과 사용자 Job을 설정하는 방법을 보여준다.
 
 ##### 사용자 정의 Job
 
@@ -71,8 +71,8 @@ public class DumbJob implements Job {
 
 ### Spring 과 Quartz 통합
 
-Spring은 Scheduling 지원을 위한 통합 클래스를 제공한다. Spring Framework는 JDK 1.3 버전부터 포함된 Timer 와 오픈소스 소프트웨어인 Quartz 스케쥴러를 지원한다. 여기서는 Quartz 스케쥴러와 Spring을 통합하여 사용하는 방법을 살펴본다.  
-Quartz 스케쥴러와의 통합을 위해 Spring은 Spring 컨텍스트 내에서 Quart Scheduler와 JobDetail, Trigger 를 빈으로 설정할 수 있도록 지원한다. 다음은 예제를 중심으로 Quartz 작업 생성과 작업 스케쥴링, 작업 시작 방법을 살펴본다.
+Spring은 Scheduling 지원을 위한 통합 클래스를 제공한다. Spring Framework는 JDK 1.3 버전부터 포함된 Timer 와 오픈소스 소프트웨어인 Quartz 스케줄러를 지원한다. 여기서는 Quartz 스케줄러와 Spring을 통합하여 사용하는 방법을 살펴본다.  
+Quartz 스케줄러와의 통합을 위해 Spring은 Spring 컨텍스트 내에서 Quart Scheduler와 JobDetail, Trigger 를 빈으로 설정할 수 있도록 지원한다. 다음은 예제를 중심으로 Quartz 작업 생성과 작업 스케줄링, 작업 시작 방법을 살펴본다.
 
 #### 작업 생성
 
@@ -162,9 +162,9 @@ public class SayHelloService {
 
 - 정의한 Bean 객체의 메소드를 직접 호출하는 작업을 생성하기 위해 MethodInvokingJobDetailFactoryBean을 정의한다.
 
-#### 작업 스케쥴링
+#### 작업 스케줄링
 
-Spring에서 주로 사용되는 Trigger타입은 SimpleTriggerBean과 CronTriggerBean 이 있다. SimpleTrigger 는 특정 시간, 반복 회수, 대기 시간과 같은 단순 스케쥴링에 사용된다. CronTrigger 는 유닉스의 Cron 명령어와 유사하며, 복잡한 스케쥴링에 사용된다. CronTrigger 는 달력을 이용하듯 특정 시간, 요일, 월에 Job 을 수행하도록 설정할 수 있다. 다음은 SimpleTriggerBean과 CronTriggerBean을 이용하여 앞서 생성한 작업을 스케쥴링하는 방법을 살펴본다.
+Spring에서 주로 사용되는 Trigger타입은 SimpleTriggerBean과 CronTriggerBean 이 있다. SimpleTrigger 는 특정 시간, 반복 회수, 대기 시간과 같은 단순 스케줄링에 사용된다. CronTrigger 는 유닉스의 Cron 명령어와 유사하며, 복잡한 스케줄링에 사용된다. CronTrigger 는 달력을 이용하듯 특정 시간, 요일, 월에 Job 을 수행하도록 설정할 수 있다. 다음은 SimpleTriggerBean과 CronTriggerBean을 이용하여 앞서 생성한 작업을 스케줄링하는 방법을 살펴본다.
 
 ##### SimpleTriggerBean을 이용한 설정
 
@@ -178,7 +178,7 @@ Spring에서 주로 사용되는 Trigger타입은 SimpleTriggerBean과 CronTrigg
 </bean>
 ```
 
-- 앞서 JobDetailBean 을 이용하여 생성한 작업을 스케쥴링을 위한 Trigger 에 등록한다. SimpleTriggerBean은 즉시 시작하고 매 10초마다 실행하도록 설정하였다.
+- 앞서 JobDetailBean 을 이용하여 생성한 작업을 스케줄링을 위한 Trigger 에 등록한다. SimpleTriggerBean은 즉시 시작하고 매 10초마다 실행하도록 설정하였다.
 
 ##### CronTriggerBean을 이용한 설정
 
@@ -190,11 +190,11 @@ Spring에서 주로 사용되는 Trigger타입은 SimpleTriggerBean과 CronTrigg
 </bean>
 ```
 
-- 앞서 MethodInvokingJobDetailFactoryBean 을 이용하여 생성한 작업을 스케쥴링을 위한 Trigger 에 등록한다. CronTriggerBean은 매 10초마다 실행하도록 설정하였다. 크론 표현식에 대한 자세한 설명은 [Quartz Cron 표현식](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/tutorial-lesson-06.html)를 참조한다.
+- 앞서 MethodInvokingJobDetailFactoryBean 을 이용하여 생성한 작업을 스케줄링을 위한 Trigger 에 등록한다. CronTriggerBean은 매 10초마다 실행하도록 설정하였다. 크론 표현식에 대한 자세한 설명은 [Quartz Cron 표현식](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/tutorial-lesson-06.html)를 참조한다.
 
 #### 작업 시작하기
 
-스케쥴링한 작업의 시작을 위해 Spring 은 SchedulerFactoryBean을 제공한다.
+스케줄링한 작업의 시작을 위해 Spring 은 SchedulerFactoryBean을 제공한다.
 
 ##### 설정
 

--- a/egovframe-runtime/presentation-layer/asynchronous-request-processing.md
+++ b/egovframe-runtime/presentation-layer/asynchronous-request-processing.md
@@ -100,7 +100,7 @@ public Callable<String> callableWithView(final Model model) {
 
 ### DefferedResult
 
-Servlet 스레드는 반환하고 Spring MVC가 제어하지 않는 쓰레드를 통해 비동기를 처리한다. DefferedResult는 JMS, AMQP, 스케쥴러, Redis, 다른 HTTP요청에서 사용된다.
+Servlet 스레드는 반환하고 Spring MVC가 제어하지 않는 쓰레드를 통해 비동기를 처리한다. DefferedResult는 JMS, AMQP, 스케줄러, Redis, 다른 HTTP요청에서 사용된다.
 
 DefferedResult의 처리과정은 다음과 같다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->
문서 본문의 표기 오류를 저장소가 이미 다수 채택한 올바른 표기로 통일했습니다(교정이 아닌 일관성 정리).

스케쥴 → 스케줄 (저장소 내 "스케줄" 25개 파일 기사용, 잔존 오기 정리)
포멧 → 포맷 (저장소 내 "포맷" 41개 파일 기사용, 잔존 오기 정리)
컨텐트 → 콘텐트

총 6개 파일 24곳(+24/−24). 본문 prose만 수정했으며 frontmatter의 title/url/menu/identifier, 마크다운 링크·이미지 경로는 변경하지 않았습니다.


## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->
없음


## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [x] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [x] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

변경 줄은 모두 대상 단어만 포함하며(오탐 0), 기술 외래어 표기 선호(메소드/디렉토리 등 저장소 다수 표기)는 의도적으로 건드리지 않았습니다.
