### PR TITLE
docs: LLM 친화 문서 인덱스 llms.txt 추가

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,49 @@
+# 전자정부 표준프레임워크 가이드 (eGovFrame Guide)
+
+> 대한민국 전자정부 표준프레임워크(eGovFrame) v5.0의 공식 가이드 문서입니다. 실행환경(egovframe-runtime), 개발환경(egovframe-development), 공통컴포넌트(common-component) 세 영역의 개발 가이드를 Markdown으로 제공합니다. 원문 저장소는 GitHub(eGovFramework/egovframe-docs)이며, 포털(https://www.egovframe.go.kr)에서도 동일한 내용을 제공합니다.
+
+이 파일은 LLM·AI 에이전트가 표준프레임워크 문서를 정확히 탐색·인용할 수 있도록 llmstxt.org 규격으로 작성한 인덱스입니다. 아래 URL의 각 섹션 페이지에서 세부 가이드 목록을 확인할 수 있습니다.
+
+## 실행환경 (egovframe-runtime)
+
+- [실행환경 소개](https://egovframework.github.io/egovframe-docs/egovframe-runtime/intro/): 실행환경 개요와 구성
+- [공통기반](https://egovframework.github.io/egovframe-docs/egovframe-runtime/foundation-layer/): IoC 컨테이너, AOP, 암복호화, 프로퍼티 등 Foundation Layer
+- [공통기반 핵심](https://egovframework.github.io/egovframe-docs/egovframe-runtime/foundation-layer-core/): Foundation Layer 핵심 모듈
+- [화면처리](https://egovframework.github.io/egovframe-docs/egovframe-runtime/presentation-layer/): Spring MVC, Ajax, 국제화, Web Reactive 등 Presentation Layer
+- [업무처리](https://egovframework.github.io/egovframe-docs/egovframe-runtime/business-logic-layer/): 트랜잭션, 예외 처리 등 Business Logic Layer
+- [데이터처리](https://egovframework.github.io/egovframe-docs/egovframe-runtime/persistence-layer/): MyBatis/JPA 기반 Persistence Layer
+- [연계통합](https://egovframework.github.io/egovframe-docs/egovframe-runtime/integration-layer/): 웹서비스 등 Integration Layer
+- [배치처리](https://egovframework.github.io/egovframe-docs/egovframe-runtime/batch-layer/): 배치 실행환경 Batch Layer
+- [AI 통합](https://egovframework.github.io/egovframe-docs/egovframe-runtime/ai-layer/): AI 연계 실행환경
+
+## 개발환경 (egovframe-development)
+
+- [개발환경 소개](https://egovframework.github.io/egovframe-docs/egovframe-development/development-intro/): 개발환경 개요
+- [개발환경 설치 가이드](https://egovframework.github.io/egovframe-docs/egovframe-development/install-guide/): 통합 설치 안내
+- [개발환경 구성 가이드](https://egovframework.github.io/egovframe-docs/egovframe-development/individual-install-guide/): 개별 구성 안내
+- [구현 도구](https://egovframework.github.io/egovframe-docs/egovframe-development/implementation-tool/): eGovFrame IDE(Eclipse) 기반 구현 도구
+- [구현 도구(VS Code)](https://egovframework.github.io/egovframe-docs/egovframe-development/vscode-implementation-tool/): VS Code 확장 기반 구현 도구
+- [테스트 도구](https://egovframework.github.io/egovframe-docs/egovframe-development/test-tool/): 단위테스트 등 테스트 도구
+- [배포 도구](https://egovframework.github.io/egovframe-docs/egovframe-development/deployment-tool/): Maven, Docker 등 배포 도구
+- [형상 관리 도구](https://egovframework.github.io/egovframe-docs/egovframe-development/configuration-management-tool/): 버전/이슈 관리 도구
+- [개발환경 활용 가이드](https://egovframework.github.io/egovframe-docs/egovframe-development/development-etcdevtool-guide/): 기타 개발 도구 활용
+
+## 공통컴포넌트 (common-component)
+
+- [공통컴포넌트 개요](https://egovframework.github.io/egovframe-docs/common-component/cc-intro/): 공통컴포넌트 정의·구성·용어사전
+- [보안](https://egovframework.github.io/egovframe-docs/common-component/security/): 인증·권한(RBAC)·세션 관리 컴포넌트
+- [사용자디렉토리/통합인증](https://egovframework.github.io/egovframe-docs/common-component/user-authentication/): 로그인, SSO 컴포넌트
+- [사용자지원](https://egovframework.github.io/egovframe-docs/common-component/user-support/): 설문, 민원, 알림, 온라인매뉴얼 등
+- [협업](https://egovframework.github.io/egovframe-docs/common-component/collaboration/): 게시판, 커뮤니티, 일정관리, SMS 등
+- [시스템관리](https://egovframework.github.io/egovframe-docs/common-component/system-management/): 메뉴·코드·배치·로그 관리
+- [시스템/서비스연계](https://egovframework.github.io/egovframe-docs/common-component/system-service-linkage/): 연계 컴포넌트
+- [통계/리포팅](https://egovframework.github.io/egovframe-docs/common-component/statistics-reporting/): 통계 컴포넌트
+- [디지털 자산관리](https://egovframework.github.io/egovframe-docs/common-component/digital-asset-management/): 지식·자산 관리
+- [요소기술](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/): 유틸리티성 요소기술
+
+## Optional
+
+- [시작하기](https://egovframework.github.io/egovframe-docs/getting-started/): HelloWorld 실습 기반 입문 가이드
+- [기여 안내(README)](https://github.com/eGovFramework/egovframe-docs/blob/main/README.md): 문서 기여 방법
+- [표준프레임워크 포털](https://www.egovframe.go.kr): 공식 포털 (다운로드·공지·커뮤니티)
+- [소스 저장소 목록](https://github.com/eGovFramework): 공통컴포넌트 등 GitHub 조직


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 신규 문서 추가 (docs/new)

## 변경 내용 (Description)

egovframe-common-components#1119 제안의 3단계 실행으로, 저장소 루트에 llmstxt.org 규격의 `llms.txt`를 추가했습니다.

- LLM·AI 에이전트(Claude, ChatGPT, Copilot 등)가 표준프레임워크 가이드 문서를 정확히 탐색·인용할 수 있도록 실행환경·개발환경·공통컴포넌트 3개 영역의 섹션 인덱스(29개 링크)를 제공합니다.
- GitHub Pages 배포 사이트(egovframework.github.io/egovframe-docs) 기준으로 배포되면 `/llms.txt` 경로에서 접근 가능합니다.
- 링크 29개 전부에 대해 HTTP 200 응답을 확인했습니다. draft 상태 섹션(개발환경 운영 가이드)은 제외했습니다.

## 관련 이슈 (Related Issues)

- eGovFramework/egovframe-common-components#1119 (AGENTS.md·copilot-instructions·llms.txt 제안)

## 변경 영역 (Affected Areas)

- [x] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다. (기존 문서 변경 없음, 각 섹션 frontmatter의 url 기준으로 링크 생성)
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다. (전 링크 200 확인)
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

빌드 파이프라인이 루트의 정적 파일을 사이트에 포함하지 않는 경우, 배포 설정에 `llms.txt`를 정적 자원으로 포함하는 후속 조정이 필요할 수 있습니다. 배치 위치(루트 vs static/)에 대해 리뷰 의견 주시면 반영하겠습니다.
