### PR TITLE
docs: 공통컴포넌트 잔여 스텁 6건 마감 (시스템관리·디지털자산·intro)

### DIFF
--- a/common-component/digital-asset-management/knowledge-info-provision.md
+++ b/common-component/digital-asset-management/knowledge-info-provision.md
@@ -9,3 +9,44 @@ menu:
     weight: 3
     parent: "knowledge-map"
 ---
+
+# 지식정보제공
+
+## 개요
+
+지식정보제공은 지식전문가에게 지식정보를 요청하고, 요청된 지식정보를 제공(답변)하는 기능이다. 소스는 디지털자산관리(`egovframework.com.dam.spe.req`) 패키지에 위치하며, 지식전문가 관리 기능과 연계되어 동작한다.
+
+## 설명
+
+### 관련소스
+
+| 유형 | 대상소스명 | 비고 |
+| --- | --- | --- |
+| Controller | egovframework.com.dam.spe.req.web.EgovRequestOfferController.java | EgovRequestOfferController Class |
+| Service | egovframework.com.dam.spe.req.service.EgovRequestOfferService.java | Service Interface |
+| ServiceImpl | egovframework.com.dam.spe.req.service.impl.EgovRequestOfferServiceImpl.java |  |
+| VO | egovframework.com.dam.spe.req.service.RequestOfferVO.java |  |
+| Class | egovframework.com.dam.spe.req.service.RequestOffer.java |  |
+| DAO | egovframework.com.dam.spe.req.service.impl.RequestOfferDao.java |  |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/spe/req/EgovComDamRequestOfferDetail.jsp |  |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/spe/req/EgovComDamRequestOfferList.jsp |  |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/spe/req/EgovComDamRequestOfferRegist.jsp |  |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/spe/req/EgovComDamRequestOfferUpdt.jsp |  |
+| Query XML | resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_*.xml | DB별 Query XML |
+
+### 주요 메서드 (EgovRequestOfferService)
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `selectRequestOfferDelCnt(Map<?, ?>)` | `int` | 목록/기본 기능을 처리한다 |
+| `selectRequestOfferSpeCheck(Map<?, ?>)` | `boolean` | 등록된 지식전문가 건수를 조회한다. |
+| `selectRequestOfferList(RequestOfferVO)` | `List<EgovMap>` | 지식정보제공/지식정보요청 목록을 조회한다. |
+| `selectRequestOfferListCnt(RequestOfferVO)` | `int` | 지식정보제공/지식정보요청를(을) 목록 전체 건수를(을) 조회한다. |
+| `selectRequestOfferDetail(RequestOfferVO)` | `RequestOfferVO` | 지식정보제공/지식정보요청를(을) 상세조회 한다. |
+| `insertRequestOffer(RequestOfferVO)` | `void` | 지식정보제공/지식정보요청를(을) 등록한다. |
+| `updateRequestOffer(RequestOfferVO)` | `void` | 지식정보제공/지식정보요청를(을) 수정한다. |
+| `deleteRequestOffer(RequestOfferVO)` | `void` | 지식정보제공/지식정보요청를(을) 삭제한다. |
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/intro/_index.md
+++ b/common-component/intro/_index.md
@@ -10,3 +10,22 @@ menu:
     parent: "common-component"
     identifier: "cc-intro"
 ---
+
+# 공통컴포넌트 개요
+
+## 개요
+
+전자정부 표준프레임워크 공통컴포넌트는 전자정부 시스템에서 공통적으로 사용되는 기능을 재사용 가능한 형태로 제공하는 컴포넌트 모음이다. 이 절은 공통컴포넌트를 도입·활용하기 위한 공통 기반 정보를 제공한다.
+
+## 관련 문서
+
+- [공통컴포넌트 시작하기](./getting-started.md) — 공통컴포넌트 도입과 실행을 위한 시작 안내.
+- [공통컴포넌트 환경설정](./environment-setup.md) — 공통컴포넌트 실행에 필요한 환경설정 안내.
+- [공통컴포넌트 배포 파일의 구성](./deployment-structure.md) — 배포 파일 구조와 구성 항목 설명.
+- [패키지 간 참조 관계](./package-reference.md) — 컴포넌트 패키지 간 의존·참조 관계 정리.
+- [공통컴포넌트 테이블 구성 정보](./table-structure.md) — 컴포넌트가 사용하는 테이블 구성 정보.
+- [공통컴포넌트 축약어 모음](./terms.md) — 패키지·클래스 명명에 사용된 축약어 목록.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/system-management/error-manage.md
+++ b/common-component/system-management/error-manage.md
@@ -9,3 +9,18 @@ menu:
     parent: "system-management"
     identifier: "error-manage"
 ---
