### PR TITLE
docs: 날짜·숫자·랜덤 요소기술 문서 8건 내용 작성 (Javadoc 기반)

### DIFF
--- a/common-component/elementary-technology/number-search.md
+++ b/common-component/elementary-technology/number-search.md
@@ -9,3 +9,32 @@ menu:
     weight: 14
     parent: "formatter-util"
 ---
+
+# 숫자검색
+
+## 개요
+
+숫자검색은 숫자 집합에서 특정 숫자의 존재 여부 확인, 특정 숫자의 치환 등 숫자 검색성 기능을 제공하는 요소기술이다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovNumberUtil.java | Number 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `getNumSearchCheck(int sourceInt, int searchInt)` | `Boolean` | 특정 숫자 집합에서 특정 숫자가 있는지 체크하는 기능 12345678에서 7이 있는지 없는지 체크하는 기능을 제공함 |
+| `getNumberCnvr(int srcNumber, int cnvrSrcNumber, int cnvrTrgtNumber)` | `int` | 특정숫자를 다른 숫자로 치환하는 기능 숫자 12345678에서 123를 999로 변환하는 기능을 제공(99945678) |
+
+## 사용 예
+
+```java
+boolean has7 = EgovNumberUtil.getNumSearchCheck(12345678, 7); // 7 포함 여부
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/number-validation.md
+++ b/common-component/elementary-technology/number-validation.md
@@ -9,3 +9,31 @@ menu:
     weight: 16
     parent: "formatter-util"
 ---
+
+# 숫자 유효성체크
+
+## 개요
+
+숫자 유효성체크는 입력값이 숫자인지 여부를 검사하는 요소기술이다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovNumberUtil.java | Number 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `getNumberValidCheck(String checkStr)` | `Boolean` | 체크할 숫자 중에서 숫자인지 아닌지 체크하는 기능 |
+
+## 사용 예
+
+```java
+boolean ok = EgovNumberUtil.getNumberValidCheck("12345"); // 숫자 여부
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/random-date.md
+++ b/common-component/elementary-technology/random-date.md
@@ -9,3 +9,31 @@ menu:
     weight: 5
     parent: "formatter-util"
 ---
+
+# 랜덤 날짜
+
+## 개요
+
+랜덤 날짜는 지정한 두 일자 사이의 임의의 일자를 생성하는 요소기술이다. 테스트 데이터 생성 등에 활용할 수 있다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovDateUtil.java | Date 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `getRandomDate(String sDate1, String sDate2)` | `String` | 입력받은 일자 사이의 임의의 일자를 반환 |
+
+## 사용 예
+
+```java
+String d = EgovDateUtil.getRandomDate("20260101", "20261231"); // 기간 내 임의 일자
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/random-number.md
+++ b/common-component/elementary-technology/random-number.md
@@ -9,3 +9,31 @@ menu:
     weight: 7
     parent: "formatter-util"
 ---
+
+# 랜덤 숫자
+
+## 개요
+
+랜덤 숫자는 시작값과 종료값 사이의 임의의 숫자를 생성하는 요소기술이다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovNumberUtil.java | Number 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `getRandomNum(int startNum, int endNum)` | `int` | 시작값과 종료값 사이의 임의의 숫자를 반환한다 |
+
+## 사용 예
+
+```java
+int n = EgovNumberUtil.getRandomNum(1, 100); // 1~100 사이 임의 숫자
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/random-string.md
+++ b/common-component/elementary-technology/random-string.md
@@ -9,3 +9,31 @@ menu:
     weight: 6
     parent: "formatter-util"
 ---
