### PR TITLE
docs: 시스템 점검 계열 요소기술 문서 10건 내용 작성

### DIFF
--- a/common-component/elementary-technology/http-service-monitoring.md
+++ b/common-component/elementary-technology/http-service-monitoring.md
@@ -9,3 +9,139 @@ menu:
     weight: 51
     parent: "system"
 ---
+
+<!-- markdownlint-disable MD013 -->
+
+## 개요
+
+HTTP서비스모니터링은 웹 서비스(웹서버 및 WAS)가 정상적인지 주기적인 점검을 수행하고, 문제 발생 시 해당 정보를 관리자에게 통보하는 기능을 제공한다.
+
+## 설명
+
+HTTP서비스모니터링을 등록하기 위한 목적으로 HTTP서비스모니터링의 등록, 수정, 삭제, 조회, 목록조회의 기능을 수반한다.
+
+1. **HTTP서비스모니터링목록조회**: HTTP서비스모니터링으로 정의된 정보를 최근 등록 순서대로 조회하고, 그 결과 목록을 화면에 반영한다.
+2. **HTTP서비스모니터링등록**: HTTP서비스모니터링정보를 등록하고, 등록 결과를 조회한다.
+3. **HTTP서비스모니터링수정**: 기 등록된 HTTP서비스모니터링정보의 항목들을 수정한다.
+4. **HTTP서비스모니터링삭제**: 기 등록된 HTTP서비스모니터링정보를 삭제한다.
+5. **HTTP서비스모니터링조회**: 등록된 HTTP서비스모니터링정보를 조회한다.
+6. **HTTP서비스모니터링로그목록조회**: HTTP서비스모니터링로그로 정의된 정보를 최근 등록 순서대로 조회하고, 그 결과 목록을 화면에 반영한다.
+7. **HTTP서비스모니터링로그조회**: 등록된 HTTP서비스모니터링로그정보를 조회한다.
+
+### 관련소스
+
+| 유형 | 대상소스명 | 비고 |
+| --- | --- | --- |
+| Controller | `egovframework.com.utl.sys.htm.web.EgovHttpMonController.java` | HTTP서비스모니터링을 위한 컨트롤러 클래스 |
+| Service | `egovframework.com.utl.sys.htm.service.EgovHttpMonService.java` | HTTP서비스모니터링을 위한 서비스 인터페이스 |
+| ServiceImpl | `egovframework.com.utl.sys.htm.service.impl.EgovHttpMonServiceImpl.java` | HTTP서비스모니터링을 위한 서비스 구현 클래스 |
+| DAO | `egovframework.com.utl.sys.htm.service.impl.HttpMonDAO.java` | HTTP서비스모니터링을 위한 데이터처리 클래스 |
+| Model | `egovframework.com.utl.sys.htm.service.HttpMon.java` | HTTP서비스모니터링을 위한 Model 클래스 |
+| Model | `egovframework.com.utl.sys.htm.service.HttpMonLog.java` | HTTP서비스모니터링로그정보를 위한 Model 클래스 |
+| Scheduling | `egovframework.com.utl.sys.htm.service.HttpMntrngScheduling.java` | HTTP서비스모니터링 스케줄링 클래스 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonList.jsp` | HTTP서비스모니터링 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonRegist.jsp` | HTTP서비스모니터링 등록 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonUpdt.jsp` | HTTP서비스모니터링 수정 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonDetail.jsp` | HTTP서비스모니터링 상세조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonLogList.jsp` | HTTP서비스모니터링로그 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonLogDetail.jsp` | HTTP서비스모니터링로그 상세조회 페이지 |
+| XML | `/egovframework/sqlmap/com/utl/sys/htm/EgovHttpMon_SQL_*.xml` | HTTP서비스모니터링 QUERY XML |
+
+### 관련테이블
+
+| 테이블명 | 테이블명(영문) | 비고 |
+| --- | --- | --- |
+| HTTP서비스모니터링 | COMTNHTTPMON | HTTP서비스모니터링정보를 관리하기 위한 속성정보를 정의하고, 관리한다. |
+| HTTP서비스모니터링로그정보 | COMTHHTTPMONLOGINFO | HTTP서비스모니터링로그정보를 관리하기 위한 속성정보를 정의하고, 관리한다. |
+
+### ID Generation
+
+ID Generation Service를 활용하기 위해서 Sequence 저장테이블인 COMTECOPSEQ에 `HTTP_ID`·`HTTL_ID` 항목을 추가한다.
+
+```sql
+INSERT INTO COMTECOPSEQ VALUES('HTTP_ID','0');
+INSERT INTO COMTECOPSEQ VALUES('HTTL_ID','0');
+```
+
+### 스케줄러 등록
+
+HTTP서비스모니터링 스케줄러를 `context-scheduling.xml`에 등록한다. `startDelay`는 서버 시작 후 시작 시점,
+`repeatInterval`은 실행 주기를 설정한다(ms 단위).
+
+```xml
+<!-- HTTP서비스모니터링 -->
+<bean id="httpMon"
+    class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+    <property name="targetObject" ref="httpMntrngScheduling" />
+    <property name="targetMethod" value="monitorHttp" />
+    <property name="concurrent" value="false" />
+</bean>
+
+<!-- HTTP서비스모니터링 트리거 -->
+<bean id="httpMntrngTrigger"
+    class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+    <property name="jobDetail" ref="httpMon" />
+    <!-- 시작하고 1분 후에 실행한다. (milisecond) -->
+    <property name="startDelay" value="60000" />
+    <!-- 매 10분마다 실행한다. (milisecond) -->
+    <property name="repeatInterval" value="600000" />
+</bean>
+
+<!-- 모니터링 스케줄러 -->
+<bean id="mntrngScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+    <property name="triggers">
+        <list>
+            <ref bean="httpMntrngTrigger" />
+        </list>
+    </property>
+</bean>
+```
+
+## 관련화면 및 수행매뉴얼
+
+### HTTP서비스모니터링 목록조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 조회 | /utl/sys/htm/selectHttpMonList.do | selectHttpMonList | HttpMonDAO.selectHttpMonList |
+| 조회 | /utl/sys/htm/selectHttpMonList.do | selectHttpMonList | HttpMonDAO.selectHttpMonListCnt |
+
+목록은 페이지당 10건씩 조회되며 검색조건은 상태·관리자명에 대해 수행된다. 상태가 비정상일 때 관리자에게 이메일을 발송한다.
+
+### HTTP서비스모니터링 등록
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 등록 | /utl/sys/htm/addHttpMon.do | insertHttpMon | HttpMonDAO.insertHttpMon |
+
+### HTTP서비스모니터링 수정
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 수정 | /utl/sys/htm/updateHttpMon | updateHttpMon | HttpMonDAO.updateHttpMon |
+
+### HTTP서비스모니터링 상세조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 상세조회 | /utl/sys/htm/getHttpMon.do | selectHttpMon | HttpMonDAO.selectHttpMon |
+| 삭제 | /utl/sys/htm/deleteHttpMon.do | deleteHttpMon | HttpMonDAO.deleteHttpMon |
+
+### HTTP서비스모니터링로그 목록조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 조회 | /utl/sys/htm/selectHttpMonLogList.do | selectHttpMonLogList | HttpMonDAO.selectHttpMonLogList |
+| 조회 | /utl/sys/htm/selectHttpMonLogList.do | selectHttpMonLogList | HttpMonDAO.selectHttpMonLogListCnt |
+
+검색조건은 상태·관리자명·모니터링시각에 대해 수행된다.
+
+### HTTP서비스모니터링로그 상세조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 상세조회 | /utl/sys/htm/getHttpMonLog.do | selectHttpMonLog | HttpMonDAO.selectHttpMonLog |
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/log-pattern-check.md
+++ b/common-component/elementary-technology/log-pattern-check.md
@@ -9,3 +9,45 @@ menu:
     weight: 13
     parent: "system"
 ---
