### PR TITLE
docs: 협업 카테고리 빈 문서 5건 내용 작성 (전자우편·주소록/명함·부서업무함)

### DIFF
--- a/common-component/collaboration/address-book.md
+++ b/common-component/collaboration/address-book.md
@@ -9,3 +9,35 @@ menu:
     weight: 2
     parent: "address"
 ---
+
+# 주소록관리
+
+## 개요
+
+주소록관리는 개인 또는 공용 주소록을 등록하고, 구성원과 명함 정보를 항목으로 담아 목록을 조회·수정할 수 있는 기능을 제공한다.
+
+## 설명
+
+### 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| Controller | egovframework.com.cop.adb.web.EgovAddressBookController.java | 주소록 관리 컨트롤러 |
+| Service | egovframework.com.cop.adb.service.EgovAddressBookService.java | 주소록 관리 서비스 인터페이스 |
+| ServiceImpl | egovframework.com.cop.adb.service.impl.EgovAddressBookServiceImpl.java | 주소록 관리 서비스 구현 클래스 |
+| DAO | egovframework.com.cop.adb.service.impl.AddressBookDAO.java | 주소록 데이터처리 클래스 |
+| Model/VO | egovframework.com.cop.adb.service.AddressBook.java, AddressBookVO.java, AddressBookUser.java, AddressBookUserVO.java | 주소록·구성원 모델 |
+| JSP | /WEB-INF/jsp/egovframework/com/cop/adb/EgovAddressBookList.jsp | 주소록 목록 |
+| JSP | /WEB-INF/jsp/egovframework/com/cop/adb/EgovAddressBookRegist.jsp | 주소록 등록 |
+| JSP | /WEB-INF/jsp/egovframework/com/cop/adb/EgovAddressBookUpdt.jsp | 주소록 수정 |
+| JSP | /WEB-INF/jsp/egovframework/com/cop/adb/EgovAddressBookPopup.jsp | 주소록 선택 팝업 |
+| Query XML | resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_*.xml | DB별(MySQL·Oracle·Tibero·Altibase·Cubrid·MariaDB·PostgreSQL·Goldilocks) Query XML |
+| Message properties | resources/egovframework/message/com/cop/adb/message_ko.properties, message_en.properties | 메시지 리소스 |
+
+### 패키지 참조 관계
+
+주소록 패키지는 요소기술의 공통 패키지(cmm)에 대해서 직접적인 함수적 참조 관계를 가진다.
+
+## 참고자료
+
+- [주소록/명함록 개요](./address.md)

--- a/common-component/collaboration/address.md
+++ b/common-component/collaboration/address.md
@@ -9,3 +9,32 @@ menu:
     parent: "collaboration"
     identifier: "address"
 ---
+
+# 주소록/명함록
+
+## 개요
+
+주소록/명함록 컴포넌트는 조직 구성원이 개인 또는 공용 주소록과 명함 정보를 등록·조회·관리할 수 있는 협업 서비스 컴포넌트이다.
+
+## 주요 개념
+
+주소록은 구성원(사용자)과 명함 정보를 항목으로 구성하며, 목록 조회·등록·수정과 팝업을 통한 선택 기능을 제공한다. 주소록과 명함 관리는 동일한 `cop.adb` 패키지의 소스를 공유한다.
+
+## 관련 문서
+
+- [명함관리](./business-card-management.md) — 명함 정보 등록·관리
+- [주소록관리](./address-book.md) — 주소록 등록·관리
+
+## 설명
+
+### 패키지 구조
+
+주소록/명함록 컴포넌트의 소스는 `egovframework.com.cop.adb` 패키지에 위치하며, Controller(EgovAddressBookController)–Service(EgovAddressBookService)–ServiceImpl–DAO(AddressBookDAO) 계층과 Model/VO(AddressBook, AddressBookUser 등), JSP, DB별 Query XML(EgovAdbk_SQL_*.xml)로 구성된다.
+
+### 패키지 참조 관계
+
+주소록 패키지는 요소기술의 공통 패키지(cmm)에 대해서 직접적인 함수적 참조 관계를 가지며, 배포 시 패키지 간 참조 관계에 따라 관련 패키지와 함께 구성한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/collaboration/business-card-management.md
+++ b/common-component/collaboration/business-card-management.md
@@ -9,3 +9,32 @@ menu:
     weight: 1
     parent: "address"
 ---
