### PR TITLE
docs: 메뉴 제목 표기 오류 수정 (문자메세지→문자메시지, 포멧유효성체크→포맷유효성체크)

### DIFF
--- a/common-component/collaboration/sms.md
+++ b/common-component/collaboration/sms.md
@@ -1,7 +1,7 @@
 ---
-title: "문자메세지"
-linkTitle: "문자메세지"
-description: "문자메세지 서비스"
+title: "문자메시지"
+linkTitle: "문자메시지"
+description: "문자메시지 서비스"
 url: /common-component/collaboration/sms/
 menu:
   depth:

--- a/common-component/elementary-technology/format-validation.md
+++ b/common-component/elementary-technology/format-validation.md
@@ -1,11 +1,11 @@
 ---
-title: "포멧유효성체크"
-linkTitle: "포멧유효성체크"
-description: "포멧유효성체크"
+title: "포맷유효성체크"
+linkTitle: "포맷유효성체크"
+description: "포맷유효성체크"
 url: /common-component/elementary-technology/formatter-util/format-validation/
 menu:
   depth:
-    name: "포멧유효성체크"
+    name: "포맷유효성체크"
     weight: 18
     parent: "formatter-util"
 ---


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

사이트 메뉴와 문서 제목에 노출되는 표기 오류 2건을 수정했습니다.

| 파일 | 수정 내용 |
|---|---|
| `common-component/collaboration/sms.md` | 문자메**세**지 → 문자메**시**지 (표준어 표기) |
| `common-component/elementary-technology/format-validation.md` | 포**멧**유효성체크 → 포**맷**유효성체크 (외래어 표기법) |

## 관련 이슈 (Related Issues)

없음

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

- 본 수정은 "Frontmatter 수정은 피해주시기 바랍니다" 규칙에 예외적으로 해당하는 변경입니다. 해당 오탈자가 frontmatter의 `title`/`linkTitle`/`menu.name`에 있어 사이트 메뉴·제목에 그대로 노출되므로, frontmatter를 수정하지 않고는 바로잡을 수 없어 부득이 포함했습니다.
- `url`, `weight`, `parent` 등 메뉴 구조에 영향을 주는 항목은 일절 변경하지 않았으며, 표기 오류가 있는 표시 문자열만 수정했습니다.
- 정책상 frontmatter 변경이 곤란하시면 본 PR을 닫아주시고 관리자 측에서 반영해 주시기를 부탁드립니다.