+
+<!-- markdownlint-disable MD013 -->
+
+## 개요
+
+로그패턴검사(로그패턴분석)는 로그파일을 분석하여 특정 문자열 등 패턴과 일치하는 내용을 추출하는 기능을 제공한다.
+
+## 설명
+
+찾을로그(패턴)명, 로그파일경로명(서버), 인코딩형식 정보를 입력·선택하여 로그 정보를 검색·분석하고, 결과를 텍스트 파일로 다운로드할 수 있다.
+
+서버 보안을 위해 관리자가 허가한 디렉토리만 분석할 수 있다. 기본 허용 디렉토리는 `C:\WindowsLog`, `/product/jeus2/logs/was2/`이며,
+필요시 `EgovLogPattrnAnals.jsp`의 허용 경로 배열을 수정한다.
+
+```java
+String[] arrPath = {"C:\\\\WindowsLog", "/product/jeus2/logs/was2/"};
+```
+
+### 관련소스
+
+| 유형 | 대상소스명 | 비고 |
+| --- | --- | --- |
+| JSP | `/WEB-INF/jsp/egovframework/cmm/utl/EgovLogPattrnAnals.jsp` | 로그패턴분석을 위한 jsp 페이지 |
+
+## 관련화면 및 수행매뉴얼
+
+### 로그패턴분석
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 로그패턴분석 | /EgovPageLink.do?link=cmm/utl/EgovLogPattrnAnals | moveToPage | |
+
+로그패턴을 분석하고 텍스트 파일로 다운로드할 수 있는 화면을 제공한다.
+
+- **찾을로그(패턴)명**: 정규표현식을 포함하여 입력할 수 있다.
+- **로그파일경로명(서버)**: 공통컴포넌트가 설치된 서버의 경로를 입력한다.
+- 검색: 로그패턴을 검색·분석한다.
+- 다운로드: 검색·분석된 로그패턴 정보를 다운로드한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/login-session-check.md
+++ b/common-component/elementary-technology/login-session-check.md
@@ -9,3 +9,43 @@ menu:
     weight: 39
     parent: "system"
 ---