+
+# 명함관리
+
+## 개요
+
+명함관리는 명함 정보를 등록·조회하여 주소록의 항목으로 활용할 수 있는 기능을 제공한다.
+
+## 설명
+
+명함관리는 주소록관리와 동일한 `egovframework.com.cop.adb` 패키지의 소스를 공유한다. 명함 목록 조회 등 명함 관련 데이터 처리는 주소록 DAO(AddressBookDAO)의 명함(Card) 관련 질의로 수행되며, 등록된 명함은 주소록 구성 항목으로 선택할 수 있다.
+
+### 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| Controller | egovframework.com.cop.adb.web.EgovAddressBookController.java | 주소록/명함 관리 컨트롤러 |
+| Service | egovframework.com.cop.adb.service.EgovAddressBookService.java | 주소록/명함 서비스 인터페이스 |
+| ServiceImpl | egovframework.com.cop.adb.service.impl.EgovAddressBookServiceImpl.java | 서비스 구현 클래스 |
+| DAO | egovframework.com.cop.adb.service.impl.AddressBookDAO.java | 명함 목록·상세 조회 포함 데이터처리 클래스 |
+| Query XML | resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_*.xml | DB별 Query XML |
+
+### 패키지 참조 관계
+
+주소록 패키지는 요소기술의 공통 패키지(cmm)에 대해서 직접적인 함수적 참조 관계를 가진다.
+
+## 참고자료
+
+- [주소록/명함록 개요](./address.md)
+- [주소록관리](./address-book.md)

--- a/common-component/collaboration/department-task-box.md
+++ b/common-component/collaboration/department-task-box.md
@@ -9,3 +9,35 @@ menu:
     weight: 6
     parent: "schedule-manage"
 ---
+
+# 부서업무함관리
+
+## 개요
+
+부서업무함관리는 부서별 업무함을 생성하고 부서 업무와 담당자를 등록·조회·관리할 수 있는 기능을 제공한다.
+
+## 설명
+
+부서업무함(DeptJobBx)을 단위로 부서의 업무(DeptJob)를 등록하고, 업무별 담당자(Charger)를 지정하여 관리한다. 부서 목록과 담당자 선택은 팝업 화면으로 제공된다.
+
+### 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| Controller | egovframework.com.cop.smt.djm.web.EgovDeptJobController.java | 부서업무함/부서업무 관리 컨트롤러 |
+| Service | egovframework.com.cop.smt.djm.service.EgovDeptJobService.java | 부서업무 서비스 인터페이스 |
+| ServiceImpl | egovframework.com.cop.smt.djm.service.impl.EgovDeptJobServiceImpl.java | 서비스 구현 클래스 |
+| DAO | egovframework.com.cop.smt.djm.service.impl.DeptJobDAO.java | 부서업무 데이터처리 클래스 |
+| Model/VO | egovframework.com.cop.smt.djm.service.DeptJobBx.java, DeptJobBxVO.java, DeptJob.java, DeptJobVO.java, Dept.java, DeptVO.java, Charger.java, ChargerVO.java | 부서업무함·업무·부서·담당자 모델 |
+| JSP | /WEB-INF/jsp/egovframework/com/cop/smt/djm/EgovDeptJobBxList.jsp 외 | 업무함 목록·등록·수정, 업무 목록·상세·등록·수정, 부서·담당자 팝업 |
+| Query XML | resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_*.xml | DB별 Query XML |
+| Message properties | resources/egovframework/message/com/cop/smt/djm/message_ko.properties, message_en.properties | 메시지 리소스 |
+
+### 패키지 참조 관계
+
+부서업무함 패키지는 요소기술의 공통 패키지(cmm)에 대해서 직접적인 함수적 참조 관계를 가진다.
+
+## 참고자료
+
+- [부서일정관리](./department-schedule.md)
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/collaboration/email.md
+++ b/common-component/collaboration/email.md
@@ -9,3 +9,47 @@ menu:
     parent: "collaboration"
     identifier: "email"
 ---
