### PR TITLE
docs: 파일 계열 요소기술 문서 11건 내용 작성

### DIFF
--- a/common-component/elementary-technology/directory-move.md
+++ b/common-component/elementary-technology/directory-move.md
@@ -9,3 +9,71 @@ menu:
     weight: 10
     parent: "system"
 ---
+
+## 개요
+
+비즈니스 로직을 처리하면서 필요시 디렉토리를 이동할 수 있는 공통 기능을 제공한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+디렉토리이동에서 제공하는 기능은 다음과 같다.
+
+1. 원본 디렉토리를 타겟 디렉토리로 이동하는 기능
+2. 원본 디렉토리의 최종수정일자가 특정 구간 내에 포함되는 경우에 한해서 타겟 디렉토리로 이동하는 기능
+3. 원본 디렉토리가 특정 소유자인 경우에 한해서 타겟 디렉토리로 이동하는 기능 (WINDOWS 시스템에서는 지원하지 않음)
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDrctryMvmn.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+디렉토리이동 기능은 `EgovFileTool` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| boolean | `moveFile(String dirOriginalPath, String dirTargetPath)` | 디렉토리 이동 | 원본디렉토리경로(`dirOriginalPath`)를 입력받아 타겟디렉토리(`dirTargetPath`)로 이동한다. 타겟디렉토리가 이미 존재하는 경우는 실패로 처리된다. 성공 시 `true`, 실패 시 `false` 리턴 |
+| boolean | `moveFile(String dirOriginalPath, String dirTargetPath, String fromDate, String toDate)` | 디렉토리 이동 (일자 조건) | 원본디렉토리의 생성일자가 조건구간(`fromDate`과 `toDate` 사이) 내에 포함되는 경우 타겟디렉토리로 이동한다. 성공 시 `true`, 실패 시 `false` 리턴 |
+| boolean | `moveFile(String dirOriginalPath, String dirTargetPath, String owner)` | 디렉토리 이동 (소유자 조건) | 원본디렉토리가 소유자조건(`owner`)에 일치하는 경우 타겟디렉토리로 이동한다. 성공 시 `true`, 실패 시 `false` 리턴 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `dirOriginalPath`: String 타입의 절대경로를 포함하는 원본디렉토리 경로 (예: `/product/jeus/egovProps/tmp/dir1`)
+- `dirTargetPath`: String 타입의 절대경로를 포함하는 타겟디렉토리 경로 (예: `/product/jeus/egovProps/tmp/move1`)
+- `fromDate` / `toDate`: String 타입의 날짜정보 (예: `20090101`, YYYYMMDD 형태)
+- `owner`: String 타입의 사용자계정명 (예: `jeus`)
+
+#### 반환값 정의 (Output)
+
+- boolean 타입: 이동 성공 여부 (`true` / `false`)
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovFileTool;
+
+// 1. 디렉토리 이동
+boolean result1 = EgovFileTool.moveFile("/user/com/dir1", "/user/com/move1");
+
+// 2. 일자 조건 디렉토리 이동
+boolean result2 = EgovFileTool.moveFile("/user/com/dir2", "/user/com/move2", "20090101", "20090131");
+
+// 3. 소유자 조건 디렉토리 이동
+boolean result3 = EgovFileTool.moveFile("/user/com/dir3", "/user/com/move3", "com");
+```
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/directory-permission-check.md
+++ b/common-component/elementary-technology/directory-permission-check.md
@@ -9,3 +9,65 @@ menu:
     weight: 4
     parent: "system"
 ---
+
+## 개요
+
+비즈니스 로직을 처리하면서 필요한 디렉토리의 접근 권한을 확인하기 위한 공통 기능을 제공한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+디렉토리권한체크에서 제공하는 기능은 다음과 같다.
+
+1. 디렉토리의 읽기 권한을 조회하는 기능
+2. 디렉토리의 쓰기 권한을 조회하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileAuthor.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+디렉토리권한체크 기능은 `EgovFileTool` 클래스의 메소드를 활용하여 제공한다. 파일과 디렉토리에 동일한 메소드를 사용한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| boolean | `canRead(String filePath)` | 읽기권한 체크 | 디렉토리(파일) 경로를 입력받아 읽기 가능하면 `true`를 리턴한다. 권한이 없거나 대상이 없는 경우는 `false`를 리턴 |
+| boolean | `canWrite(String filePath)` | 쓰기권한 체크 | 디렉토리(파일) 경로를 입력받아 쓰기 가능하면 `true`를 리턴한다. 권한이 없거나 대상이 없는 경우는 `false`를 리턴 (대상경로가 파일인 경우만 정보가 유효함) |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `filePath`: String 타입의 절대경로를 포함한 디렉토리 경로 (예: `/user/com/test/dir1`)
+
+#### 반환값 정의 (Output)
+
+- boolean 타입: 권한 보유 여부 (`true` / `false`)
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovFileTool;
+
+String dirPath = "/user/com/test/dir1";
+
+// 읽기 권한 확인
+boolean readVal = EgovFileTool.canRead(dirPath);
+
+// 쓰기 권한 확인
+boolean writeVal = EgovFileTool.canWrite(dirPath);
+```
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/file-exist-check.md
+++ b/common-component/elementary-technology/file-exist-check.md
@@ -9,3 +9,81 @@ menu:
     weight: 43
     parent: "system"
 ---