+
+# 장애관리
+
+## 개요
+
+장애관리는 시스템 장애 발생 시 장애 내역의 신청(접수)과 조치·처리결과 관리를 지원하는 시스템관리 기능 묶음이다.
+
+## 관련 문서
+
+- [장애신청관리](./error-application.md) — 시스템 장애발생 시 장애내역을 등록하고 처리를 요청하는 기능을 제공한다.
+- [장애처리결과관리](./error-result.md) — 시스템 장애발생 시 장애조치내역을 등록하고 처리결과를 조회하는 기능을 제공한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/system-management/program-manage.md
+++ b/common-component/system-management/program-manage.md
@@ -9,3 +9,17 @@ menu:
     parent: "system-management"
     identifier: "program-manage"
 ---
+
+# 프로그램관리
+
+## 개요
+
+프로그램관리는 시스템을 구성하는 프로그램 목록과 프로그램 변경 이력을 관리하는 시스템관리 기능 묶음이다.
+
+## 관련 문서
+
+- [프로그램관리](./program-management.md) — 프로그램목록관리와 프로그램변경관리로 구성되며, 프로그램 목록 등록·조회와 변경요청·처리 기능을 제공한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/system-management/road-name-address.md
+++ b/common-component/system-management/road-name-address.md
@@ -9,3 +9,54 @@ menu:
     weight: 9
     parent: "common-code-manage"
 ---
+
+# 도로명주소연계
+
+## 개요
+
+도로명주소연계는 도로명주소 기반 우편번호 정보를 등록(엑셀 일괄 등록 포함)·조회·수정·삭제하는 기능이다. 소스는 공통코드관리(`egovframework.com.sym.ccm.zip`) 패키지에 위치하며, 도로명주소 우편번호 데이터를 시스템에 적재해 주소 검색에 활용한다.
+
+## 설명
+
+### 관련소스
+
+| 유형 | 대상소스명 | 비고 |
+| --- | --- | --- |
+| Controller | egovframework.com.sym.ccm.zip.web.EgovCcmZipManageController.java | EgovCcmZipManageController Class |
+| Service | egovframework.com.sym.ccm.zip.service.EgovCcmRdnmadZipManageService.java | Service Interface |
+| Service | egovframework.com.sym.ccm.zip.service.EgovCcmZipManageService.java | Service Interface |
+| ServiceImpl | egovframework.com.sym.ccm.zip.service.impl.EgovCcmRdnmadZipServiceImpl.java |  |
+| ServiceImpl | egovframework.com.sym.ccm.zip.service.impl.EgovCcmZipManageServiceImpl.java |  |
+| VO | egovframework.com.sym.ccm.zip.service.ZipVO.java |  |
+| Class | egovframework.com.sym.ccm.zip.service.Zip.java |  |
+| Class | egovframework.com.sym.ccm.zip.service.impl.EgovCcmExcelRdnmadZipMapping.java |  |
+| Class | egovframework.com.sym.ccm.zip.service.impl.EgovCcmExcelZipMapping.java |  |
+| DAO | egovframework.com.sym.ccm.zip.service.impl.RdnmadZipDAO.java |  |
+| DAO | egovframework.com.sym.ccm.zip.service.impl.ZipManageDAO.java |  |
+| JSP | /WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovAdressPop.jsp |  |
+| JSP | /WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmExcelZipRegist.jsp |  |
+| JSP | /WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipDetail.jsp |  |
+| JSP | /WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipList.jsp |  |
+| JSP | /WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipModify.jsp |  |
+| JSP | /WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipRegist.jsp |  |
+| JSP | /WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipSearchList.jsp |  |
+| JSP | /WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipSearchPopup.jsp |  |
+| Query XML | resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_*.xml | DB별 Query XML |
+| Query XML | resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_*.xml | DB별 Query XML |
+
+### 주요 메서드 (EgovCcmRdnmadZipManageService)
+
+| 메서드 | 반환형 | 설명 |
+| --- | --- | --- |
+| `deleteZip(Zip)` | `void` | 우편번호에 관한 서비스 인터페이스 클래스를 정의한다 |
+| `deleteAllZip()` | `void` | 우편번호 전체를 삭제한다. |
+| `insertZip(Zip)` | `void` | 우편번호를 등록한다. |
+| `insertExcelZip(InputStream)` | `void` | 우편번호 엑셀파일을 등록한다. |
+| `selectZipDetail(Zip)` | `Zip` | 우편번호 상세항목을 조회한다. |
+| `selectZipList(ZipVO)` | `List<EgovMap>` | 우편번호 목록을 조회한다. |
+| `selectZipListTotCnt(ZipVO)` | `int` | 우편번호 총 개수를 조회한다. |
+| `updateZip(Zip)` | `void` | 우편번호를 수정한다. |
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)

