### PR TITLE
docs: 요소기술 잔여 스텁 8건 내용 작성 — 카테고리 빈 문서 정비 완료

### DIFF
--- a/common-component/elementary-technology/format-validation.md
+++ b/common-component/elementary-technology/format-validation.md
@@ -9,3 +9,54 @@ menu:
     weight: 18
     parent: "formatter-util"
 ---
+
+# 포맷유효성체크
+
+## 개요
+
+포맷유효성체크는 주어진 전화번호, 휴대폰번호, 이메일의 유효성을 체크하여 `true`/`false`를 반환하는 요소기술이다.
+각 입력마다 구분 입력(앞·중간·뒤 분리)과 하나의 문자열 입력 두 가지 방식을 지원한다.
+`EgovFormatCheckUtil` 유틸리티의 정적 메서드로 사용한다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovFormatCheckUtil.java | 포맷 유효성 체크 유틸리티 클래스 |
+| Controller | egovframework.com.utl.fcc.web.EgovFormatCheckUtilController.java | 테스트용 Controller |
+| JSP | /WEB-INF/jsp/egovframework/cmm/utl/EgovFormatCheck.jsp | 테스트 페이지 |
+
+## 주요 메서드
+
+<!-- markdownlint-disable MD013 -->
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `checkFormatTell(String tell1, String tell2, String tell3)` | `boolean` | 전화번호 앞·중간·뒤 문자열을 받아 유효한 전화번호인지 체크 |
+| `checkFormatTell(String tellNumber)` | `boolean` | `-`를 제외한 하나의 문자열을 받아 유효한 전화번호인지 체크 |
+| `checkFormatCell(String cell1, String cell2, String cell3)` | `boolean` | 휴대폰번호 앞·중간·뒤 문자열을 받아 유효한 휴대폰번호인지 체크 |
+| `checkFormatCell(String cellNumber)` | `boolean` | `-`를 제외한 하나의 문자열을 받아 유효한 휴대폰번호인지 체크 |
+| `checkFormatMail(String mail1, String mail2)` | `boolean` | 이메일의 앞·뒤 문자열을 받아 유효한 이메일인지 체크 |
+| `checkFormatMail(String mail)` | `boolean` | `@`를 포함한 하나의 문자열을 받아 유효한 이메일인지 체크 |
+<!-- markdownlint-restore -->
+
+## 사용 예
+
+```java
+import egovframework.com.utl.fcc.service.EgovFormatCheckUtil;
+
+// 전화번호 유효성 체크
+boolean tel1 = EgovFormatCheckUtil.checkFormatTell("070", "4448", "2678");
+boolean tel2 = EgovFormatCheckUtil.checkFormatTell("07044482678");
+
+// 휴대폰번호 유효성 체크
+boolean cell1 = EgovFormatCheckUtil.checkFormatCell("010", "1111", "1111");
+boolean cell2 = EgovFormatCheckUtil.checkFormatCell("01011111111");
+
+// 이메일 유효성 체크
+boolean mail1 = EgovFormatCheckUtil.checkFormatMail("example", "example.com");
+boolean mail2 = EgovFormatCheckUtil.checkFormatMail("example@example.com");
+```
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/holiday-management.md
+++ b/common-component/elementary-technology/holiday-management.md
@@ -9,3 +9,96 @@ menu:
     weight: 1
     parent: "calendar"
 ---