+
+## 개요
+
+디렉토리에 파일이 존재하는지 체크하는 기능을 제공한다. 파일명뿐 아니라 확장자, 수정기간, 사이즈, 생성자(Owner)별 조건으로도
+파일의 존재 여부를 확인할 수 있다. 서버(Server) 및 클라이언트(Client) 응용 애플리케이션에서 파일 존재 체크 시 활용할 수 있다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+파일존재체크에서 제공하는 기능은 다음과 같다.
+
+1. 디렉토리에 특정 파일이 존재하는지 체크하는 기능
+2. 파일 확장자별로 파일이 존재하는지 체크하는 기능
+3. 파일 수정기간별로 파일이 존재하는지 체크하는 기능
+4. 파일 사이즈별로 파일이 존재하는지 체크하는 기능
+5. 파일 생성자(Owner)별로 파일이 존재하는지 체크하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileExst.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+파일존재체크 기능은 `EgovFileTool` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| boolean | `checkFileExstByName(String dir, String file)` | 파일존재확인 | 디렉토리에 파일이 존재하는지 체크한다 |
+| boolean | `checkFileExstByExtnt(String dir, String eventn)` | 확장자별 파일존재확인 | 확장자별로 디렉토리에 파일이 존재하는지 체크한다 |
+| boolean | `checkFileExstByOwner(String dir, String owner)` | 생성자별 파일존재확인 | 생성자별로 디렉토리에 파일이 존재하는지 체크한다 |
+| boolean | `checkFileExstByUpdtPd(String dir, String updtFrom, String updtTo)` | 수정기간별 파일존재확인 | 수정기간별로 디렉토리에 파일이 존재하는지 체크한다 |
+| boolean | `checkFileExstBySize(String dir, long sizeFrom, long sizeTo)` | 사이즈별 파일존재확인 | 사이즈별로 디렉토리에 파일이 존재하는지 체크한다 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `dir`: String 타입의 절대경로를 포함한 디렉토리 (예: `/user/com/test`)
+- `file`: String 타입의 파일명 (예: `file1.txt`)
+- `eventn`: String 타입의 확장자 (예: `.txt` 형태로 입력)
+- `updtFrom` / `updtTo`: String 타입의 수정기간 시작/종료일자 (예: `20090501`, YYYYMMDD 형태)
+- `sizeFrom` / `sizeTo`: long 타입의 사이즈 범위 (KB 단위)
+- `owner`: String 타입의 파일 생성자 (예: `com`)
+
+#### 반환값 정의 (Output)
+
+- boolean 타입: 파일 존재 여부 (`true` / `false`)
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovFileTool;
+
+// 1. 파일 존재 확인
+boolean result1 = EgovFileTool.checkFileExstByName("/user/com/test", "file1.txt");
+
+// 2. 확장자별 파일 존재 확인
+boolean result2 = EgovFileTool.checkFileExstByExtnt("/user/com/test", ".txt");
+
+// 3. 수정기간별 파일 존재 확인
+boolean result3 = EgovFileTool.checkFileExstByUpdtPd("/user/com/test", "20090501", "20090531");
+
+// 4. 사이즈별 파일 존재 확인
+boolean result4 = EgovFileTool.checkFileExstBySize("/user/com/test", 100L, 2000L);
+```
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/file-move.md
+++ b/common-component/elementary-technology/file-move.md
@@ -9,3 +9,64 @@ menu:
     weight: 41
     parent: "system"
 ---
+
+## 개요
+
+비즈니스 로직을 처리하면서 필요시 파일을 이동할 수 있는 공통 기능을 제공한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+파일이동에서 제공하는 기능은 다음과 같다.
+
+1. 원본 파일을 타겟 파일로 이동하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDrctryMvmn.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+파일이동 기능은 `EgovFileTool` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| boolean | `moveFile(String fileOriginalPath, String fileTargetPath)` | 파일 이동 | 원본파일(`fileOriginalPath`)을 입력받아 타겟파일(`fileTargetPath`)로 이동한다. 타겟파일이 이미 존재하는 경우는 실패로 처리된다. 성공 시 `true`, 실패 시 `false` 리턴 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `fileOriginalPath`: String 타입의 절대경로를 포함하는 원본파일 경로 (예: `/product/jeus/egovProps/tmp/file1.txt`)
+- `fileTargetPath`: String 타입의 절대경로를 포함하는 타겟파일 경로 (예: `/product/jeus/egovProps/tmp/move1.txt`)
+
+#### 반환값 정의 (Output)
+
+- boolean 타입: 이동 성공 여부 (`true` / `false`)
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovFileTool;
+
+String fileOriginalPath = "/user/com/file1.txt";
+String fileTargetPath   = "/user/com/move1.txt";
+
+boolean result = EgovFileTool.moveFile(fileOriginalPath, fileTargetPath);
+if (result) {
+    System.out.println("파일 이동 성공");
+}
+```
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/file-parsing.md
+++ b/common-component/elementary-technology/file-parsing.md
@@ -9,3 +9,75 @@ menu:
     weight: 44
     parent: "system"
 ---
