### PR TITLE
FAQ 관리 문서의 URL과 설정 현행화

### DIFF
--- a/common-component/user-support/faq-management.md
+++ b/common-component/user-support/faq-management.md
@@ -20,7 +20,7 @@ menu:
 ### 패키지 참조 관계
 FAQ 관리 패키지는 요소기술의 공통 패키지(cmm)에 대해서만 직접적인 함수적 참조 관계를 가진다. 
 
-- 패키지 간 참조 관계 : [사용자지원 Package Dependency](../../intro/package-reference.md#사용자지원)
+- 패키지 간 참조 관계 : [사용자지원 Package Dependency](../intro/package-reference.md#사용자지원)
 
 ### 관련 소스
 
@@ -61,7 +61,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
            next_id DECIMAL(30) NOT NULL,
            PRIMARY KEY (table_name));
  
-INSERT INTO COMTECOPSEQ VALUES('FAQ_ID','0');
+INSERT INTO COMTECOPSEQ VALUES('FAQ_ID', 1);
 ```
 
 #### ID Generation 환경설정(context-idgn-FaqManage.xml)
@@ -105,11 +105,11 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /uss/ion/faq/selectFaqList.do | selectFaqList | "FaqManage" | "selectFaqList" |
+| 목록조회 | /uss/olh/faq/selectFaqList.do | selectFaqList | "FaqManage" | "selectFaqList" |
 | | | | "FaqManage" | "selectFaqListCnt" |
 
 FAQ 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 
-검색조건은 용어명, 영문명에 대해서 수행된다.
+검색조건은 질문제목에 대해서 수행된다.
 페이지 당 검색 범위를 변경하고자 하는 경우 
 context-properties.xml 파일의 pageUnit, pageSize를 변경한다.(단 해당 설정은 전체 공통서비스 기능에 영향을 미친다.)
 
@@ -131,7 +131,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /uss/ion/faq/selectFaqDetail.do | selectFaqDetail | "FaqManage" | "selectFaqDetail" |
+| 상세조회 | /uss/olh/faq/selectFaqDetail.do | selectFaqDetail | "FaqManage" | "selectFaqDetail" |
 | 삭제 | /uss/olh/faq/deleteFaq.do | deleteFaq | "FaqManage" | "deleteFaq" |
 
 FAQ 상세조회 화면에서는 FAQ 내용수정, FAQ 내용삭제, FAQ 목록조회를 수행할 수 있다.
@@ -154,7 +154,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 등록화면 | /uss/ion/faq/insertFaqView.do | insertFaqView | | |
+| 등록화면 | /uss/olh/faq/insertFaqView.do | insertFaqView | | |
 | 등록 | /uss/olh/faq/insertFaq.do | insertFaq | "FaqManage" | "insertFaq" |
 
 ![FAQ 등록](./images/faq-management-regist.png)
@@ -178,7 +178,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 수정화면 | /uss/ion/faq/updateFaqView.do | updateFaqView | "FaqManage" | "selectFaqDetail" |
+| 수정화면 | /uss/olh/faq/updateFaqView.do | updateFaqView | "FaqManage" | "selectFaqDetail" |
 | 수정 | /uss/olh/faq/updateFaq.do | updateFaq | "FaqManage" | "updateFaq" |
 
 ![FAQ 수정](./images/faq-management-update.png)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

- FAQ관리 문서의 패키지 참조 링크를 실제 `common-component/intro/package-reference.md` 위치에 맞게 수정했습니다.
- ID Generation 예제의 `FAQ_ID` 초기값을 현행 DML과 일치시켰습니다.
- 목록조회, 상세조회, 등록화면, 수정화면 URL을 현행 `EgovFaqController`의 `/uss/olh/faq/...` 매핑과 일치시켰습니다.
- 목록조회 검색조건 설명을 현행 화면의 질문제목 조건과 일치시켰습니다.
- 기존 Frontmatter와 이미지·메뉴 설정은 수정하지 않았습니다.

## 관련 이슈 (Related Issues)

- 없음

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] 최신 `upstream/main` 기준 커밋에서 작업했습니다.
- [x] Frontmatter가 변경되지 않았음을 확인했습니다.
- [x] 내부 링크 대상 파일과 `사용자지원` 앵커가 존재함을 확인했습니다.
- [x] `FAQ_ID` 초기값을 8개 지원 DB의 현행 DML과 대조했습니다.
- [x] FAQ 화면 URL을 현행 `EgovFaqController` 매핑과 대조했습니다.
- [x] 목록조회 검색조건을 현행 `EgovFaqList.jsp`와 대조했습니다.
- [x] `git diff --check`를 통과했습니다.
- [x] 변경 영역 외 파일이 포함되지 않았음을 확인했습니다.

## 추가 참고 사항 (Additional Notes)

- 기존 공식 위키 원문: https://www.egovframe.go.kr/wiki/doku.php?id=egovframework%3Acom%3Av5.0%3Auss%3Afaq%EA%B4%80%EB%A6%AC
- 현행 구현 근거: https://github.com/eGovFramework/egovframe-common-components/blob/main/src/main/java/egovframework/com/uss/olh/faq/web/EgovFaqController.java
- 내부 링크 대상: https://github.com/eGovFramework/egovframe-docs/blob/main/common-component/intro/package-reference.md#사용자지원
- 변경 파일: `common-component/user-support/faq-management.md`