--- a/common-component/system-management/system-manage.md
+++ b/common-component/system-management/system-manage.md
@@ -9,3 +9,19 @@ menu:
     parent: "system-management"
     identifier: "system-manage"
 ---
+
+# 시스템관리
+
+## 개요
+
+시스템관리는 시스템을 구성하는 서버·네트워크 자원 정보와 백업 작업을 관리하는 기능 묶음이다.
+
+## 관련 문서
+
+- [서버장비관리](./server-info-management.md) — 웹서버, WAS서버, DB서버 등 시스템을 구성하는 서버의 정보를 관리하는 기능을 제공한다.
+- [네트워크관리](./network-management.md) — 서버자원이나 사용자 등에게 할당하기 위한 IP 등의 네트워크 정보를 관리하는 기능을 제공한다.
+- [백업관리](./backup-management.md) — 시스템에서 주기적으로 실행하는 백업작업을 관리하고 백업결과를 조회하는 기능을 제공한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 신규 문서 추가 (docs/new)

## 변경 내용 (Description)

공통컴포넌트 카테고리의 잔여 빈 스텁을 마감하는 배치입니다 (#704, #705 후속). 이 PR로 소스 근거가 있는 빈 스텁이 모두 소진됩니다.

**허브 문서 4건** — 하위 문서 개요 발췌 목차 방식:
- system-management/error-manage.md (장애관리 — 하위 2건)
- system-management/program-manage.md (프로그램관리 — 하위 1건)
- system-management/system-manage.md (시스템관리 — 서버·네트워크·백업 3건)
- intro/_index.md (공통컴포넌트 개요 — 시작하기·환경설정·배포구성·패키지참조·테이블·축약어 6건 안내)

**내용 문서 2건** — 소스(Javadoc·파일 인벤토리) 기반:
- system-management/road-name-address.md — sym.ccm.zip (EgovCcmRdnmadZipManageService 8개 메서드, 엑셀 일괄등록 포함)
- digital-asset-management/knowledge-info-provision.md — dam.spe.req (EgovRequestOfferService 8개 메서드, 지식전문가 연계 명시)

**미포함 2건**: collaboration/brief-approval.md(약식결재)·edsm.md(전자문서연계)는 현행 egovframe-common-components에 해당 패키지가 없어(#704에서 보고) 근거 기반 작성이 불가합니다. 메뉴 정리(삭제) 또는 안내 문서화 방향을 결정해 주시면 후속 PR로 반영하겠습니다.

## 관련 이슈 (Related Issues)

없음 (스텁 채우기 시리즈 마감 — #687, #688, #690, #695, #704, #705 연장)

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다. (기존 frontmatter 유지, 본문만 추가)
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.