+
+<!-- markdownlint-disable MD013 -->
+
+## 개요
+
+공휴일관리(휴일관리)는 휴일의 등록, 수정, 삭제, 목록조회, 상세조회 기능을 제공한다.
+등록된 휴일 정보는 일반달력·행정달력 팝업 및 일간/주간/월간/연간 달력 화면에 반영된다.
+
+## 설명
+
+휴일의 관리는 목록조회, 상세조회, 등록, 수정, 삭제 처리를 할 수 있도록 구성되어 있다.
+
+### 관련소스
+
+| 유형 | 대상소스명 | 비고 |
+| --- | --- | --- |
+| Controller | `egovframework.com.sym.cal.web.EgovCalRestdeManageController.java` | 달력, 휴일관리를 위한 컨트롤러 클래스 |
+| Service | `egovframework.com.sym.cal.service.EgovCalRestdeManageService.java` | 달력, 휴일관리를 위한 서비스 인터페이스 |
+| ServiceImpl | `egovframework.com.sym.cal.service.impl.EgovCalRestdeManageServiceImpl.java` | 달력, 휴일관리를 위한 서비스 구현 클래스 |
+| DAO | `egovframework.com.sym.cal.service.impl.RestdeManageDAO.java` | 휴일 정보 관리를 위한 데이터처리 클래스 |
+| Model | `egovframework.com.sym.cal.service.Restde.java` | 휴일 정보 Model 클래스 |
+| VO | `egovframework.com.sym.cal.service.RestdeVO.java` | 달력, 휴일관리를 위한 VO 클래스 |
+| JS | `/js/egovframework/cmm/sym/cal/EgovCalPopup.js` | 일반달력·행정달력 팝업 호출 JavaScript |
+| JSP | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovRestdeList.jsp` 외 | 휴일 목록/등록/수정/상세 및 일반·행정달력(팝업/일간/주간/월간/연간) JSP 페이지 일체 |
+
+### 관련테이블
+
+| 테이블명 | 테이블명(영문) | 비고 |
+| --- | --- | --- |
+| 휴일 | COMTNRESTDE | 휴일 정보를 관리 |
+
+### ID Generation (`context-idgen.xml`)
+
+```xml
+<bean name="egovRestDeIdGnrService"
+    class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+    destroy-method="destroy">
+    <property name="dataSource" ref="dataSource" />
+    <property name="blockSize" value="10"/>
+    <property name="table" value="COMTECOPSEQ"/>
+    <property name="tableName" value="RESTDE_ID"/>
+</bean>
+```
+
+ID Generation Service를 활용하기 위해서 Sequence 저장테이블인 COMTECOPSEQ에 `RESTDE_ID` 항목을 추가한다.
+
+```sql
+INSERT INTO COMTECOPSEQ VALUES('RESTDE_ID','0');
+```
+
+## 관련화면 및 수행매뉴얼
+
+### 휴일 관리
+
+| 기능 | URL | Controller method | 화면(URL) |
+| --- | --- | --- | --- |
+| 목록조회 | /sym/cal/EgovRestdeList.do | selectRestdeList | /cmm/sym/cal/EgovRestdeList |
+| 등록 | /sym/cal/EgovRestdeRegist.do | insertRestde | /cmm/sym/cal/EgovRestdeRegist |
+| 수정 | /sym/cal/EgovRestdeModify.do | updateRestde | /cmm/sym/cal/EgovRestdeModify |
+| 상세조회 | /sym/cal/EgovRestdeDetail.do | selectRestdeDetail | /cmm/sym/cal/EgovRestdeDetail |
+| 삭제 | /sym/cal/EgovRestdeRemove.do | deleteRestde | /cmm/sym/cal/EgovRestdeDetail |
+
+휴일 목록은 페이지당 10건씩 조회되며 검색조건은 휴일일자·휴일명에 대해 수행된다.
+
+### 달력 팝업 사용
+
+일반달력·행정달력 팝업 호출을 위하여 `EgovCalPopup.js`를 해당 페이지에 등록한다.
+
+```html
+<script type="text/javascript" src="<c:url value='/js/egovframework/cmm/sym/cal/EgovCalPopup.js' />"></script>
+
+<form name="Form1" action="<c:url value='/sym/cmm/EgovNormalCalPopup.do'/>" method="post">
+    <input type="hidden" name="sDate" value="" size="8" readonly
+        onClick="javascript:fn_egov_NormalCalendar(document.Form1, document.Form1.sDate, document.Form1.vDate);" />
+    <input type="text" name="vDate" value="" size="10" readonly
+        onClick="javascript:fn_egov_NormalCalendar(document.Form1, document.Form1.sDate, document.Form1.vDate);" />
+</form>
+```
+
+`sDate`는 연월일 8자리를, `vDate`는 `-`를 포함한 날짜를 받는다. 행정달력은 `fn_egov_AdministCalendar`를 사용한다.
+
+### 달력 조회
+
+| 기능 | URL (일반달력) | URL (행정달력) |
+| --- | --- | --- |
+| 일간조회 | /sym/cal/EgovNormalDayCalendar.do | /sym/cal/EgovAdministDayCalendar.do |
+| 주간조회 | /sym/cal/EgovNormalWeekCalendar.do | /sym/cal/EgovAdministWeekCalendar.do |
+| 월간조회 | /sym/cal/EgovNormalMonthCalendar.do | /sym/cal/EgovAdministMonthCalendar.do |
+| 연간조회 | /sym/cal/EgovNormalYearCalendar.do | /sym/cal/EgovAdministYearCalendar.do |
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/main-menu.md
+++ b/common-component/elementary-technology/main-menu.md
@@ -9,3 +9,75 @@ menu:
     weight: 1
     parent: "interface"
 ---
+
+## 개요
+
+클라이언트(Client)에서 서버(Server)의 데이터를 받아 메뉴 형태로 보여주는 기능을 제공한다.
+메뉴의 추가, 수정, 삭제 기능을 지원하며, 저장된 정보는 트리메뉴 생성에 활용할 수 있다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+메인메뉴에서 제공하는 기능은 다음과 같다.
+
+1. 서버의 메뉴 데이터(DAT 파일)를 읽어 메뉴 필드 형태로 파싱하는 기능
+2. 메뉴관리 화면의 데이터(추가·수정·삭제)를 DAT 파일로 생성하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovMenuGov.java` | 메인메뉴 요소기술 클래스 | 메뉴파일 생성 |
+| JSP | `WEB_INF/jsp/egovframework/cmm/EgovMenuGov.jsp` | 테스트 페이지 | 직접 생성 (사용방법 참고) |
+
+### 클래스 및 메소드 설명
+
+메인메뉴 기능은 `EgovMenuGov` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| Vector | `parsFileByMenuChar(String parFile, String parChar, int parField)` | 메뉴테이블형태 파싱 | 데이터를 받아 구분값·필드수에 맞추어 메뉴필드 형태로 나눈다 |
+| boolean | `setDataByDATFile(String parFile, String[] menuIDArray, String[] menuNameArray, String[] menuLevelArray, String[] menuURLArray)` | 메뉴 데이터 파일 생성 | 메뉴관리 화면의 데이터를 받아 서버 데이터 파일(DAT)을 생성한다 (수정·삭제 반영) |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `parFile`: String 타입의 절대경로를 포함한 메뉴변환파일 (예: `/user/com/test/file1.dat`)
+- 메뉴ID / 상위메뉴ID: Number 타입의 숫자 (예: `1`, `10`, `100`)
+- 메뉴명: String 타입 (예: `메뉴관리`), URL: String 타입의 URL 경로
+
+#### 반환값 정의 (Output)
+
+- boolean 타입: 생성 성공 여부 / Vector 타입: 파싱된 메뉴 목록
+
+### 사용 방법
+
+DAT 파일의 데이터 형식은 라인별 `nodeId|parentNodeId|nodeName|nodeUrl` 이다.
+
+```java
+import egovframework.com.utl.sim.service.EgovMenuGov;
+
+// 1. 서버의 DAT 파일을 읽어 메뉴 필드 형태로 파싱
+Vector result = EgovMenuGov.parsFileByMenuChar("/user/com/test/file1.dat", "|", 4);
+
+// 2. 메뉴관리 화면의 데이터를 DAT 파일로 생성
+String[] menuIDArray = {"1", "10", "100"};
+String[] menuNameArray = {"메인메뉴", "메뉴관리", "하위메뉴"};
+String[] menuLevelArray = {"0", "1", "10"};
+String[] menuURLArray = {"/main.do", "/menu.do", "/sub.do"};
+
+boolean result2 = EgovMenuGov.setDataByDATFile("/user/com/test/file1.dat",
+        menuIDArray, menuNameArray, menuLevelArray, menuURLArray);
+```
+
+## 환경설정
+
+해당 계정으로 서버(Server)의 데이터(File 형태)를 읽고 쓸 수 있는 권한을 가진 디렉토리가 지정되어 있어야 한다.
+
+## 참고자료
+
+- [트리메뉴](../tree-menu/) — 메인메뉴로 생성한 DAT 파일을 활용하여 트리메뉴를 표현
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/property.md
+++ b/common-component/elementary-technology/property.md
@@ -9,3 +9,80 @@ menu:
     weight: 46
     parent: "system"
 ---
