### PR TITLE
docs: user-support 관련소스 표의 실제 소스와 불일치하는 경로 정정

### DIFF
--- a/common-component/user-support/company-member-management.md
+++ b/common-component/user-support/company-member-management.md
@@ -43,12 +43,12 @@ menu:
 | VO | egovframework.com.uss.umt.service.EntrprsManageVO.java | 기업회원 관리를 위한 모델 클래스 |
 | VO | egovframework.com.uss.umt.service.UserDefaultVO.java | 기업회원 관리를 위한 검색조건용 VO 클래스 |
 | DAO | egovframework.com.uss.umt.service.impl.EntrprsManageDAO.java | 기업회원 관리를 위한 데이터처리 클래스 |
-| JSP | /WEB-INF/jsp/egovframework/com/uss/umt/EgovEntrprsMberInsert.jsp | 기업회원 등록을 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/com/uss/umt/EgovEntrprsMberSelectUpdt.jsp | 기업회원 상세조회 및 수정을 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/uss/umt/EgovEntrprsInsert.jsp | 기업회원 등록을 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/uss/umt/EgovEntrprsSelectUpdt.jsp | 기업회원 상세조회 및 수정을 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/umt/EgovEntrprsPasswordUpdt.jsp | 기업회원 암호수정을 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/com/uss/umt/EgovEntrprsMberManage.jsp | 기업회원 목록조회를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/uss/umt/EgovEntrprsManage.jsp | 기업회원 목록조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/umt/EgovIdDplctCnfirm.jsp | 중복아이디 확인을 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/com/uss/umt/EgovEntrprsMberSbscrb.jsp | 기업회원 가입신청을 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/uss/umt/EgovEntrprsSbscrb.jsp | 기업회원 가입신청을 위한 jsp페이지 |
 | Query XML | resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_altibase.xml | Altibase용 Query XML |
 | Query XML | resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_cubrid.xml | Cubrid용 Query XML |
 | Query XML | resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_maria.xml | MariaDB용 Query XML |

--- a/common-component/user-support/mypage.md
+++ b/common-component/user-support/mypage.md
@@ -41,8 +41,6 @@ menu:
 | JSP | /WEB-INF/jsp/egovframework/com/uss/mpe/EgovIndvdlPgeRegist.jsp | 마이페이지 컨텐츠 등록 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/mpe/EgovIndvdlPgeUpdt.jsp | 마이페이지 컨텐츠 수정 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/mpe/EgovIndvdlPgeDetail.jsp | 마이페이지 컨텐츠 상세조회 페이지 |
-| JSP | /WEB-INF/jsp/egovframework/com/uss/mpe/EgovIndvdlpgeList.jsp | 마이페이지 컨텐츠 추가 페이지 |
-| JSP | /WEB-INF/jsp/egovframework/com/uss/mpe/EgovIndvdlpgeDetail.jsp | 마이페이지 조회 페이지 |
 | Query XML | resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge\_SQL\_altibase.xml | 마이페이지 관리를 위한 Altibase용 Query XML |
 | Query XML | resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge\_SQL\_cubrid.xml | 마이페이지 관리를 위한 Cubrid용 Query XML |
 | Query XML | resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge\_SQL\_maria.xml | 마이페이지 관리를 위한 MariaDB용 Query XML |

--- a/common-component/user-support/popup-management.md
+++ b/common-component/user-support/popup-management.md
@@ -40,7 +40,7 @@ menu:
 | ServiceImpl | egovframework.com.uss.ion.pwm.service.impl.EgovPopupManageServiceImpl.java | 팝업창관리 ServiceImpl Class |
 | VO | egovframework.com.uss.ion.pwm.service.PopupManageVO.java | 팝업창관리 VO Class |
 | VO | egovframework.com.cmm.ComDefaultVO.java | 검색 VO Class |
-| DAO | egovframework.com.uss.ion.pwm.service.impl.PopupManageDao.java | 팝업창관리 Dao Class |
+| DAO | egovframework.com.uss.ion.pwm.service.impl.PopupManageDAO.java | 팝업창관리 Dao Class |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/ion/pwm/EgovPopupList.jsp | 팝업창관리 목록조회 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/ion/pwm/EgovPopupRegist.jsp | 팝업창관리 등록 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/ion/pwm/EgovPopupUpdt.jsp | 팝업창관리 수정 페이지 |

--- a/common-component/user-support/wiki.md
+++ b/common-component/user-support/wiki.md
@@ -29,7 +29,7 @@ Wiki기능은 외부 위키 서비스 페이지를 북마크로 등록·조회·
 | DAO | egovframework.com.uss.ion.wik.bmk.service.impl.WikiBookmarkDao.java |  |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/ion/wik/bmk/EgovWikiBookmarkList.jsp |  |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/ion/wik/bmk/EgovWikiBookmarkRegist.jsp |  |
-| Query XML | resources/egovframework/mapper/com/uss/ion/wik/EgovWikiBookmark_SQL_*.xml | DB별 Query XML |
+| Query XML | resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_*.xml | DB별 Query XML |
 
 ### 주요 메서드 (EgovWikiBookmarkService)
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

사용자지원(user-support) 문서 62건의 "관련소스" 표를 egovframe-common-components 저장소 main 기준 실제 소스(참조 639건)와 전수 대조하여, 불일치가 확인된 4개 문서의 경로를 정정합니다.

- **company-member-management.md**: JSP 파일명 4건 정정 — 실제 소스에는 `EgovEntrprsMber*` 형태의 JSP가 존재하지 않아 실제 파일명으로 수정 (`EgovEntrprsMberInsert` → `EgovEntrprsInsert`, `EgovEntrprsMberSelectUpdt` → `EgovEntrprsSelectUpdt`, `EgovEntrprsMberManage` → `EgovEntrprsManage`, `EgovEntrprsMberSbscrb` → `EgovEntrprsSbscrb`)
- **mypage.md**: 존재하지 않는 소문자 표기(`EgovIndvdlpge*`) JSP 중복 행 2건 제거 — 바로 위에 올바른 표기(`EgovIndvdlPge*`) 행이 이미 있음
- **popup-management.md**: `PopupManageDao.java` → `PopupManageDAO.java` (실제 클래스명 대소문자)
- **wiki.md**: Query XML 경로에 누락된 `bmk` 하위 디렉토리 보완 (`mapper/com/uss/ion/wik/` → `mapper/com/uss/ion/wik/bmk/`)

## 관련 이슈 (Related Issues)

없음

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

- 검증 방법: 문서의 관련소스 표에서 Java 클래스·JSP·Query XML 경로를 추출해 egovframe-common-components `main` 브랜치 파일 존재 여부를 스크립트로 대조했습니다. 위 4개 문서 외 58건은 모두 실제 소스와 일치했습니다.
- 열려 있는 #664(띄어쓰기 수정)와 파일이 겹치는 popup-management.md는 수정 위치(43행 vs 125행)가 달라 충돌하지 않습니다.