+
+<!-- markdownlint-disable MD013 -->
+
+## 개요
+
+로그인세션정보체크는 로그인한 세션정보를 체크하여 정의한 페이지로 이동하게 하는 기능을 제공한다.
+
+## 설명
+
+로그인세션정보체크는 세션정보에 사용자 정의 페이지를 조회, 설정, 화면이동하는 기능을 수반한다.
+
+1. **로그인세션정보체크**: 세션정보에 사용자 정의 페이지를 설정하고, 화면이동을 한다.
+
+### 관련소스
+
+| 유형 | 대상소스명 | 비고 |
+| --- | --- | --- |
+| Controller | `egovframework.com.utl.sys.rsc.web.EgovLoginSesionController.java` | 로그인세션정보체크를 위한 컨트롤러 클래스 |
+| Util | `egovframework.com.utl.sys.rsc.service.EgovLoginSesionCeckUtil.java` | 로그인세션정보체크를 위한 Util 클래스 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/rsc/EgovLoginSesionCheck.jsp` | 로그인세션정보체크 페이지 |
+
+## 관련화면 및 수행매뉴얼
+
+### 로그인세션정보 체크
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 조회 | /utl/sys/rsc/loginSessionView.do | checkLoginSessionView | |
+| 설정 | /utl/sys/rsc/setLoginSession.do | setLoginSession | |
+
+로그인세션정보는 현재 세션URL을 조회하고, URL 항목에 세션으로 설정할 URL을 입력한 후 설정 버튼을 선택하여 세션에 등록한다.
+이동 버튼은 현재 설정된 세션URL로 새창을 띄워 해당 화면을 호출한다.
+
+- 조회: 현재 설정된 세션정보를 조회한다.
+- 설정: 세션정보에 새로운 URL을 설정한다.
+- 이동: 기 설정된 세션 URL로 화면을 이동한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/network-info-check.md
+++ b/common-component/elementary-technology/network-info-check.md
@@ -9,3 +9,75 @@ menu:
     weight: 2
     parent: "system"
 ---
+
+## 개요
+
+네트워크 정보인 IP ADDRESS, MAC ADDRESS, PortScan 리스트를 확인하는 기능을 제공한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+네트워크정보확인에서 제공하는 기능은 다음과 같다.
+
+1. 시스템의 IP ADDRESS를 가져오는 기능
+2. 시스템의 MAC ADDRESS를 가져오는 기능
+3. 시스템의 PortScan(포트 사용) 정보를 가져오는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovNetworkState.java` | 네트워크정보 확인 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovNetworkInfo.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+네트워크정보확인 기능은 `EgovNetworkState` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| String | `getMyIPaddress()` | IP ADDRESS 검색 | 시스템의 IP ADDRESS를 리턴 |
+| String | `getMyMACAddress(String ipAddress)` | MAC ADDRESS 검색 | 시스템의 MAC ADDRESS를 리턴 |
+| List | `getMyPortScan()` | Port 사용정보 | Port 사용내역을 리턴 |
+<!-- markdownlint-restore -->
+
+### 사용 방법
+
+```java
+import java.util.Iterator;
+import java.util.List;
+
+import egovframework.com.utl.sim.service.EgovNetworkState;
+
+// 1. IP 주소 조회
+String myIPAddress = EgovNetworkState.getMyIPaddress();
+
+// 2. MAC 주소 조회
+String myMACAddress = EgovNetworkState.getMyMACAddress(myIPAddress);
+
+// 3. Port 사용정보 조회
+List<String> list = EgovNetworkState.getMyPortScan();
+Iterator<String> it = list.iterator();
+while (it.hasNext()) {
+    String text = it.next();
+}
+```
+
+## 환경설정
+
+윈도우 환경은 `nbtstat -A <IP>`(MAC 주소)·`netstat -an`(포트 사용정보) 명령을 사용하며,
+유닉스 환경은 네트워크정보 조회 쉘 스크립트 경로를 프로퍼티에 등록하여 사용한다.
+
+```properties
+# 네트워크 정보 쉘 스크립트
+SHELL.UNIX.getNetWorkInfo = /product/jeus/egovProps/prg/getNetWorkInfo.sh
+```
+
+유닉스용 스크립트는 `netstat`·`prtconf`·`hostname`·`host` 명령 조합으로 MAC·IP·서브넷 마스크·게이트웨이·DNS·포트스캔 정보를 조회한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/network-status-check.md
+++ b/common-component/elementary-technology/network-status-check.md
@@ -9,3 +9,60 @@ menu:
     weight: 1
     parent: "system"
 ---