+
+## 개요
+
+애플리케이션에서 공통으로 사용할 프로퍼티 정보를 로드하여 파싱 후 메모리에 가지고 있는 기능을 제공한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+프로퍼티에서 제공하는 기능은 다음과 같다.
+
+1. 프로퍼티 파일을 로드하여 파싱 후 메모리에 가지고 있는 기능
+2. Key값으로 프로퍼티 값을 조회하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.cmm.service.EgovProperties.java` | 프로퍼티 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovProperty.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+프로퍼티 기능은 `EgovProperties` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| String | `getProperty(String keyName)` | 프로퍼티조회 | 인자로 주어진 문자열을 Key값으로 하는 프로퍼티 값을 반환 |
+| String | `getProperty(String fileName, String key)` | 프로퍼티조회 | 지정한 파일에서 인자로 주어진 문자열을 Key값으로 하는 프로퍼티 값을 반환 |
+| ArrayList | `loadPropertyFile(String property)` | 프로퍼티파싱 | 주어진 프로퍼티 파일의 내용을 파싱하여 (key-value) 형태의 구조체 배열을 반환 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- Property 파일명: String 타입의 절대경로를 포함한 파일명 (예: `/user/com/test/test.properties`)
+- Key: String 타입의 Key값 (예: `path`)
+
+#### 반환값 정의 (Output)
+
+- String 타입 Value값 또는 ArrayList 타입 (key-value) 목록
+
+### 사용 방법
+
+```java
+import java.util.ArrayList;
+import java.util.Map;
+
+import egovframework.com.cmm.service.EgovProperties;
+
+// 1. 프로퍼티 파일 파싱 후 Key로 조회
+String file = "/user/com/test/test.properties";
+String key = "path";
+
+ArrayList list = EgovProperties.loadPropertyFile(file);
+
+String resultStr = "";
+for (int i = 0; i < list.size(); i++) {
+    Map prop = (Map) list.get(i);
+    String str = (String) prop.get(key);
+    if (str != null && !"".equals(str)) {
+        resultStr = str;
+    }
+}
+
+// 2. globals.properties에서 직접 조회
+String fileStorePath = EgovProperties.getProperty("Globals.fileStorePath");
+```
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/string-validation.md
+++ b/common-component/elementary-technology/string-validation.md
@@ -9,3 +9,46 @@ menu:
     weight: 10
     parent: "formatter-util"
 ---
+
+# 문자열유효성체크
+
+## 개요
+
+문자열유효성체크는 두 개의 문자열을 비교하여 서로 값이 같은지를 확인하는 요소기술이다. 같은 값인지 다른 값인지에 따라
+서로 다른 문자열을 리턴한다. `EgovStringUtil` 유틸리티의 정적 메서드로 사용한다.
+
+## 관련 소스
+
+| 유형 | 대상소스 | 비고 |
+| --- | --- | --- |
+| 유틸리티 | egovframework.com.utl.fcc.service.EgovStringUtil.java | 문자열 처리 유틸리티 클래스 |
+| Controller | egovframework.com.utl.fcc.web.EgovComUtlTestController.java | 테스트용 Controller |
+| JSP | /WEB-INF/jsp/egovframework/cmm/utl/EgovStringValidation.jsp | 테스트 페이지 |
+
+## 주요 메서드
+
+<!-- markdownlint-disable MD013 -->
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `decode(String source, String compare, String ret, String defaultValue)` | `String` | 오라클의 decode 함수와 동일한 기능 — `source`와 `compare`가 같으면 `ret`, 다르면 `defaultValue`를 반환 |
+<!-- markdownlint-restore -->
+
+## 사용 예
+
+```java
+import egovframework.com.utl.fcc.service.EgovStringUtil;
+
+// foo 출력 (null == null)
+System.out.println(EgovStringUtil.decode(null, null, "foo", "bar"));
+// bar 출력 ("" != null)
+System.out.println(EgovStringUtil.decode("", null, "foo", "bar"));
+// foo 출력 (같은 값)
+System.out.println(EgovStringUtil.decode("하이", "하이", "foo", "bar"));
+// bar 출력 (다른 값 — 공백 포함)
+System.out.println(EgovStringUtil.decode("하이", "하이  ", "foo", "bar"));
+```
+
+## 참고자료
+
+- [문자열변환](../string-conversion/), [문자열치환](../string-replacement/), [문자열검색](../string-search/)
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/tree-menu.md
+++ b/common-component/elementary-technology/tree-menu.md
@@ -9,3 +9,74 @@ menu:
     weight: 2
     parent: "interface"
 ---
+
+## 개요
+
+클라이언트(Client)에서 서버(Server)의 데이터를 받아 트리 형태로 메뉴를 구성하는 기능을 제공한다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+트리메뉴에서 제공하는 기능은 다음과 같다.
+
+1. 서버의 메뉴 데이터(DAT 파일)를 파싱하여 트리 형태로 화면에 표현하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovMenuGov.java` | 메인메뉴 요소기술 클래스 | 메뉴파일 생성 |
+| JS | `/js/egovframework/cmm/utl/EgovMenuGov.js` | 트리생성 JavaScript | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/EgovTreeMenu.jsp` | 테스트 페이지 | 직접 생성 (사용방법 참고) |
+
+### 클래스 및 메소드 설명
+
+트리메뉴 기능은 `EgovMenuGov` 클래스의 메소드와 트리생성 JavaScript를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| Vector | `parsFileByMenuChar(String parFile, String parChar, int parField)` | 메뉴테이블형태 파싱 | 데이터를 받아 구분값·필드수에 맞추어 메뉴필드 형태로 나눈다 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- `parFile`: String 타입의 절대경로를 포함한 메뉴변환파일 (예: `/user/com/test/file1.dat`)
+
+### 사용 방법
+
+메인메뉴로 생성한 DAT 파일(라인별 `nodeId|parentNodeId|nodeName|nodeUrl`)을 파싱하여 트리메뉴를 표현한다.
+
+```jsp
+<%
+import egovframework.com.utl.sim.service.EgovMenuGov;
+Vector result1 = EgovMenuGov.parsFileByMenuChar(parFile, parChar, parField);
+%>
+
+<div class="tree">
+<script type="text/javascript">
+    var Tree = new Array;
+<%  // nodeId | parentNodeId | nodeName | nodeUrl
+    String temp = "";
+    for (int j = 0; j < result1.size() - 1; j++) {
+        ArrayList arr = (ArrayList) result1.elementAt(j);
+        temp = (String) arr.get(0) + "|" + (String) arr.get(1) + "|"
+             + (String) arr.get(2) + "|" + (String) arr.get(3);
+%>  Tree[<%=j%>] = "<%=temp%>"; <%
+    }
+%>
+    createTree(Tree);
+</script>
+</div>
+```
+
+## 환경설정
+
+N/A
+
+## 참고자료
+
+- [메인메뉴](../main-menu/) — 트리메뉴에서 사용하는 DAT 파일의 생성·관리
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/xml-data-assembly.md
+++ b/common-component/elementary-technology/xml-data-assembly.md
@@ -9,3 +9,74 @@ menu:
     weight: 47
     parent: "system"
 ---
+
+## 개요
+
+일반 구조적 형태의 데이터를 XML 데이터로 조립하여 파일로 저장하는 기능을 제공한다.
+웹서비스(Web Service), 전자문서, 데이터교환과 같은 응용 애플리케이션에서 사용할 수 있다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+XML 데이터조립에서 제공하는 기능은 다음과 같다.
+
+1. 일반 구조적 형태의 데이터(자바 객체)를 XML 데이터로 조립하여 파일로 저장하는 기능
+2. Document 객체 기반으로 Element·Text 노드를 생성·조작하여 XML 파일로 저장하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovXMLDoc.java` | XML파싱/조립 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovXMLDoc.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+XML 데이터조립 기능은 `EgovXMLDoc` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| boolean | `getClassToXML(SndngMailDocument mailDoc, String file)` | XML조립 | 객체(예제: 메일발송 클래스)의 데이터를 XML파일로 저장 |
+| boolean | `getXMLFile(Document document, String file)` | XML조립 | Document 객체를 XML파일로 저장 |
+| Document | `getXMLDocument(String xml)` | XML파싱 | XML 파일을 파싱하여 조작 가능한 Document 객체를 반환 |
+| Element | `getRootElement(Document document)` | ROOT이동 | Document의 최상위 Element로 이동 |
+| Element | `insertElement(Document document, Element rt, String id)` | 노드생성 | 하위에 새로운 Element를 생성 |
+| Element | `insertElement(Document document, Element rt, String id, String text)` | 문자열노드생성 | 하위에 문자열을 가지는 새로운 Element를 생성 |
+| Text | `insertText(Document document, Element rt, String text)` | 문자열추가 | 하위에 문자열을 추가 |
+| Element | `getParentNode(Element current)` | 상위노드반환 | 마지막으로 입력·참조된 XML Node의 상위 Element를 리턴 |
+<!-- markdownlint-restore -->
+
+#### 반환값 정의 (Output)
+
+- boolean 타입: 조립(저장) 성공 여부 (`true` / `false`)
+
+### 사용 방법
+
+예제는 XML 스키마로 생성한 메일정보 클래스(`SndngMailDocument`)에 데이터를 담아 XML 파일로 조립하는 방식이다.
+
+```java
+import egovframework.com.utl.sim.service.EgovXMLDoc;
+
+SndngMailDocument mailDoc = SndngMailDocument.Factory.newInstance();
+SndngMailDocument.SndngMail mailElement = mailDoc.addNewSndngMail();
+mailElement.setDsptchPerson("example1@example.com");
+mailElement.setRecptnPerson("example2@example.com");
+mailElement.setSj("test mail");
+mailElement.setEmailCn("This is test mail.");
+mailElement.setSndngResultCode("R");
+
+boolean result = EgovXMLDoc.getClassToXML(mailDoc, "/user/com/test/mail_result.xml");
+```
+
+## 환경설정
+
+XML 스키마 기반 클래스 생성을 위해 Apache XMLBeans 라이브러리를 사용한다. 자세한 스키마 컴파일 절차는
+[XML 데이터파싱](../xml-data-parsing/) 문서의 환경설정을 참조한다.
+
+## 참고자료
+
+- [XML 데이터파싱](../xml-data-parsing/)
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/elementary-technology/xml-data-parsing.md
+++ b/common-component/elementary-technology/xml-data-parsing.md
@@ -9,3 +9,82 @@ menu:
     weight: 48
     parent: "system"
 ---
