### PR TITLE
docs: 제목 표기 수정 (문자메세지→문자메시지, 포멧유효성체크→포맷유효성체크)

### DIFF
--- a/common-component/collaboration/sms.md
+++ b/common-component/collaboration/sms.md
@@ -1,7 +1,7 @@
 ---
-title: "문자메세지"
-linkTitle: "문자메세지"
-description: "문자메세지 서비스"
+title: "문자메시지"
+linkTitle: "문자메시지"
+description: "문자메시지 서비스"
 url: /common-component/collaboration/sms/
 menu:
   depth:

--- a/common-component/elementary-technology/format-validation.md
+++ b/common-component/elementary-technology/format-validation.md
@@ -1,11 +1,11 @@
 ---
-title: "포멧유효성체크"
-linkTitle: "포멧유효성체크"
-description: "포멧유효성체크"
+title: "포맷유효성체크"
+linkTitle: "포맷유효성체크"
+description: "포맷유효성체크"
 url: /common-component/elementary-technology/formatter-util/format-validation/
 menu:
   depth:
-    name: "포멧유효성체크"
+    name: "포맷유효성체크"
     weight: 18
     parent: "formatter-util"
 ---


### PR DESCRIPTION
## 변경 유형 (Type of Change)
- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)
문서 제목(frontmatter)의 표기 오류를 수정했습니다.

- `common-component/collaboration/sms.md`: 문자메세지 → **문자메시지** (title/linkTitle/description)
- `common-component/elementary-technology/format-validation.md`: 포멧유효성체크 → **포맷유효성체크** (title/linkTitle/description/menu.name) 및 본문 내 `포멧`→`포맷`

`url`·`identifier`·`weight` 등 라우팅 관련 필드는 변경하지 않았습니다.

## 관련 이슈 (Related Issues)
없음 (오타 수정 PR #634·#635에서 frontmatter 변경분만 분리한 후속)

## 변경 영역 (Affected Areas)
- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)
- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)
자동머지 워크플로우가 frontmatter 변경을 차단하므로 **의도적으로 분리한 수동검토용 PR**입니다. 제목 표기 교정이 목적이며(`문자메세지`/`포멧`은 각각 `문자메시지`/`포맷`의 오기), `url`·`identifier`는 그대로 두어 기존 링크가 깨지지 않습니다. 검토 부탁드립니다.