+
+## 개요
+
+Ping Test를 통해 네트워크 통신가능 여부를 확인하는 기능을 제공한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+네트워크상태체크에서 제공하는 기능은 다음과 같다.
+
+1. 네트워크 사용가능 상태 여부를 확인하는 기능 (`true` / `false`)
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovNetworkState.java` | 네트워크 상태 체크 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovNetworkState.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+네트워크상태체크 기능은 `EgovNetworkState` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| boolean | `getPingTest(String source)` | 네트워크 상태체크 | Ping Test를 통해 통신 가능 여부(`true`/`false`)를 리턴 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `source`: String 타입의 IP 주소 (예: `192.168.100.21`)
+
+#### 반환값 정의 (Output)
+
+- boolean 타입: 통신 가능 여부 (`true` / `false`)
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovNetworkState;
+
+// 네트워크 상태 체크 (Ping Test)
+boolean status = EgovNetworkState.getPingTest("192.168.100.21");
+```
+
+내부적으로 `InetAddress.getByName(ip).isReachable(timeout)` 방식으로 도달 가능 여부를 확인한다.
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/process-id-check.md
+++ b/common-component/elementary-technology/process-id-check.md
@@ -9,3 +9,80 @@ menu:
     weight: 45
     parent: "system"
 ---
+
+## 개요
+
+시스템에서 동작하는 프로세스에 대한 정보를 확인하는 기능을 제공한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+프로세스ID확인에서 제공하는 기능은 다음과 같다.
+
+1. 전체 프로세스 아이디 정보를 확인하는 기능
+2. 특정 프로세스명에 해당하는 아이디 정보를 확인하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovSysInfo.java` | 시스템 정보 확인 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovProcsInfo.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+프로세스ID확인 기능은 `EgovSysInfo` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| ArrayList | `getProcessId()` | 프로세스아이디 정보 조회 | 전체 프로세스의 아이디·그룹정보·사용계정정보·실행명령·실행명령위치 정보를 문자열로 LIST에 담아 리턴 |
+| ArrayList | `getProcessId(String processName)` | 프로세스아이디 정보 조회 (프로세스명 조건) | `processName`에 해당하는 프로세스의 아이디·그룹정보·사용계정정보·실행명령·실행명령위치 정보를 LIST에 담아 리턴 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `processName`: String 타입의 프로세스명 (예: `java`)
+
+#### 반환값 정의 (Output)
+
+- ArrayList 타입: 프로세스정보 목록 (예: `{"javaw", "user", "jeus", "java", "/usr/java5_64/bin/java"}`)
+
+### 사용 방법
+
+```java
+import java.util.ArrayList;
+
+import egovframework.com.utl.sim.service.EgovSysInfo;
+
+// 프로세스아이디, 그룹정보, 사용계정정보, 실행명령, 실행명령위치 항목이 순차적으로 등록됨
+ArrayList result1 = EgovSysInfo.getProcessId();
+
+String strProcessName = "oracle";
+ArrayList result2 = EgovSysInfo.getProcessId(strProcessName);
+```
+
+## 환경설정
+
+`getProcessId` 메소드는 쉘 스크립트 실행 결과를 활용하여 정보를 확인하며, 스크립트 경로를 `globals.properties`에 등록한다.
+
+```properties
+# getProcInfo 메소드에 해당되는 쉘 스크립트
+SHELL.UNIX.getProcInfo = /product/jeus/egovProps/prg/getProcInfo.sh
+```
+
+```shell
+# getProcInfo.sh (유닉스용 프로세스정보 조회 스크립트)
+if [ $1 == "-all" ]
+then
+    ps -eo "%p %G %U %c %a" | awk -F" " '{print $1,$2,$3,$4,$5}'
+else
+    ps -eo "%p %G %U %c %a" | awk -F" " '{print $1,$2,$3,$4,$5}' | grep $1
+fi
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/process-monitoring.md
+++ b/common-component/elementary-technology/process-monitoring.md
@@ -9,3 +9,151 @@ menu:
     weight: 24
     parent: "system"
 ---