+
+# 전자우편
+
+## 개요
+
+전자우편 컴포넌트는 시스템에서 발송하는 전자우편(발송메일)을 등록하고, 발송 내역과 상세 내용을 관리할 수 있는 협업 서비스 컴포넌트이다. 첨부파일을 포함한 메일 발송을 지원한다.
+
+## 주요 개념
+
+발송할 메일을 등록(수신자·제목·본문·첨부파일)하면 발송메일 내역으로 관리되며, 발송 목록과 상세 내용을 조회할 수 있다. 멀티파트 메일(EgovMultiPartEmail)로 첨부파일이 포함된 메일 발송을 처리한다.
+
+## 관련 문서
+
+- [협업 카테고리 개요](./_index.md)
+
+## 설명
+
+### 패키지 구조
+
+전자우편 컴포넌트의 소스는 `egovframework.com.cop.ems` 패키지에 위치한다.
+
+### 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| Controller | egovframework.com.cop.ems.web.EgovSndngMailRegistController.java | 발송메일 등록 컨트롤러 |
+| Controller | egovframework.com.cop.ems.web.EgovSndngMailDtlsController.java | 발송메일 내역 컨트롤러 |
+| Controller | egovframework.com.cop.ems.web.EgovSndngMailDetailController.java | 발송메일 상세 컨트롤러 |
+| Service | egovframework.com.cop.ems.service.EgovSndngMailService.java | 메일 발송 서비스 인터페이스 |
+| Service | egovframework.com.cop.ems.service.EgovSndngMailRegistService.java | 발송메일 등록 서비스 인터페이스 |
+| Service | egovframework.com.cop.ems.service.EgovSndngMailDtlsService.java | 발송메일 내역 서비스 인터페이스 |
+| Service | egovframework.com.cop.ems.service.EgovSndngMailDetailService.java | 발송메일 상세 서비스 인터페이스 |
+| Model/VO | egovframework.com.cop.ems.service.SndngMail.java, SndngMailVO.java, AtchmnFileVO.java | 발송메일·첨부파일 모델 |
+| 유틸 | egovframework.com.cop.ems.service.EgovMultiPartEmail.java | 첨부파일 포함 멀티파트 메일 처리 |
+| JSP | /WEB-INF/jsp/egovframework/com/cop/ems/EgovMailRegist.jsp 외 | 메일 등록·내역·상세 화면 |
+| Query XML | resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_*.xml 외 | DB별 Query XML |
+
+### 패키지 참조 관계
+
+전자우편 패키지는 요소기술의 공통 패키지(cmm)에 대해서 직접적인 함수적 참조 관계를 가지며, 배포 시 패키지 간 참조 관계에 따라 관련 패키지와 함께 구성한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 기존 문서 보완 (docs/update)

## 변경 내용 (Description)

협업(collaboration) 카테고리에서 frontmatter만 있고 본문이 비어 있던 문서 5건에 내용을 작성했습니다. #672, #673과 같은 방향의 후속 작업입니다.

- `email.md` — 전자우편(발송메일) 개요: cop.ems 패키지, 발송메일 등록·내역·상세 관련 소스 표
- `address.md` — 주소록/명함록 개요(허브): 하위 2문서 연결, cop.adb 패키지 구조
- `address-book.md` — 주소록관리: 관련 소스(Controller/Service/DAO/JSP/Query XML) 표
- `business-card-management.md` — 명함관리: cop.adb 공유 구조 설명 및 관련 소스 표
- `department-task-box.md` — 부서업무함관리: cop.smt.djm 패키지(DeptJobBx·DeptJob·Charger) 관련 소스 표

모든 클래스·JSP·매퍼 경로는 egovframe-common-components 저장소(main) 실제 파일 목록에서 추출했습니다.

## 관련 이슈 (Related Issues)

없음 (#672, #673과 같은 계열의 빈 문서 보완입니다)

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다. (기존 frontmatter 그대로 유지)
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

`edsm.md`(전자결재)와 `brief-approval.md`(약식결재)는 현재 공통컴포넌트 저장소에 해당 소스가 없어 이번 범위에서 제외했습니다. 문서 유지 여부(구버전 안내 또는 문서 정리)에 대한 메인테이너 의견을 여쭙습니다.
