### PR TITLE
docs: 문자열 처리 요소기술 문서 4건 내용 작성 (검색·변환·치환·특수문자)

### DIFF
--- a/common-component/elementary-technology/special-string-processing.md
+++ b/common-component/elementary-technology/special-string-processing.md
@@ -9,3 +9,34 @@ menu:
     weight: 22
     parent: "formatter-util"
 ---
+
+# 특수문자처리
+
+## 개요
+
+특수문자처리는 HTML 등 웹 표시 환경에서 특수문자가 깨지거나 스크립트로 해석되지 않도록 변환·복원하는 기능을 제공하는 요소기술이다. `EgovStringUtil` 유틸리티의 정적 메서드로 사용한다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovStringUtil.java | 문자열 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `getSpclStrCnvr(String srcString)` | `String` | 특수문자를 웹 브라우저에서 정상적으로 보이기 위해 특수문자를 처리(' & lT)하는 기능이다 |
+| `getHtmlStrCnvr(String srcString)` | `String` | html의 특수문자를 표현하기 위해 |
+| `checkHtmlView(String strString)` | `String` | Html 코드가 들어간 문서를 표시할때 태그에 손상없이 보이기 위한 메서드 |
+
+## 사용 예
+
+```java
+String esc = EgovStringUtil.getSpclStrCnvr("<script>");  // &lt;script&gt; 형태로 변환
+String htm = EgovStringUtil.getHtmlStrCnvr(escapedText);  // HTML 특수문자 복원
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/string-conversion.md
+++ b/common-component/elementary-technology/string-conversion.md
@@ -9,3 +9,44 @@ menu:
     weight: 9
     parent: "formatter-util"
 ---
+
+# 문자열변환
+
+## 개요
+
+문자열변환은 대소문자 변환, 문자셋 인코딩 변환, null 안전 변환, 지정 길이 절단 등 변환성 기능을 제공하는 요소기술이다. `EgovStringUtil` 유틸리티의 정적 메서드로 사용한다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovStringUtil.java | 문자열 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `lowerCase(String str)` | `String` | {@link String#toLowerCase()}를 이용하여 소문자로 변환한다 |
+| `upperCase(String str)` | `String` | {@link String#toUpperCase()}를 이용하여 대문자로 변환한다 |
+| `getEncdDcd(String srcString, String srcCharsetNm, String cnvrCharsetNm)` | `String` | 문자열을 다양한 문자셋(EUC-KR[KSC5601],UTF-8..)을 사용하여 인코딩하는 기능 역으로 디코딩하여 원래의 문자열을 |
+| `isNullToString(Object object)` | `String` | 객체가 null인지 확인하고 null인 경우 "" 로 바꾸는 메서드 |
+| `nullConvert(Object src)` | `String` | 인자로 받은 String이 null일 경우 &quot;&quot;로 리턴한다 |
+| `nullConvert(String src)` | `String` | 인자로 받은 String이 null일 경우 &quot;&quot;로 리턴한다 |
+| `zeroConvert(Object src)` | `int` | 인자로 받은 String이 null일 경우 &quot;0&quot;로 리턴한다 |
+| `zeroConvert(String src)` | `int` | 인자로 받은 String이 null일 경우 &quot;&quot;로 리턴한다 |
+| `cutString(String source, String output, int slength)` | `String` | 2009.01.13     박정규          최초 생성 |
+| `cutString(String source, int slength)` | `String` | 문자열이 지정한 길이를 초과했을때 해당 문자열을 삭제하는 메서드 |
+| `decode(String sourceStr, String compareStr, String returnStr, String defaultStr)` | `String` | 오라클의 decode 함수와 동일한 기능을 가진 메서드이다 |
+| `decode(String sourceStr, String compareStr, String returnStr)` | `String` | 오라클의 decode 함수와 동일한 기능을 가진 메서드이다 |
+
+## 사용 예
+
+```java
+String lower = EgovStringUtil.lowerCase("EgovFrame");            // egovframe
+String safe  = EgovStringUtil.isNullToString(nullableValue);      // null이면 ""
+String cut   = EgovStringUtil.cutString("표준프레임워크", "…", 4); // 지정 길이 절단
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/string-replacement.md
+++ b/common-component/elementary-technology/string-replacement.md
@@ -9,3 +9,43 @@ menu:
     weight: 11
     parent: "formatter-util"
 ---
+
+# 문자열치환
+
+## 개요
+
+문자열치환은 특정 문자열·문자 치환, 대상 문자 제거, 앞뒤 지정 문자 제거(strip), 공백 제거 등 치환·정리 기능을 제공하는 요소기술이다. `EgovStringUtil` 유틸리티의 정적 메서드로 사용한다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovStringUtil.java | 문자열 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `replace(String source, String subject, String object)` | `String` | 원본 문자열의 포함된 특정 문자열을 새로운 문자열로 변환하는 메서드 |
+| `replaceOnce(String source, String subject, String object)` | `String` | 원본 문자열의 포함된 특정 문자열 첫번째 한개만 새로운 문자열로 변환하는 메서드 |
+| `replaceChar(String source, String subject, String object)` | `String` | subject에 포함된 각각의 문자를 object로 변환한다 |
+| `remove(String str, char remove)` | `String` | 기준 문자열에 포함된 모든 대상 문자(char)를 제거한다 |
+| `removeCommaChar(String str)` | `String` | 문자열 내부의 콤마 character(,)를 모두 제거한다 |
+| `removeMinusChar(String str)` | `String` | 문자열 내부의 마이너스 character(-)를 모두 제거한다 |
+| `removeWhitespace(String str)` | `String` | 문자열에서 {@link Character#isWhitespace(char)}에 정의된 |
+| `strip(String str, String stripChars)` | `String` | 입력된 String의 앞, 뒤에서 두번째 인자로 전달된 문자(stripChars)를 모두 제거한다 |
+| `stripStart(String str, String stripChars)` | `String` | 입력된 String의 앞쪽에서 두번째 인자로 전달된 문자(stripChars)를 모두 제거한다 |
+| `stripEnd(String str, String stripChars)` | `String` | 입력된 String의 뒤쪽에서 두번째 인자로 전달된 문자(stripChars)를 모두 제거한다 |
+| `addMinusChar(String date)` | `String` | 날짜 형식의 문자열 내부에 마이너스 character(-)를 추가한다 |
+
+## 사용 예
+
+```java
+String s1 = EgovStringUtil.replace("a-b-c", "-", ":");   // a:b:c
+String s2 = EgovStringUtil.removeMinusChar("2026-07-11"); // 20260711
+String s3 = EgovStringUtil.strip("  egov  ", " ");        // egov
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/string-search.md
+++ b/common-component/elementary-technology/string-search.md
@@ -9,3 +9,36 @@ menu:
     weight: 8
     parent: "formatter-util"
 ---
+
+# 문자열검색
+
+## 개요
+
+문자열검색은 문자열 내 특정 문자열의 위치 확인, 분리자 기준 분할, 공백 여부 확인 등 검색성 기능을 제공하는 요소기술이다. `EgovStringUtil` 유틸리티의 정적 메서드로 사용한다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovStringUtil.java | 문자열 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `indexOf(String str, String searchStr)` | `int` | str 중 searchStr의 시작(index) 위치를 반환 |
+| `split(String source, String separator)` | `String[]` | 문자열을 지정한 분리자에 의해 배열로 리턴하는 메서드 |
+| `split(String source, String separator, int arraylength)` | `String[]` | 문자열을 지정한 분리자에 의해 지정된 길이의 배열로 리턴하는 메서드 |
+| `isEmpty(String str)` | `boolean` | String이 비었거나("") 혹은 null 인지 검증한다 |
+
+## 사용 예
+
+```java
+int pos = EgovStringUtil.indexOf("egovframework", "gov");   // 1
+String[] parts = EgovStringUtil.split("a,b,c", ",");        // [a, b, c]
+boolean empty = EgovStringUtil.isEmpty("");                   // true
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 기존 문서 보완 (docs/update)

## 변경 내용 (Description)

요소기술 카테고리의 문자열 처리 문서 4건이 frontmatter만 있고 본문이 비어 있어 내용을 작성했습니다. #672~#689(병합 완료)와 같은 방향의 후속 작업입니다.

- `string-search.md` (문자열검색) — indexOf·split·isEmpty
- `string-conversion.md` (문자열변환) — 대소문자·문자셋 인코딩·null 안전 변환·절단·decode
- `string-replacement.md` (문자열치환) — replace 계열·remove 계열·strip 계열
- `special-string-processing.md` (특수문자처리) — getSpclStrCnvr·getHtmlStrCnvr·checkHtmlView

각 문서는 개요 / 관련 소스 / **주요 메서드 표(시그니처·반환형·설명)** / 사용 예 / 참고자료로 구성했으며, 메서드 표의 시그니처와 설명은 `egovframework.com.utl.fcc.service.EgovStringUtil` 소스의 Javadoc에서 직접 추출했습니다.

## 관련 이슈 (Related Issues)

없음 (#672~#689와 같은 계열의 빈 문서 보완입니다)

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다. (기존 frontmatter 그대로 유지)
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

string-validation.md(문자열 유효성체크)는 근거 클래스가 달라 별도 조사 후 후속 PR로 진행하겠습니다. 날짜/숫자/파일 계열도 동일 방식(EgovDateUtil·EgovNumberUtil·EgovFileUtil Javadoc 추출)으로 이어갈 수 있습니다.