+
+<!-- markdownlint-disable MD013 -->
+
+## 개요
+
+프로세스모니터링은 특정 프로세스가 기동 중인지 주기적으로 점검을 수행하고, 문제 발생 시 해당 정보를 관리자에게 통보하는 기능을 제공한다.
+WINDOWS 및 UNIX 환경을 모두 지원하며, `globals.properties`의 `Globals.OsType`으로 운영체제를 설정한다.
+
+## 설명
+
+프로세스모니터링을 등록하기 위한 목적으로 프로세스모니터링의 등록, 수정, 삭제, 조회, 목록조회의 기능을 수반한다.
+
+1. **프로세스모니터링목록조회**: 프로세스모니터링으로 정의된 정보를 최근 등록 순서대로 조회하고, 그 결과 목록을 화면에 반영한다.
+2. **프로세스모니터링등록**: 프로세스모니터링정보를 등록하고, 등록 결과를 조회한다.
+3. **프로세스모니터링수정**: 기 등록된 프로세스모니터링정보의 항목들을 수정한다.
+4. **프로세스모니터링삭제**: 기 등록된 프로세스모니터링정보를 삭제한다.
+5. **프로세스모니터링조회**: 등록된 프로세스모니터링정보를 조회한다.
+6. **프로세스모니터링로그목록조회**: 프로세스모니터링로그로 정의된 정보를 최근 등록 순서대로 조회하고, 그 결과 목록을 화면에 반영한다.
+7. **프로세스모니터링로그조회**: 등록된 프로세스모니터링로그정보를 조회한다.
+
+### 관련소스
+
+| 유형 | 대상소스명 | 비고 |
+| --- | --- | --- |
+| Controller | `egovframework.com.utl.sys.prm.web.EgovProcessMonController.java` | 프로세스모니터링을 위한 컨트롤러 클래스 |
+| Service | `egovframework.com.utl.sys.prm.service.EgovProcessMonService.java` | 프로세스모니터링을 위한 서비스 인터페이스 |
+| ServiceImpl | `egovframework.com.utl.sys.prm.service.impl.EgovProcessMonServiceImpl.java` | 프로세스모니터링을 위한 서비스 구현 클래스 |
+| DAO | `egovframework.com.utl.sys.prm.service.impl.ProcessMonDAO.java` | 프로세스모니터링을 위한 데이터처리 클래스 |
+| Model | `egovframework.com.utl.sys.prm.service.ProcessMon.java` | 프로세스모니터링을 위한 Model 클래스 |
+| Model | `egovframework.com.utl.sys.prm.service.ProcessMonLog.java` | 프로세스모니터링로그정보를 위한 Model 클래스 |
+| Scheduling | `egovframework.com.utl.sys.prm.service.EgovProcessMonScheduling.java` | 프로세스모니터링 스케줄링 클래스 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonList.jsp` | 프로세스모니터링 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonRegist.jsp` | 프로세스모니터링 등록 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonUpdt.jsp` | 프로세스모니터링 수정 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonDetail.jsp` | 프로세스모니터링 상세조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonLogList.jsp` | 프로세스모니터링로그 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonLogDetail.jsp` | 프로세스모니터링로그 상세조회 페이지 |
+| XML | `/egovframework/sqlmap/com/utl/sys/prm/EgovProcessMon_SQL_*.xml` | 프로세스모니터링 QUERY XML |
+
+### 관련테이블
+
+| 테이블명 | 테이블명(영문) | 비고 |
+| --- | --- | --- |
+| 프로세스모니터링 | COMTNPROCESSMON | 프로세스모니터링정보를 관리하기 위한 속성정보를 정의하고, 관리한다. |
+| 프로세스모니터링로그정보 | COMTNPROCESSMONLOGINFO | 프로세스모니터링로그정보를 관리하기 위한 속성정보를 정의하고, 관리한다. |
+
+### ID Generation
+
+ID Generation Service를 활용하기 위해서 Sequence 저장테이블인 COMTECOPSEQ에 `PROC_ID`·`PROL_ID` 항목을 추가한다.
+
+```sql
+INSERT INTO COMTECOPSEQ VALUES('PROC_ID','0');
+INSERT INTO COMTECOPSEQ VALUES('PROL_ID','0');
+```
+
+### 프로퍼티 설정
+
+운영체제 유형을 `globals.properties`에 설정한다.
+
+```properties
+# UNIX인 경우
+Globals.OsType = UNIX
+# WINDOWS인 경우
+# Globals.OsType = WINDOWS
+```
+
+### 스케줄러 등록
+
+프로세스모니터링 스케줄러를 `context-scheduling.xml`에 등록한다. `startDelay`는 서버 시작 후 시작 시점,
+`repeatInterval`은 실행 주기를 설정한다(ms 단위).
+
+```xml
+<!-- 프로세스모니터링 -->
+<bean id="processMntrng"
+    class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+    <property name="targetObject" ref="egovProcessMonScheduling" />
+    <property name="targetMethod" value="monitorProcess" />
+    <property name="concurrent" value="false" />
+</bean>
+
+<!-- 프로세스모니터링 트리거 -->
+<bean id="processMntrngTrigger"
+    class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+    <property name="jobDetail" ref="processMntrng" />
+    <property name="startDelay" value="60000" />
+    <property name="repeatInterval" value="600000" />
+</bean>
+
+<!-- 모니터링 스케줄러 -->
+<bean id="mntrngScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+    <property name="triggers">
+        <list>
+            <ref bean="processMntrngTrigger" />
+        </list>
+    </property>
+</bean>
+```
+
+## 관련화면 및 수행매뉴얼
+
+### 프로세스모니터링 목록조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 조회 | /utl/sys/prm/selectProcessMonList.do | selectProcessMonList | ProcessMonDAO.selectProcessMonList |
+| 조회 | /utl/sys/prm/selectProcessMonList.do | selectProcessMonList | ProcessMonDAO.selectProcessMonListCnt |
+
+목록은 페이지당 10건씩 조회되며 검색조건은 상태·관리자명에 대해 수행된다. 상태가 비정상일 때 관리자에게 이메일을 발송한다.
+
+### 프로세스모니터링 등록
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 등록 | /utl/sys/prm/addProcessMon.do | insertProcessMon | ProcessMonDAO.insertProcessMon |
+
+프로세스모니터링의 속성정보를 입력한 뒤 등록한다. 프로세스명은 공통컴포넌트가 설치된 서버의 프로세스명을 의미한다.
+
+### 프로세스모니터링 수정
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 수정 | /utl/sys/prm/updateProcessMon | updateProcessMon | ProcessMonDAO.updateProcessMon |
+
+### 프로세스모니터링 상세조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 상세조회 | /utl/sys/prm/getProcessMon.do | selectProcessMon | ProcessMonDAO.selectProcessMon |
+| 삭제 | /utl/sys/prm/deleteProcessMon.do | deleteProcessMon | ProcessMonDAO.deleteProcessMon |
+
+### 프로세스모니터링로그 목록조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 조회 | /utl/sys/prm/selectProcessMonLogList.do | selectProcessMonLogList | ProcessMonDAO.selectProcessMonLogList |
+| 조회 | /utl/sys/prm/selectProcessMonLogList.do | selectProcessMonLogList | ProcessMonDAO.selectProcessMonLogListCnt |
+
+검색조건은 상태·관리자명·모니터링시각에 대해 수행된다.
+
+### 프로세스모니터링로그 상세조회
+
+| Action | URL | Controller method | QueryID |
+| --- | --- | --- | --- |
+| 상세조회 | /utl/sys/prm/getProcessMonLog.do | selectProcessMonLog | ProcessMonDAO.selectProcessMonLog |
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/server-info-check.md
+++ b/common-component/elementary-technology/server-info-check.md
@@ -9,3 +9,90 @@ menu:
     weight: 19
     parent: "system"
 ---