+
+## 개요
+
+XML 파일을 로드한 후 XML 데이터를 파싱하여 구조적인 데이터 형태로 변환하는 기능을 제공한다.
+웹서비스(Web Service), 전자문서, 데이터교환과 같은 응용 애플리케이션에서 사용할 수 있다.
+본 기능은 전자정부 표준프레임워크 공통컴포넌트 요소기술 내에 구성되어 있다.
+
+## 설명
+
+### 기능 설명
+
+XML 데이터파싱에서 제공하는 기능은 다음과 같다.
+
+1. XML 스키마 구조를 읽어 이에 맞는 자바클래스(JAR)를 생성하는 기능
+2. XML 데이터를 파싱하여 구조적인 데이터 형태(자바 객체·Document)로 변환하는 기능
+
+### 관련 소스
+
+| 유형 | 대상소스명 | 설명 | 비고 |
+| --- | --- | --- | --- |
+| Service | `egovframework.com.utl.sim.service.EgovXMLDoc.java` | XML파싱/조립 요소기술 클래스 | |
+| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovXMLDoc.jsp` | 테스트 페이지 | |
+
+### 클래스 및 메소드 설명
+
+XML 데이터파싱 기능은 `EgovXMLDoc` 클래스의 메소드를 활용하여 제공한다.
+
+<!-- markdownlint-disable MD013 -->
+| 결과값 | 메소드명 | 설명 | 내용 |
+| --- | --- | --- | --- |
+| boolean | `creatSchemaToClass(String xml, String ja)` | 클래스생성 | XML스키마 구조를 읽어 이에 맞는 자바클래스(JAR)를 생성 |
+| SndngMailDocument | `getXMLToClass(String file)` | XML파싱 | XML파일을 파싱하여 객체(예제: 메일발송 클래스)에 내용을 담아 반환 |
+| Document | `getXMLDocument(String xml)` | XML파싱 | XML 파일을 파싱하여 조작 가능한 Document 객체를 반환 |
+| Element | `getRootElement(Document document)` | ROOT이동 | Document의 최상위 Element로 이동 |
+| Element | `getParentNode(Element current)` | 상위노드반환 | 마지막으로 입력·참조된 XML Node의 상위 Element를 리턴 |
+<!-- markdownlint-restore -->
+
+#### 파라미터 정의 (Input)
+
+- XML스키마 파일: String 타입의 절대경로 (예: `/user/com/test/mail.xsd`)
+- 생성 JAR 경로: String 타입의 절대경로 (예: `/user/com/test/mail.jar`)
+- XML데이터 파일: String 타입의 절대경로 (예: `/user/com/test/mail_data.xml`)
+
+### 사용 방법
+
+```java
+import egovframework.com.utl.sim.service.EgovXMLDoc;
+
+// 1. 스키마 파일을 읽어 자바 클래스(JAR) 생성
+boolean result = EgovXMLDoc.creatSchemaToClass("/user/com/test/mail.xsd", "/user/com/test/mail.jar");
+
+// 2. XML 파일의 데이터를 읽어 객체로 파싱
+SndngMailDocument mailDoc = EgovXMLDoc.getXMLToClass("/user/com/test/mail_data.xml");
+SndngMailDocument.SndngMail mailElement = mailDoc.getSndngMail();
+
+String dsptchPerson = mailElement.getDsptchPerson();  // 발신자
+String recptnPerson = mailElement.getRecptnPerson();  // 수신자
+String sj = mailElement.getSj();                      // 제목
+```
+
+## 환경설정
+
+XML 스키마 컴파일을 위해 [Apache XMLBeans](https://xmlbeans.apache.org/) 라이브러리를 사용한다.
+
+```text
+# 시스템변수 및 PATH 설정 (윈도우 예시)
+set XMLBEANS_HOME=C:\xmlbeans-2.0.0
+set PATH=%XMLBEANS_HOME%\bin;%JAVA_HOME%\bin;
+
+# 스키마 파일 컴파일 (JAR 생성: -out, 소스 생성: -src)
+scomp -out target.jar source.xsd
+```
+
+XML 스키마(`.xsd`)로 생성된 JAR를 시스템에 추가한 뒤, 해당 클래스로 XML 데이터를 파싱·조립한다.
+
+## 참고자료
+
+- [XML 데이터조립](../xml-data-assembly/)
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 기존 문서 보완 (docs/update)

## 변경 내용 (Description)

요소기술 카테고리의 마지막 빈 문서 8건에 내용을 작성했습니다. #690·#695·#696·#699와 같은 계열의 작업으로, 표준프레임워크 위키 원문을 근거로 구성했습니다.

**이 PR로 요소기술 카테고리의 빈 스텁 문서(15줄 미만)가 모두 해소됩니다** — #672부터 이어온 빈 문서 정비 시리즈로 총 12개 PR, 문서 64건입니다.

| 문서 | 근거 |
| --- | --- |
| `string-validation.md` (문자열유효성체크) | EgovStringUtil.decode — 위키 "유효성체크" 원문 |
| `format-validation.md` (포맷유효성체크) | EgovFormatCheckUtil — 전화·휴대폰·이메일 체크 6종 |
| `property.md` (프로퍼티) | EgovProperties.getProperty·loadPropertyFile |
| `holiday-management.md` (공휴일관리(달력)) | sym.cal 휴일관리 — 관련테이블·ID Generation·달력 팝업·화면 URL 표 |
| `main-menu.md` (메인메뉴) | EgovMenuGov.parsFileByMenuChar·setDataByDATFile |
| `tree-menu.md` (트리메뉴) | EgovMenuGov + EgovMenuGov.js (DAT 파일 트리 표현) |
| `xml-data-assembly.md` (XML 데이터조립) | EgovXMLDoc — Document/Element 조작·getClassToXML |
| `xml-data-parsing.md` (XML 데이터파싱) | EgovXMLDoc — creatSchemaToClass·getXMLToClass, XMLBeans 환경설정 |

frontmatter의 parent(formatter-util/system/calendar/interface)별로 기존 병합 문서와 동일한 구성을 따랐고, 기존 frontmatter는 그대로 유지했습니다. 메인메뉴↔트리메뉴, XML 조립↔파싱은 상호 참조 링크로 연결했습니다.

## 관련 이슈 (Related Issues)

없음 (#672~#699와 같은 계열의 빈 문서 보완입니다)

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다. (기존 frontmatter 그대로 유지)
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.