+
+## 개요
+
+사용자가 업로드한 파일 및 서버(Server)의 텍스트 파일을 특정 구분자(`,`, `|`, `TAB`)로 파싱하여 정보를 추출하는 기능을 제공한다.
+또한 파일의 텍스트 라인을 일정 길이(Size)별로 파싱하여 정보를 추출할 수 있다.
+사용자 정보, 제품목록 정보 등을 CSV 파일로 작성하여 서버에 업로드한 후 파싱하여 일괄적으로 데이터베이스에 입력하는 경우에 활용할 수 있다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+파일파싱에서 제공하는 기능은 다음과 같다.
+
+1. 텍스트 파일을 구분자에 의해 파싱하는 기능
+2. 텍스트 파일을 일정 길이에 의해 파싱하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFilePars.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+파일파싱 기능은 `EgovFileTool` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| Vector | `parsFileByChar(String parFile, String parChar, int parField)` | 특정구분자 파일파싱 | 파일을 특정 구분자(콤마, 파이프, TAB)로 파싱한다 |
+| Vector | `parsFileBySize(String parFile, int[] parLen, int parLine)` | 일정길이 파일파싱 | 파일을 필드별 일정 길이로 파싱한다 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `parFile`: String 타입의 절대경로를 포함한 파일명 (예: `/user/com/test/file1.txt`)
+- `parChar`: String 타입의 파싱 구분자 (예: `,`)
+- `parField`: int 타입의 파싱 필드수 (예: `3`)
+- `parLen`: int[] 타입의 각 필드 길이 (예: `{3, 3, 3}`)
+- `parLine`: int 타입의 읽어낼 라인수 (예: `10`)
+
+#### 반환값 정의 (Output)
+
+- Vector 타입: 파싱 결과 구조체 (라인별 필드 목록)
+
+### 사용 방법
+
+```java
+import java.util.List;
+import java.util.Vector;
+
+import egovframework.com.utl.sim.service.EgovFileTool;
+
+// 1. 특정 구분자 파일파싱
+String parFile = "/user/com/test/file1.txt";
+Vector<List<String>> result1 = EgovFileTool.parsFileByChar(parFile, ",", 3);
+
+// 2. 일정 길이 파일파싱
+int[] parLen = {3, 3, 3};
+int parLine = 10;
+Vector<List<String>> result2 = EgovFileTool.parsFileBySize(parFile, parLen, parLine);
+```
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/file-permission-check.md
+++ b/common-component/elementary-technology/file-permission-check.md
@@ -9,3 +9,65 @@ menu:
     weight: 23
     parent: "system"
 ---