+
+## 개요
+
+시스템에 설치된 다양한 서버(웹서버, WAS서버, 메일서버)의 정보를 확인하는 기능을 제공한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+서버정보확인에서 제공하는 기능은 다음과 같다.
+
+1. 시스템에 설치된 서버(Server)의 제품명을 가져오는 기능
+2. 시스템에 설치된 서버(Server)의 버전을 가져오는 기능
+3. 시스템에 설치된 서버(Server)의 포트번호를 가져오는 기능
+4. 시스템에 설치된 서버(Server)의 실행상태를 가져오는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovSysInfo.java` | 시스템 정보 확인 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovSysInfo.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+서버정보확인 기능은 `EgovSysInfo` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| String | `getPrductVersion(String server)` | 제품명·버전 조회 | 서버명(`server`)으로 제품명과 제품버전을 리턴 |
+| String | `getPrductPort(String server)` | 포트 조회 | 서버명(`server`)으로 사용포트번호를 리턴 |
+| String | `getPrductStatus(String port)` | 실행상태 조회 | 사용포트번호(`port`)로 실행상태를 리턴 |
+<!-- markdownlint-restore -->
+
+#### 반환값 정의 (Output)
+
+- String 타입 서버명 (예: `WEBLOGIC`), 버전 (예: `9.2 MP3`), 사용포트 (예: `7001`), 실행상태 (예: `LISTENING`)
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovSysInfo;
+
+// 1. 서버 목록 조회
+String strlist = EgovProperties.getProperty(Globals.ServerConfPath, "SERVER_LIST");
+String[] list = strlist.split("\\$");
+
+for (int i = 0; i < list.length; i++) {
+    String name = list[i];                                   // 제품명
+    String version = EgovSysInfo.getPrductVersion(list[i]);  // 제품버전
+    String port = EgovSysInfo.getPrductPort(list[i]);        // 사용포트번호
+    String status = EgovSysInfo.getPrductStatus(port);       // 실행상태
+}
+```
+
+## 환경설정
+
+서버 목록·버전·포트 및 실행상태 조회 스크립트는 `server.properties`에 정의한다.
+
+```properties
+#1. 목록(구분자 $)
+SERVER_LIST = WEBLOGIC$JEUS$JBOSS
+#2. 버전
+WEBLOGIC.VERSION = 9.2 MP3
+JEUS.VERSION = 6.0
+JBOSS.VERSION = 3.1
+#3. 사용포트
+WEBLOGIC.PORT = 7001
+JEUS.PORT = 9736
+JBOSS.PORT = 8080
+#4. 실행상태 확인 쉘 스크립트
+SHELL.WINDOWS.getPrductStatus = C:/egovProps/prg/getPrductStatus.bat
+SHELL.UNIX.getPrductStatus = /product/jeus/egovProps/prg/getPrductStatus.sh
+```
+
+실행상태 조회 스크립트 예시는 다음과 같다.
+
+```shell
+# getPrductStatus.sh (유닉스용)
+netstat -na | grep -w "LISTEN" | grep -c $1
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/system-info-check.md
+++ b/common-component/elementary-technology/system-info-check.md
@@ -9,3 +9,101 @@ menu:
     weight: 20
     parent: "system"
 ---
+
+## 개요
+
+시스템 고유의 속성정보인 프로세서 ID, 호스트, 운영체제(OS), 메모리(Memory), 디스크(HDD) 정보를 확인하는 기능을 제공한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+시스템정보확인에서 제공하는 기능은 다음과 같다.
+
+1. 시스템의 프로세서(Processor) ID(CPU ID)를 가져오는 기능
+2. 시스템의 운영체제 정보를 가져오는 기능
+3. 시스템의 메모리 용량 정보를 가져오는 기능
+4. 시스템의 디스크 정보를 가져오는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovSysInfo.java` | 시스템정보 확인 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovSysInfo.jsp` | 테스트 페이지 | |
+
+> ※ 해당 파일은 보안상의 이유로 배포되지 않는다. 필요시 표준프레임워크 지원 이메일(egovframesupport@gmail.com)로 요청하면 관련 파일을 전달받을 수 있다.
+
+### 클래스 및 메소드 설명
+
+시스템정보확인 기능은 `EgovSysInfo` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| String | `getProcessorID()` | 프로세서ID 조회 | 시스템의 프로세서ID를 리턴 |
+| String | `getHostName()` | 호스트명 조회 | 시스템의 호스트명을 리턴 |
+| String | `getOSName()` | OS이름 조회 | 시스템의 OS 이름을 리턴 |
+| String | `getOSVersion()` | OS버전 조회 | 시스템의 OS 버전을 리턴 |
+| String | `getOSPrductor()` | OS제조사 조회 | 시스템의 OS 제조사를 리턴 |
+| float | `getMoryFullCpcty()` | 메모리 전체용량 조회 | 시스템의 메모리 전체용량 리턴 |
+| float | `getMoryUsedCpcty()` | 메모리 사용용량 조회 | 시스템의 메모리 사용용량 리턴 |
+| float | `getMoryFreeCpcty()` | 메모리 유효용량 조회 | 시스템의 메모리 유효용량 리턴 |
+| ArrayList | `getDiskName()` | 디스크 목록 조회 | 시스템의 디스크목록 리턴 |
+| float | `getDiskFullCpcty()` | 디스크 전체용량 조회 | 시스템의 디스크 전체용량 리턴 |
+| float | `getDiskUsedCpcty()` | 디스크 사용용량 조회 | 시스템의 디스크 사용용량 리턴 |
+| float | `getDiskFreeCpcty()` | 디스크 유효용량 조회 | 시스템의 디스크 유효용량 리턴 |
+<!-- markdownlint-restore -->
+
+#### 반환값 정의 (Output)
+
+- String 타입: 호스트명 (예: `WAS`), OS이름 (예: `AIX`), OS버전 (예: `5.3.0.0`), OS제조사 (예: `IBM,8204-E8A`), 프로세서ID (예: `0B0AA2`)
+- float 타입: 메모리·디스크 전체/사용/유효 용량 (MB 단위)
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovSysInfo;
+
+// 1. 호스트명, OS명, OS버전, OS제조사, 프로세서
+String hostname = EgovSysInfo.getHostName();
+String osname = EgovSysInfo.getOSName();
+String osversion = EgovSysInfo.getOSVersion();
+String osprductor = EgovSysInfo.getOSPrductor();
+String processor = EgovSysInfo.getProcessorID();
+
+// 2. 메모리 용량
+float moryFull = EgovSysInfo.getMoryFullCpcty();
+float moryUsed = EgovSysInfo.getMoryUsedCpcty();
+float moryFree = EgovSysInfo.getMoryFreeCpcty();
+
+// 3. 디스크 용량
+ArrayList list = EgovSysInfo.getDiskName();
+for (int i = 0; i < list.size(); i++) {
+    String diskName = (String) list.get(i);
+}
+```
+
+## 환경설정
+
+프로세서ID·OS·메모리·디스크 정보 조회는 OS별 쉘 스크립트 실행 결과를 활용하며, 스크립트 경로를 `server.properties`에 정의한다.
+
+```properties
+#1. 프로세서ID, OS정보 조회 쉘 스크립트
+SHELL.WINDOWS.getOSInfo = C:/egovProps/prg/getOSInfo.bat
+SHELL.UNIX.getOSInfo = /product/jeus/egovProps/prg/getOSInfo.sh
+#2. 메모리정보 조회 쉘 스크립트
+SHELL.WINDOWS.getMoryInfo = C:/egovProps/prg/getMoryInfo.bat
+SHELL.UNIX.getMoryInfo = /product/jeus/egovProps/prg/getMoryInfo.sh
+#3. 디스크정보 조회 쉘 스크립트
+SHELL.WINDOWS.getDiskInfo = C:/egovProps/prg/getDiskInfo.bat
+SHELL.UNIX.getDiskInfo = /product/jeus/egovProps/prg/getDiskInfo.sh
+```
+
+윈도우 환경은 `systeminfo` 명령을, 유닉스 환경은 `uname`·`oslevel`·`vmstat`·`lspv` 등의 명령 조합 스크립트를 사용한다.
+윈도우 환경에서는 디스크정보 조회를 지원하지 않는다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/valid-memory-check.md
+++ b/common-component/elementary-technology/valid-memory-check.md
@@ -9,3 +9,60 @@ menu:
     weight: 21
     parent: "system"
 ---
