### PR TITLE
용어사전 문서의 URL과 ID 생성 설정 현행화

### DIFF
--- a/common-component/user-support/glossary.md
+++ b/common-component/user-support/glossary.md
@@ -30,7 +30,7 @@ menu:
 | --- | --- | --- |
 | Controller | egovframework.com.uss.olh.wor.web.EgovWordDicaryController.java | 용어사전관리를 위한 컨트롤러 클래스 |
 | Service | egovframework.com.uss.olh.wor.service.EgovWordDicaryService.java | 용어사전관리를 위한 서비스 인터페이스 |
-| ServiceImpl | egovframework.comuss.olh.wor.service.impl.EgovWordDicaryServiceImpl.java | 용어사전관리를 위한 서비스 구현 클래스 |
+| ServiceImpl | egovframework.com.uss.olh.wor.service.impl.EgovWordDicaryServiceImpl.java | 용어사전관리를 위한 서비스 구현 클래스 |
 | VO | egovframework.com.uss.olh.wor.service.WordDicaryVO.java | 용어사전관리를 위한 VO 클래스 |
 | VO | egovframework.com.uss.olh.wor.service.WordDicaryDefaultVO.java | 용어사전관리를 위한 SearchVO 클래스 |
 | DAO | egovframework.com.uss.olh.wor.service.impl.EgovWordDicaryDAO.java | 용어사전 관리를 위한 데이터처리 클래스 |
@@ -65,14 +65,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
   		   next_id DECIMAL(30) NOT NULL,
   		   PRIMARY KEY (table_name));
  
-  INSERT INTO COMTECOPSEQ VALUES('WORD_ID','0');
+  INSERT INTO COMTECOPSEQ VALUES('WORD_ID', 1);
 ```
 
 #### ID Generation 환경설정(context-idgn-WordDicary.xml)
 
 ```xml
 <bean name="egovWordDicaryIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy"   ref="wordDicaryStrategy" />
@@ -82,7 +82,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 	</bean>
  
 	<bean name="wordDicaryStrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="WORDDICARY_" />
 		<property name="cipers" value="9" />
 		<property name="fillChar" value="0" />
@@ -113,7 +113,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /uss/ion/wor/selectWordDicaryList.do | selectWordDicaryList | "WordDicary" | "selectWordDicaryList" |
+| 목록조회 | /uss/olh/wor/selectWordDicaryList.do | selectWordDicaryList | "WordDicary" | "selectWordDicaryList" |
 |  |  |  | "WordDicary" | "selectWordDicaryListCnt" |
 
  용어사전 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
@@ -131,7 +131,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 #### 비즈니스 규칙
 
- 일반사용자가 아닌 관리자가 사용하는 화면으로 용어사전조회에서 목록 클릭 시 이동되는 화면으로 사이트에 대한 상세정보를 보여준다.
+ 일반사용자가 아닌 관리자가 사용하는 화면으로 용어사전조회에서 목록 클릭 시 이동되는 화면으로 용어에 대한 상세정보를 보여준다.
 
 #### 관련코드
 
@@ -141,7 +141,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /uss/ion/wor/selectWordDicaryDetail.do | selectWordDicaryDetail | "WordDicary" | "selectWordDicaryDetail" |
+| 상세조회 | /uss/olh/wor/selectWordDicaryDetail.do | selectWordDicaryDetail | "WordDicary" | "selectWordDicaryDetail" |
 | 삭제 | /uss/olh/wor/deleteWordDicary.do | deleteWordDicary | "WordDicary" | "deleteWordDicary" |
 
  용어사전 상세조회화면은 용어사전목록조회에서 목록클릭 시 상세조회화면으로 이동된다.
@@ -166,7 +166,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 등록화면 | /uss/ion/wor/insertWordDicaryView.do | insertWordDicaryView |  |  |
+| 등록화면 | /uss/olh/wor/insertWordDicaryView.do | insertWordDicaryView |  |  |
 | 등록 | /uss/olh/wor/insertWordDicary.do | insertWordDicary | "WordDicary" | "insertWordDicary" |
 
  ![image](./images/uss-glossary-worddicary_regist.png)
@@ -188,7 +188,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 수정화면 | /uss/ion/wor/updateWordDicaryView.do | updateWordDicaryView | "WordDicary" | "selectWordDicaryDetail" |
+| 수정화면 | /uss/olh/wor/updateWordDicaryView.do | updateWordDicaryView | "WordDicary" | "selectWordDicaryDetail" |
 | 수정 | /uss/olh/wor/updateWordDicary.do | updateWordDicary | "WordDicary" | "updateWordDicary" |
 
  ![image](./images/uss-glossary-worddicary_updt.png)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

- 용어사전 관련 소스의 `ServiceImpl` 패키지 오타를 현행 클래스 경로에 맞게 수정했습니다.
- ID Generation 예제의 구현 클래스, 전략 클래스와 `WORD_ID` 초기값을 현행 설정 및 DML과 일치시켰습니다.
- 목록조회, 상세조회, 등록화면, 수정화면 URL을 현행 `EgovWordDicaryController`의 `/uss/olh/wor/...` 매핑과 일치시켰습니다.
- 상세조회 설명과 Action 명칭의 복사 오류를 용어사전 기능에 맞게 수정했습니다.
- 기존 Frontmatter와 이미지·메뉴 설정은 수정하지 않았습니다.

## 관련 이슈 (Related Issues)

- 없음

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] 최신 `upstream/main` 기준 커밋에서 작업했습니다.
- [x] Frontmatter가 변경되지 않았음을 확인했습니다.
- [x] 관련 클래스와 ID Generation 예제를 현행 소스, 설정, 5.0.0 JAR과 대조했습니다.
- [x] 용어사전 화면 URL을 현행 `EgovWordDicaryController` 매핑과 대조했습니다.
- [x] 문서가 참조하는 내부 링크와 이미지 파일의 존재를 확인했습니다.
- [x] `git diff --check`를 통과했습니다.
- [x] 변경 영역 외 파일이 포함되지 않았음을 확인했습니다.

## 추가 참고 사항 (Additional Notes)

- 기존 공식 위키 원문: https://www.egovframe.go.kr/wiki/doku.php?id=egovframework%3Acom%3Av5.0%3Auss%3A%EC%9A%A9%EC%96%B4%EC%82%AC%EC%A0%84
- 현행 Controller 근거: https://github.com/eGovFramework/egovframe-common-components/blob/main/src/main/java/egovframework/com/uss/olh/wor/web/EgovWordDicaryController.java
- 현행 ID Generation 설정: https://github.com/eGovFramework/egovframe-common-components/blob/main/src/main/resources/egovframework/spring/com/idgn/context-idgn-WordDicary.xml
- 현행 DML 근거: https://github.com/eGovFramework/egovframe-common-components/blob/main/script/dml/mysql/com_DML_mysql.sql
- 변경 파일: `common-component/user-support/glossary.md`