+
+## 개요
+
+비즈니스 로직을 처리하면서 필요한 파일의 접근 권한을 확인하기 위한 공통 기능을 제공한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+파일권한체크에서 제공하는 기능은 다음과 같다.
+
+1. 파일의 읽기 권한을 조회하는 기능
+2. 파일의 쓰기 권한을 조회하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileAuthor.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+파일권한체크 기능은 `EgovFileTool` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| boolean | `canRead(String filePath)` | 읽기권한 체크 | 파일경로를 입력받아 읽기 가능하면 `true`를 리턴한다. 권한이 없거나 파일이 없는 경우는 `false`를 리턴 |
+| boolean | `canWrite(String filePath)` | 쓰기권한 체크 | 파일경로를 입력받아 쓰기 가능하면 `true`를 리턴한다. 권한이 없거나 파일이 없는 경우는 `false`를 리턴 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `filePath`: String 타입의 절대경로를 포함한 파일명 (예: `/user/com/test/file1.txt`)
+
+#### 반환값 정의 (Output)
+
+- boolean 타입: 권한 보유 여부 (`true` / `false`)
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovFileTool;
+
+String filePath = "/user/com/sample/test.txt";
+
+// 읽기 권한 확인
+boolean readVal = EgovFileTool.canRead(filePath);
+
+// 쓰기 권한 확인
+boolean writeVal = EgovFileTool.canWrite(filePath);
+```
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/file-security.md
+++ b/common-component/elementary-technology/file-security.md
@@ -9,3 +9,81 @@ menu:
     weight: 29
     parent: "system"
 ---
+
+## 개요
+
+암호화 알고리즘을 사용하여 파일을 암호화하거나 역으로 복호화하는 기능을 제공한다. 다양한 파일 포맷의 암호화/복호화를 지원하며,
+문자열 데이터의 인코딩/디코딩과 복호화가 불가능한 비밀번호 암호화 기능도 함께 제공한다.
+서버(Server) 및 클라이언트(Client) 응용 애플리케이션에서 파일 보안 처리 시 활용할 수 있다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+파일보안에서 제공하는 기능은 다음과 같다.
+
+1. 암호화 알고리즘에 의해 파일을 암호화하는 기능
+2. 복호화 알고리즘을 사용하여 파일을 복호화하는 기능
+3. 문자열 데이터를 암호화(인코딩)/복호화(디코딩)하는 기능
+4. 비밀번호를 복호화가 불가능한 방식(단방향 해시)으로 암호화하고 검증하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovFileScrty.java` | 파일 암호화/복호화 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileScrty.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+파일보안 기능은 `EgovFileScrty` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| boolean | `encryptFile(String source, String target)` | 파일 암호화 | 원본파일(`source`)을 암호화하여 결과파일(`target`)로 생성한다. 성공 시 `true`, 실패 시 `false` 리턴 |
+| boolean | `decryptFile(String source, String target)` | 파일 복호화 | 암호화된 파일(`source`)을 복호화하여 결과파일(`target`)로 생성한다. 성공 시 `true`, 실패 시 `false` 리턴 |
+| String | `encode(String data)` | 데이터 암호화 | String 데이터를 암호화(인코딩) 처리한다 |
+| String | `decode(String data)` | 데이터 복호화 | 암호화(인코딩)된 String 데이터를 복호화(디코딩) 처리한다 |
+| String | `encryptPassword(String password, String id)` | 비밀번호 암호화 | 비밀번호를 복호화가 불가능한 단방향 해시로 암호화한다 (아이디를 salt로 사용) |
+| boolean | `checkPassword(String data, String encoded, byte[] salt)` | 비밀번호 검증 | 입력한 비밀번호가 암호화되어 저장된 비밀번호와 일치하는지 검증한다 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `source`: String 타입의 절대경로를 포함한 원본 파일명 (예: `/user/com/test/file1.txt`)
+- `target`: String 타입의 절대경로를 포함한 결과 파일명 (예: `/user/com/test/encodeFile1.txt`)
+- `data`: String 타입의 암호화/복호화 대상 데이터
+- `password`, `id`: String 타입의 비밀번호와 salt로 사용할 아이디
+
+#### 반환값 정의 (Output)
+
+- boolean 타입: 처리 성공 여부 (`true` / `false`)
+- String 타입: 암호화/복호화된 문자열
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovFileScrty;
+
+// 1. 파일 암호화
+String source = "/user/com/test/file1.txt";
+String target = "/user/com/test/encodeFile1.txt";
+boolean result1 = EgovFileScrty.encryptFile(source, target);
+
+// 2. 파일 복호화
+String decTarget = "/user/com/test/decodeFile1.txt";
+boolean result2 = EgovFileScrty.decryptFile(target, decTarget);
+
+// 3. 비밀번호 암호화
+String encrypted = EgovFileScrty.encryptPassword("password1!", "userId");
+```
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/file-send-receive.md
+++ b/common-component/elementary-technology/file-send-receive.md
@@ -9,3 +9,86 @@ menu:
     weight: 35
     parent: "system"
 ---
+
+## 개요
+
+FTP 프로토콜을 사용하여 파일을 송수신하는 기능을 제공한다. 서버(Server) 간 파일 송수신 및 서버(Server)와
+클라이언트(Client) 간 파일 송수신 시 사용할 수 있다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+파일송/수신에서 제공하는 기능은 다음과 같다.
+
+1. FTP 클라이언트(Client)에서 서버(Server)로 파일을 전송하는 기능
+2. FTP 서버(Server)에서 로컬로 파일을 전송받는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovFtpTool.java` | 파일송수신 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFtpTool.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+파일송/수신 기능은 `EgovFtpTool` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| boolean | `getFile(String ftp_ip, int ftp_port, String ftp_id, String ftp_pw, String remote)` | 파일수신 | FTP 서버로부터 파일을 다운로드한다 |
+| boolean | `getFile(String ftp_ip, int ftp_port, String ftp_id, String ftp_pw, int ftp_mode, String remote)` | 파일수신 | FTP 서버로부터 파일을 다운로드한다 (전송모드 지정) |
+| boolean | `getFile(String ftp_ip, int ftp_port, String ftp_id, String ftp_pw, int ftp_mode, String remote, String local)` | 파일수신 | FTP 서버로부터 파일을 지정한 로컬 경로로 다운로드한다 |
+| byte[] | `getFileAsByte(String ftp_ip, int ftp_port, String ftp_id, String ftp_pw, int ftp_mode, String remote, String local)` | 파일읽기 | FTP 서버로부터 파일을 읽어 byte[]로 반환한다 |
+| boolean | `sendFile(String ftp_ip, int ftp_port, String ftp_id, String ftp_pw, String local)` | 파일송신 | FTP 서버로 파일을 업로드한다 |
+| boolean | `sendFile(String ftp_ip, int ftp_port, String ftp_id, String ftp_pw, int ftp_mode, String local)` | 파일송신 | FTP 서버로 파일을 업로드한다 (전송모드 지정) |
+| boolean | `sendFile(String ftp_ip, int ftp_port, String ftp_id, String ftp_pw, int ftp_mode, InputStream data, String remote)` | 파일쓰기 | FTP 서버로 데이터(InputStream)를 업로드한다 |
+| boolean | `connect(FTPClient ftpClient, String ftp_ip, int ftp_port, String ftp_id, String ftp_pw, int ftp_mode)` | FTP연결 | FTP 클라이언트를 연결한다 |
+| void | `disconnect(FTPClient ftpClient)` | FTP연결종료 | FTP 클라이언트 연결을 종료한다 |
+| boolean | `changeRemoteDrctry(FTPClient ftpClient, String remote_drctry)` | 디렉토리이동 | FTP 서버의 디렉토리로 이동한다 |
+| String[] | `splitPathAndName(String path, String fileSep)` | 파일명분리 | 파일명이 포함된 전체경로를 파일경로와 파일명으로 분리한다 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `ftp_ip`: String 타입의 FTP 접속 아이피 (예: `192.168.200.21`)
+- `ftp_port`: int 타입의 FTP 접속 포트 (예: `21`)
+- `ftp_id` / `ftp_pw`: String 타입의 FTP 접속 계정 정보
+- `ftp_mode`: int 타입의 FTP 전송모드
+- `remote`: String 타입의 절대경로를 포함한 원격 파일명 (예: `/user/com/test/file1.txt`)
+- `local`: String 타입의 절대경로를 포함한 로컬 파일명 (예: `/user/com/test/ftp/downFile1.txt`)
+
+#### 반환값 정의 (Output)
+
+- boolean 타입: 송수신 성공 여부 (`true` / `false`)
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovFtpTool;
+
+String ip = "192.168.200.21";
+int port = 21;
+String id = "com";
+String pw = "com01";
+int mode = 0;
+
+// 1. FTP 파일 수신
+String remote = "/user/com/test/file1.txt";
+String local = "/user/com/test/ftp/downFile1.txt";
+boolean result1 = EgovFtpTool.getFile(ip, port, id, pw, mode, remote, local);
+
+// 2. FTP 파일 송신
+boolean result2 = EgovFtpTool.sendFile(ip, port, id, pw, mode, local);
+```
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/file-sync.md
+++ b/common-component/elementary-technology/file-sync.md
@@ -9,3 +9,107 @@ menu:
     weight: 38
     parent: "system"
 ---
+
+<!-- markdownlint-disable MD013 -->
+
+## 개요
+
+파일동기화는 파일 저장 및 삭제에 대하여 여러 AP 서버에 동기화시키는 기능으로,
+AP 서버들 간 동기화를 통해 파일 첨부 및 다운로드 기능을 제공한다.
+
+## 설명
+
+파일동기화는 파일 저장 및 삭제에 대하여 여러 AP 서버에 동기화시키기 위한 목적으로
+동기화대상 서버정보의 등록, 수정, 삭제, 조회, 목록조회 기능 및 파일 동기화 처리 기능을 수반한다.
+
+1. **동기화대상서버목록조회**: 동기화대상 서버정보를 최근 등록 순서대로 조회하고, 그 결과를 화면에 반영한다.
+2. **동기화대상서버등록**: 동기화대상 서버정보를 등록하고, 등록한 결과를 조회한다.
+3. **동기화대상서버수정**: 기 등록된 동기화대상 서버정보를 수정한다.
+4. **동기화대상서버삭제**: 기 등록된 동기화대상 서버정보를 삭제한다.
+5. **동기화대상서버상세조회**: 동기화대상 서버목록에서 선택한 서버의 상세정보를 보여준다.
+6. **동기화대상파일등록**: 동기화대상 파일을 등록한다.
+7. **동기화대상파일삭제**: 동기화대상 파일을 삭제한다.
+8. **파일동기화처리**: 업로드 파일들에 대하여 동기화 처리를 수행한다.
+
+### 관련소스
+
+| 유형 | 대상소스명 | 비고 |
+| --- | --- | --- |
+| Controller | `egovframework.com.utl.sys.ssy.web.EgovSynchrnServerController.java` | 동기화대상 서버관리를 위한 컨트롤러 클래스 |
+| Service | `egovframework.com.utl.sys.ssy.service.EgovSynchrnServerService.java` | 동기화대상 서버관리를 위한 서비스 인터페이스 |
+| ServiceImpl | `egovframework.com.utl.sys.ssy.service.impl.EgovSynchrnServerServiceImpl.java` | 동기화대상 서버관리를 위한 서비스 구현 클래스 |
+| DAO | `egovframework.com.utl.sys.ssy.service.impl.SynchrnServerDAO.java` | 동기화대상 서버관리를 위한 데이터처리 클래스 |
+| Model | `egovframework.com.utl.sys.ssy.service.SynchrnServer.java` | 동기화대상 서버관리를 위한 Model 클래스 |
+| VO | `egovframework.com.utl.sys.ssy.service.SynchrnServerVO.java` | 동기화대상 서버관리를 위한 VO 클래스 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/ssy/EgovSynchrnServerList.jsp` | 동기화대상서버 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/ssy/EgovSynchrnServerDetail.jsp` | 동기화대상서버 상세조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/ssy/EgovSynchrnServerRegist.jsp` | 동기화대상서버 등록 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/ssy/EgovSynchrnServerUpdt.jsp` | 동기화대상서버 수정 페이지 |
+| XML | `/egovframework/sqlmap/com/utl/sys/ssy/EgovSynchrnServer_SQL_*.xml` | 동기화대상서버정보 QUERY XML |
+
+### 관련테이블
+
+| 테이블명 | 테이블명(영문) | 비고 |
+| --- | --- | --- |
+| 동기화서버정보 | COMTNSYNCHRNSERVERINFO | 파일 동기화대상 AP서버 정보를 관리한다. |
+
+### 관련설정
+
+`globals.properties` 파일에 `Globals.SynchrnServerPath` 경로가 없을 경우 에러가 발생하므로, 반드시 해당 디렉토리를 생성해야 한다.
+
+```properties
+# 파일 동기화 컴포넌트에서 사용할 파일 업로드 경로
+# (경로 설정은 반드시 절대경로를 사용해야 하며, 경로 뒤에 /를 붙여 주어야 함)
+Globals.SynchrnServerPath = C:/egovframework/upload/Synch/
+```
+
+## 관련화면 및 수행매뉴얼
+
+### 동기화대상서버 목록조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 조회 | /utl/sys/ssy/selectSynchrnServerList.do | selectSynchrnServerList | synchrnServerDAO.selectSynchrnServerList |
+| 조회 | /utl/sys/ssy/selectSynchrnServerList.do | selectSynchrnServerList | synchrnServerDAO.selectSynchrnServerListTotCnt |
+
+동기화대상서버 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 검색조건은 서버명에 대해서 수행된다.
+
+### 동기화대상서버 등록
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 저장 | /utl/sys/ssy/addSynchrnServer.do | insertSynchrnServer | synchrnServerDAO.insertSynchrnServer |
+
+동기화대상서버의 속성정보를 입력한 뒤 등록한다. 서버ID는 등록 시 자동으로 부여된다.
+
+### 동기화대상서버 수정
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 저장 | /utl/sys/ssy/updtSynchrnServer.do | updateSynchrnServer | synchrnServerDAO.updateSynchrnServer |
+| 삭제 | /utl/sys/ssy/removeSynchrnServer.do | deleteSynchrnServer | synchrnServerDAO.deleteSynchrnServer |
+
+동기화대상서버의 속성정보를 변경한 후 저장하거나, 기 등록된 동기화대상서버를 삭제한다.
+
+### 동기화대상서버 상세조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 조회 | /utl/sys/ssy/getSynchrnServer.do | selectSynchrnServer | synchrnServerDAO.selectSynchrnServer |
+
+동기화대상서버의 속성정보를 조회한다. 동기화대상서버에 등록되어 있는 파일을
+동기화대상 컴포넌트가 설치된 서버로 다운로드하거나 삭제할 수 있다.
+
+### 동기화대상 처리
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 파일등록 | /utl/sys/ssy/uploadFile.do | uploadFile | |
+| 파일삭제 | /utl/sys/ssy/deleteFile.do | deleteFile | |
+| 동기화 | /utl/sys/ssy/processSynchrn.do | processSynchrn | synchrnServerDAO.processSynchrn |
+
+기 등록된 동기화대상서버를 대상으로 동기화 대상파일에 대하여 동기화 처리를 수행한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/file-system-monitoring.md
+++ b/common-component/elementary-technology/file-system-monitoring.md
@@ -9,3 +9,154 @@ menu:
     weight: 26
     parent: "system"
 ---
+
+<!-- markdownlint-disable MD013 -->
+
+## 개요
+
+파일시스템모니터링은 파일시스템 상태를 주기적으로 모니터링하는 기능을 제공한다.
+모니터링하고자 하는 파일시스템은 파일시스템대상목록으로 시스템에 등록되어 있어야 한다.
+등록한 임계치를 초과하는 경우 관리자 메일주소로 모니터링 정보를 발송한다.
+
+## 설명
+
+파일시스템모니터링을 등록하기 위한 목적으로 파일시스템모니터링의 등록, 수정, 삭제, 조회, 목록조회의 기능을 수반한다.
+
+1. **파일시스템모니터링목록조회**: 파일시스템모니터링으로 정의된 정보를 최근 등록 순서대로 조회하고, 그 결과 목록을 화면에 반영한다.
+2. **파일시스템모니터링등록**: 파일시스템모니터링정보를 등록하고, 등록 결과를 조회한다.
+3. **파일시스템모니터링수정**: 기 등록된 파일시스템모니터링정보의 항목들을 수정한다.
+4. **파일시스템모니터링삭제**: 기 등록된 파일시스템모니터링정보를 삭제한다.
+5. **파일시스템모니터링조회**: 등록된 파일시스템모니터링정보를 조회한다.
+6. **파일시스템모니터링로그목록조회**: 파일시스템모니터링로그로 정의된 정보를 최근 등록 순서대로 조회하고, 그 결과 목록을 화면에 반영한다.
+7. **파일시스템모니터링로그조회**: 등록된 파일시스템모니터링로그정보를 조회한다.
+
+### 관련소스
+
+| 유형 | 대상소스명 | 비고 |
+| --- | --- | --- |
+| Controller | `egovframework.com.utl.sys.fsm.web.EgovFileSysMntrngController.java` | 파일시스템모니터링을 위한 컨트롤러 클래스 |
+| Service | `egovframework.com.utl.sys.fsm.service.EgovFileSysMntrngService.java` | 파일시스템모니터링을 위한 서비스 인터페이스 |
+| ServiceImpl | `egovframework.com.utl.sys.fsm.service.impl.EgovFileSysMntrngServiceImpl.java` | 파일시스템모니터링을 위한 서비스 구현 클래스 |
+| DAO | `egovframework.com.utl.sys.fsm.service.impl.FileSysMntrngDAO.java` | 파일시스템모니터링을 위한 데이터처리 클래스 |
+| Model | `egovframework.com.utl.sys.fsm.service.FileSysMntrng.java` | 파일시스템모니터링을 위한 Model 클래스 |
+| Model | `egovframework.com.utl.sys.fsm.service.FileSysMntrngLog.java` | 파일시스템모니터링로그정보를 위한 Model 클래스 |
+| VO | `egovframework.com.utl.sys.fsm.service.FileSysMntrngVO.java` | 파일시스템모니터링을 위한 VO 클래스 |
+| VO | `egovframework.com.utl.sys.fsm.service.FileSysMntrngLogVO.java` | 파일시스템모니터링로그정보를 위한 VO 클래스 |
+| Scheduling | `egovframework.com.utl.sys.fsm.service.EgovFileSystemMntrngScheduling.java` | 파일시스템모니터링 스케줄링 클래스 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngList.jsp` | 파일시스템모니터링 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngRegist.jsp` | 파일시스템모니터링 등록 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngUpdt.jsp` | 파일시스템모니터링 수정 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngDetail.jsp` | 파일시스템모니터링 상세조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngLogList.jsp` | 파일시스템모니터링로그 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngLogDetail.jsp` | 파일시스템모니터링로그 상세조회 페이지 |
+| XML | `/egovframework/sqlmap/com/utl/sys/fsm/EgovFileSysMntrng_SQL_*.xml` | 파일시스템모니터링 QUERY XML |
+
+### 관련테이블
+
+| 테이블명 | 테이블명(영문) | 비고 |
+| --- | --- | --- |
+| 파일시스템모니터링 | COMTNFILESYSMNTRNG | 파일시스템모니터링정보를 관리하기 위한 속성정보를 정의하고, 관리한다. |
+| 파일시스템모니터링로그정보 | COMTNFILESYSMNTRNGLOGINFO | 파일시스템모니터링로그정보를 관리하기 위한 속성정보를 정의하고, 관리한다. |
+
+### ID Generation
+
+ID Generation Service를 활용하기 위해서 Sequence 저장테이블인 COMTECOPSEQ에 `FILESYS_MNTRNG` 항목과 `FILESYS_LOGID` 항목을 추가한다.
+
+```sql
+INSERT INTO COMTECOPSEQ VALUES('FILESYS_MNTRNG','0');
+INSERT INTO COMTECOPSEQ VALUES('FILESYS_LOGID','0');
+```
+
+### 스케줄러 등록
+
+파일시스템모니터링 스케줄러를 등록하기 위해서 `context-scheduling.xml` 파일에 다음과 같이 등록한다.
+`startDelay`는 서버 시작 후 몇 초 뒤에 시작할지를, `repeatInterval`은 몇 초에 한 번씩 실행될지를 설정한다(ms 단위).
+
+```xml
+<!-- 파일시스템모니터링 -->
+<bean id="fileSysMntrng"
+    class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+    <property name="targetObject" ref="egovFileSysMntrngScheduling" />
+    <property name="targetMethod" value="monitorFileSys" />
+    <property name="concurrent" value="false" />
+</bean>
+
+<!-- 파일시스템모니터링 트리거 -->
+<bean id="fileSysMntrngTrigger"
+    class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+    <property name="jobDetail" ref="fileSysMntrng" />
+    <!-- 시작하고 1분 후에 실행한다. (milisecond) -->
+    <property name="startDelay" value="60000" />
+    <!-- 매 10분마다 실행한다. (milisecond) -->
+    <property name="repeatInterval" value="600000" />
+</bean>
+
+<!-- 모니터링 스케줄러 -->
+<bean id="mntrngScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+    <property name="triggers">
+        <list>
+            <ref bean="fileSysMntrngTrigger" />
+        </list>
+    </property>
+</bean>
+```
+
+## 관련화면 및 수행매뉴얼
+
+### 파일시스템모니터링 목록조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 조회 | /utl/sys/fsm/selectFileSysMntrngList.do | selectFileSysMntrngList | FileSysMntrngDAO.selectFileSysMntrngList |
+| 조회 | /utl/sys/fsm/selectFileSysMntrngList.do | selectFileSysMntrngList | FileSysMntrngDAO.selectFileSysMntrngListCnt |
+
+파일시스템모니터링 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
+검색조건은 파일시스템명, 파일시스템관리명, 관리자명, 상태에 대해서 수행된다.
+
+### 파일시스템모니터링 등록
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 등록 | /utl/sys/fsm/addFileSysMntrng.do | insertFileSysMntrng | FileSysMntrngDAO.insertFileSysMntrng |
+
+파일시스템모니터링의 속성정보를 입력한 뒤 등록한다. **임계치** 필드는 등록한 파일시스템의 크기에서 위험을 알리는 경계 수치로,
+임계치를 초과할 경우 관리자 메일주소로 모니터링 정보를 보낸다.
+
+### 파일시스템모니터링 수정
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 수정 | /utl/sys/fsm/modifyFileSysMntrng.do | updateFileSysMntrng | FileSysMntrngDAO.updateFileSysMntrng |
+
+파일시스템모니터링의 속성정보를 변경한 후 저장한다.
+
+### 파일시스템모니터링 상세조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 상세조회 | /utl/sys/fsm/selectFileSysMntrng.do | selectFileSysMntrng | FileSysMntrngDAO.selectFileSysMntrng |
+| 삭제 | /utl/sys/fsm/deleteFileSysMntrng.do | deleteFileSysMntrng | FileSysMntrngDAO.deleteFileSysMntrng |
+
+파일시스템모니터링의 속성정보를 조회하며, 수정 화면으로 이동하거나 등록된 정보를 삭제할 수 있다.
+
+### 파일시스템모니터링로그 목록조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 조회 | /utl/sys/fsm/selectFileSysMntrngLogList.do | selectFileSysMntrngLogList | FileSysMntrngDAO.selectFileSysMntrngLogList |
+| 조회 | /utl/sys/fsm/selectFileSysMntrngLogList.do | selectFileSysMntrngLogList | FileSysMntrngDAO.selectFileSysMntrngLogListCnt |
+
+파일시스템모니터링로그 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
+검색조건은 파일시스템명, 파일시스템관리명, 관리자명, 상태, 모니터링시각에 대해서 수행된다.
+
+### 파일시스템모니터링로그 상세조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 상세조회 | /utl/sys/fsm/selectFileSysMntrngLog.do | selectFileSysMntrngLog | FileSysMntrngDAO.selectFileSysMntrngLog |
+
+파일시스템모니터링로그의 속성정보를 조회한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/file-upload.md
+++ b/common-component/elementary-technology/file-upload.md
@@ -9,3 +9,86 @@ menu:
     weight: 40
     parent: "system"
 ---
+
+## 개요
+
+첨부파일에 대한 업로드 기능을 제공한다. `MultipartHttpServletRequest` 및 `MultipartFile`을 통해 첨부된 파일 정보를
+취득하고 서버에 저장하는 기능을 처리한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+파일업로드에서 제공하는 기능은 다음과 같다.
+
+1. 첨부로 등록된 파일을 서버에 업로드하는 기능
+2. 첨부로 등록된 파일에 대한 정보를 취득하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.cmm.service.EgovFileMngUtil.java` | 첨부파일 처리 공통 유틸리티 | |
+| Controller | `egovframework.com.utl.fcc.web.EgovFileUploadController.java` | 테스트용 Controller | |
+| JSP | `/WEB-INF/jsp/egovframework/cmm/utl/EgovFileUpload.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+파일업로드 기능은 `EgovFileMngUtil` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| HashMap | `uploadFile(MultipartFile file)` | 파일 업로드 | 첨부로 등록된 파일을 서버에 업로드한다 |
+| List | `parseFileInf(Map<String, MultipartFile> files, String key, int fileKeyParam, String atchFileId, String storePath)` | 첨부파일 정보취득 | 첨부로 등록된 파일에 대한 정보(FileVO 목록)를 얻는다 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `file`: `MultipartHttpServletRequest` 객체로부터 얻어진 `MultipartFile` 객체 (null이 아닌 유효 객체)
+- `files`: 첨부파일 Map, `key`: 파일 구분 키, `atchFileId`: 첨부파일 ID, `storePath`: 저장 경로
+
+#### 반환값 정의 (Output)
+
+- HashMap 타입: 업로드된 파일 정보 (파일경로, 사이즈, 원본파일명, 업로드파일명, 확장자)
+- List 타입: `FileVO` 객체 리스트
+
+### 사용 방법
+
+```java
+import java.util.HashMap;
+import java.util.Iterator;
+
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import egovframework.com.cmm.service.EgovFileMngUtil;
+
+MultipartHttpServletRequest mptRequest = (MultipartHttpServletRequest) request;
+
+Iterator<String> fileIter = mptRequest.getFileNames();
+
+while (fileIter.hasNext()) {
+    MultipartFile mFile = mptRequest.getFile(fileIter.next());
+
+    if (mFile.getSize() > 0) {
+        HashMap<String, String> map = EgovFileMngUtil.uploadFile(mFile);
+        // map에서 파일경로, 사이즈, 원본파일명, 업로드파일명, 확장자 정보를 취득
+    }
+}
+```
+
+## 환경설정
+
+파일 저장 위치를 지정하기 위해서 `EgovPropertyService` 서비스를 사용한다.
+`globals.properties` 파일의 `Globals.fileStorePath` 속성에 파일 저장 경로를 정의한다.
+
+```properties
+Globals.fileStorePath = C:/egovframework/upload/
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)
+- 파일다운로드 문서 참조: [파일다운로드](../file-download/)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 기존 문서 보완 (docs/update)