+
+## 개요
+
+시스템에서 사용 가능한 유효메모리를 체크하는 기능을 제공한다. 새로운 프로그램을 실행하기 전에 시스템의 유효 메모리를
+체크하여 프로그램 실행 여부를 판단할 때 활용할 수 있다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+유효메모리체크에서 제공하는 기능은 다음과 같다.
+
+1. 시스템에서 사용 가능한 유효메모리를 체크하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovSysInfo.java` | 시스템정보 확인 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovSysInfo.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+유효메모리체크 기능은 `EgovSysInfo` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| boolean | `checkMoryCpcty(long memory)` | 유효메모리체크 | 특정 프로그램을 실행시키기 위한 메모리용량이 충분한지 확인한다 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `memory`: long 타입의 사용할 메모리 사이즈 (MB 단위, 예: `300`)
+
+#### 반환값 정의 (Output)
+
+- boolean 타입: 유효메모리 충분 여부 (`true` / `false`)
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovSysInfo;
+
+// 프로그램 실행을 위한 유효 메모리 체크
+long memory = 300L;
+boolean result = EgovSysInfo.checkMoryCpcty(memory);
+```
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 기존 문서 보완 (docs/update)

## 변경 내용 (Description)

요소기술 카테고리의 빈 문서(시스템 점검·정보확인 계열) 10건에 내용을 작성했습니다. #690·#695·#696과 같은 계열의 작업으로, 표준프레임워크 위키 원문을 근거로 각 문서의 기능 설명·관련 소스·메소드 표·환경설정(쉘 스크립트·스케줄러)·사용 예를 구성했습니다.