+
+# 랜덤 문자열
+
+## 개요
+
+랜덤 문자열은 시작 문자와 종료 문자 사이의 임의의 문자열을 생성하는 요소기술이다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovStringUtil.java | String 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `getRandomStr(char startChr, char endChr)` | `String` | 문자열 A에서 Z사이의 랜덤 문자열을 구하는 기능을 제공 시작문자열과 종료문자열 사이의 랜덤 문자열을 구하는 기능 |
+
+## 사용 예
+
+```java
+String s = EgovStringUtil.getRandomStr('A', 'Z'); // A~Z 사이 임의 문자열
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/real-int-negative-check.md
+++ b/common-component/elementary-technology/real-int-negative-check.md
@@ -9,3 +9,31 @@ menu:
     weight: 19
     parent: "formatter-util"
 ---
+
+# 실수/정수/음수 체크
+
+## 개요
+
+실수/정수/음수 체크는 특정 숫자가 실수인지, 정수인지, 음수인지 판별하는 요소기술이다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovNumberUtil.java | Number 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `checkRlnoInteger(double srcNumber)` | `int` | 특정숫자가 실수인지, 정수인지, 음수인지 체크하는 기능 123이 실수인지, 정수인지, 음수인지 체크하는 기능을 제공함 |
+
+## 사용 예
+
+```java
+int type = EgovNumberUtil.checkRlnoInteger("123"); // 실수/정수/음수 판별
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/solar-lunar-conversion.md
+++ b/common-component/elementary-technology/solar-lunar-conversion.md
@@ -9,3 +9,31 @@ menu:
     weight: 20
     parent: "formatter-util"
 ---
+
+# 양음력변환
+
+## 개요
+
+양음력변환은 양력 일자를 음력 일자로 변환하는 요소기술이다. 명절·기념일 등 음력 기반 일자 처리에 활용한다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovDateUtil.java | Date 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `toSolar(String sDate, int iLeapMonth)` | `String` | 입력받은 양력일자를 변환하여 음력일자로 반환 |
+
+## 사용 예
+
+```java
+String lunar = EgovDateUtil.toSolar("20260711", 0); // 양력 → 음력 변환
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/timestamp-value.md
+++ b/common-component/elementary-technology/timestamp-value.md
@@ -9,3 +9,31 @@ menu:
     weight: 24
     parent: "formatter-util"
 ---
+
+# TIMESTAMP값
+
+## 개요
+
+TIMESTAMP값은 응용시스템에서 고유값이 필요할 때 시스템 시각 기반의 17자리 TIMESTAMP 문자열을 생성하는 요소기술이다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovStringUtil.java | String 처리 유틸리티 클래스 |
+
+## 주요 메서드
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `getTimeStamp()` | `String` | 응용어플리케이션에서 고유값을 사용하기 위해 시스템에서17자리의TIMESTAMP값을 구하는 기능 |
+
+## 사용 예
+
+```java
+String ts = EgovStringUtil.getTimeStamp(); // 예: 20260711153021123 (17자리)
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 기존 문서 보완 (docs/update)

## 변경 내용 (Description)

요소기술 카테고리의 빈 문서 8건에 내용을 작성했습니다. #690(문자열 처리 4건)과 같은 방식으로, 각 문서의 주요 메서드 표(시그니처·반환형·설명)를 해당 유틸리티 클래스의 Javadoc에서 직접 추출했습니다.

| 문서 | 근거 클래스·메서드 |
| --- | --- |
| `random-date.md` (랜덤 날짜) | EgovDateUtil.getRandomDate |
| `solar-lunar-conversion.md` (양음력변환) | EgovDateUtil.toSolar |
| `random-number.md` (랜덤 숫자) | EgovNumberUtil.getRandomNum |
| `random-string.md` (랜덤 문자열) | EgovStringUtil.getRandomStr |
| `timestamp-value.md` (TIMESTAMP값) | EgovStringUtil.getTimeStamp |
| `number-search.md` (숫자검색) | EgovNumberUtil.getNumSearchCheck·getNumberCnvr |
| `number-validation.md` (숫자 유효성체크) | EgovNumberUtil.getNumberValidCheck |
| `real-int-negative-check.md` (실수/정수/음수 체크) | EgovNumberUtil.checkRlnoInteger |

구성은 개요 / 관련 소스 / 주요 메서드 표 / 사용 예 / 참고자료이며, 기존 frontmatter는 그대로 유지했습니다.

## 관련 이슈 (Related Issues)

없음 (#672~#690과 같은 계열의 빈 문서 보완입니다)

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다. (기존 frontmatter 그대로 유지)
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.