## 변경 내용 (Description)

요소기술 카테고리의 빈 문서(파일·디렉토리 계열) 11건에 내용을 작성했습니다. #690(문자열 처리)·#695(날짜·숫자·랜덤)와 같은 계열의 작업으로, 표준프레임워크 위키 원문과 공통컴포넌트 소스(Javadoc)를 근거로 각 문서의 기능 설명·관련 소스·메소드 표·사용 예를 구성했습니다.

| 문서 | 근거 클래스 |
| --- | --- |
| `file-exist-check.md` (파일존재체크) | EgovFileTool.checkFileExstByName/Extnt/Owner/UpdtPd/Size |
| `file-move.md` (파일이동) | EgovFileTool.moveFile |
| `file-parsing.md` (파일파싱) | EgovFileTool.parsFileByChar·parsFileBySize |
| `file-permission-check.md` (파일권한체크) | EgovFileTool.canRead·canWrite |
| `directory-permission-check.md` (디렉토리권한체크) | EgovFileTool.canRead·canWrite |
| `directory-move.md` (디렉토리이동) | EgovFileTool.moveFile (3종 오버로드) |
| `file-security.md` (파일보안) | EgovFileScrty.encryptFile·decryptFile·encode·decode·encryptPassword·checkPassword |
| `file-send-receive.md` (파일송/수신) | EgovFtpTool (FTP 송수신) |
| `file-upload.md` (파일업로드) | EgovFileMngUtil.uploadFile·parseFileInf |
| `file-sync.md` (파일동기화) | utl.sys.ssy (EgovSynchrnServerService 등) |
| `file-system-monitoring.md` (파일시스템모니터링) | utl.sys.fsm (EgovFileSysMntrngService 등) |

참고: 권한체크 2건의 메소드명은 위키 원문(checkReadAuth/checkWriteAuth)이 아닌 실제 소스에 존재하는 `canRead`/`canWrite`(EgovFileTool) 기준으로 작성했습니다. 유틸리티형 9건은 기존 병합 문서(파일복사·디렉토리존재체크 등)와 동일한 구성(개요/기능 설명/관련 소스/메소드 표/사용 방법)을, 관리형 2건(동기화·모니터링)은 송수신모니터링 문서와 동일한 구성(관련소스/관련테이블/스케줄러 설정/관련화면)을 따랐습니다. 기존 frontmatter는 그대로 유지했습니다.

## 관련 이슈 (Related Issues)

없음 (#672~#695와 같은 계열의 빈 문서 보완입니다)

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다. (포크를 upstream main과 동기화 후 작업)
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다. (기존 frontmatter 그대로 유지)
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.