| 문서 | 근거 |
| --- | --- |
| `server-info-check.md` (서버정보확인) | EgovSysInfo — 서버 제품명·버전·포트·실행상태, server.properties |
| `system-info-check.md` (시스템정보확인) | EgovSysInfo — 프로세서·OS·메모리·디스크 12개 메소드 (배포 제외 안내 포함) |
| `valid-memory-check.md` (유효메모리체크) | EgovSysInfo.checkMoryCpcty |
| `process-id-check.md` (프로세스ID확인) | EgovSysInfo.getProcessId (2종 오버로드), getProcInfo.sh |
| `network-info-check.md` (네트워크정보확인) | EgovNetworkState — IP·MAC·PortScan |
| `network-status-check.md` (네트워크상태체크) | EgovNetworkState.getPingTest |
| `process-monitoring.md` (프로세스모니터링) | utl.sys.prm — 관련테이블·ID Generation·Globals.OsType·스케줄러 설정 포함 |
| `http-service-monitoring.md` (HTTP서비스모니터링) | utl.sys.htm — 관련테이블·ID Generation·스케줄러 설정 포함 |
| `login-session-check.md` (로그인세션정보체크) | utl.sys.rsc — Controller/Util/JSP, Action URL 표 |
| `log-pattern-check.md` (로그패턴검사) | 위키 "로그패턴분석" 원문 — 허용 디렉토리 보안 설정 포함 |

유틸리티형 6건은 기존 병합 문서(#696 파일 계열 등)와 동일한 구성(개요/기능 설명/관련 소스/메소드 표/환경설정/사용 방법)을, 관리형 4건(모니터링 2·세션체크·로그패턴)은 송수신모니터링·파일시스템모니터링 문서와 동일한 구성을 따랐습니다. 기존 frontmatter는 그대로 유지했습니다.

이번 배치로 요소기술 카테고리 잔여 스텁은 8건(문자열·포맷 유효성, 프로퍼티, 공휴일관리, 메인/트리메뉴, XML 조립·파싱)입니다 — 다음 배치에서 마무리해 카테고리 정비를 완료할 예정입니다.

## 관련 이슈 (Related Issues)

없음 (#672~#696과 같은 계열의 빈 문서 보완입니다)

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다. (포크를 upstream main과 동기화 후 작업)
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다. (기존 frontmatter 그대로 유지)
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.