### PR TITLE
fix: 가이드 관련소스 파일명 대소문자·JSP 경로 정정

### DIFF
--- a/common-component/collaboration/sms-service.md
+++ b/common-component/collaboration/sms-service.md
@@ -72,10 +72,8 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_mysql.xml | 문자메시지서비스를 위한 Mysql용 Query 파일 |
 | Query XML | resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_oracle.xml | 문자메시지서비스를 위한 Oracle용 Query 파일 |
 | Query XML | resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_postgres.xml | 문자메시지서비스를 위한 Postgres용 Query 파일 |
-| Query XML | resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_Tibero.xml | 문자메시지서비스를 위한 Tibero용 Query 파일 |
+| Query XML | resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_tibero.xml | 문자메시지서비스를 위한 Tibero용 Query 파일 |
 | Query XML | resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_goldilocks.xml | 문자메시지서비스를 위한 Goldilocks용 Query 파일 |
-| Validator Rule XML | resources/egovframework/validator/validator-rules.xml | Validator Rule을 정의한 XML |
-| Validator XML | resources/egovframework/validator/com/uss/olp/cns/EgovCnsltManage.xml | 문자메시지서비스를 위한 Validator XML |
 | Message properties | resources/egovframework/message/com/cop/sms/message_ko.properties | 문자메시지서비스를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/sms/message_en.properties | 문자메시지서비스를 위한 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-Sms.xml | 문자메시지서비스를 위한 Id생성 Idgen XML |

--- a/common-component/digital-asset-management/knowledge-evaluation-manage.md
+++ b/common-component/digital-asset-management/knowledge-evaluation-manage.md
@@ -36,9 +36,9 @@ menu:
 | DAO | egovframework.com.dam.app.service.impl.KnoAppraisalDAO.java | 지식평가 관리를 위한 데이터처리 클래스 |
 | Model | egovframework.com.dam.app.service.KnoAppraisal.java | 지식평가 관리를 위한 Model 클래스 |
 | VO | egovframework.com.dam.app.service.KnoAppraisalVO.java | 지식평가 관리를 위한 VO 클래스 |
-| JSP | /WEB-INF/jsp/egovframework/dam/app/EgovComDamAppraisalList.jsp | 지식평가 목록조회를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/app/EgovComDamAppraisalModify.jsp | 지식평가 수정를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/app/EgovComDamAppraisalDetail.jsp | 등록된 지식평가을 조회하기 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/app/EgovComDamAppraisalList.jsp | 지식평가 목록조회를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/app/EgovComDamAppraisalModify.jsp | 지식평가 수정를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/app/EgovComDamAppraisalDetail.jsp | 등록된 지식평가을 조회하기 위한 jsp페이지 |
 | Query XML | resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal\_SQL\_altibase.xml | 지식평가 관리를 위한 Altibase용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal\_SQL\_cubrid.xml | 지식평가 관리를 위한 Cubrid용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal\_SQL\_maria.xml | 지식평가 관리를 위한 MariaDB용 Query XML |

--- a/common-component/digital-asset-management/knowledge-expert-manage.md
+++ b/common-component/digital-asset-management/knowledge-expert-manage.md
@@ -37,10 +37,10 @@ menu:
 | DAO | egovframework.com.dam.spe.spe.service.impl.KnoSpecialistDAO.java | 지식전문가 관리를 위한 데이터처리 클래스 |
 | Model | egovframework.com.dam.spe.spe.service.KnoSpecialist.java | 지식전문가 관리를 위한 Model 클래스 |
 | VO | egovframework.com.dam.spe.spe.service.KnoSpecialistVO.java | 지식전문가 관리를 위한 VO 클래스 |
-| JSP | /WEB-INF/jsp/egovframework/dam/spe/spe/EgovComDamSpecialistList.jsp | 지식전문가 목록조회를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/spe/spe/EgovComDamSpecialistRegist.jsp | 지식전문가 등록를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/spe/spe/EgovComDamSpecialistModify.jsp | 지식전문가 수정를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/spe/spe/EgovComDamSpecialistDetail.jsp | 등록된 지식전문가을 조회하기 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/spe/spe/EgovComDamSpecialistList.jsp | 지식전문가 목록조회를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/spe/spe/EgovComDamSpecialistRegist.jsp | 지식전문가 등록를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/spe/spe/EgovComDamSpecialistModify.jsp | 지식전문가 수정를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/spe/spe/EgovComDamSpecialistDetail.jsp | 등록된 지식전문가을 조회하기 위한 jsp페이지 |
 | Query XML | resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList\_SQL\_altibase.xml | 지식전문가 관리를 위한 Altibase용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList\_SQL\_cubrid.xml | 지식전문가 관리를 위한 Cubrid용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList\_SQL\_maria.xml | 지식전문가 관리를 위한 MariaDB용 Query XML |

--- a/common-component/digital-asset-management/knowledge-info-manage.md
+++ b/common-component/digital-asset-management/knowledge-info-manage.md
@@ -35,9 +35,9 @@ menu:
 | DAO | egovframework.com.dam.mgm.service.impl.KnoManagementDAO.java | 지식정보 관리를 위한 데이터처리 클래스 |
 | Model | egovframework.com.dam.mgm.service.KnoManagement.java | 지식정보 관리를 위한 Model 클래스 |
 | VO | egovframework.com.dam.mgm.service.KnoManagementVO.java | 지식정보 관리를 위한 VO 클래스 |
-| JSP | /WEB-INF/jsp/egovframework/dam/mgm/EgovComDamManagementList.jsp | 지식정보 목록조회를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/mgm/EgovComDamManagementModify.jsp | 지식정보 수정를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/mgm/EgovComDamManagementDetail.jsp | 등록된 지식정보을 조회하기 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/mgm/EgovComDamManagementList.jsp | 지식정보 목록조회를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/mgm/EgovComDamManagementModify.jsp | 지식정보 수정를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/mgm/EgovComDamManagementDetail.jsp | 등록된 지식정보을 조회하기 위한 jsp페이지 |
 | Query XML | resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement\_SQL\_altibase.xml | 지식정보 관리를 위한 Altibase용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement\_SQL\_cubrid.xml | 지식정보 관리를 위한 Cubrid용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement\_SQL\_maria.xml | 지식정보 관리를 위한 MariaDB용 Query XML |

--- a/common-component/digital-asset-management/org-knowledge-map-management.md
+++ b/common-component/digital-asset-management/org-knowledge-map-management.md
@@ -37,10 +37,10 @@ menu:
 | DAO | egovframework.com.dam.map.tea.service.impl.MapTeamDAO.java | 지식맵(조직별) 관리를 위한 데이터처리 클래스 |
 | Model | egovframework.com.dam.map.tea.service.MapTeam.java | 지식맵(조직별) 관리를 위한 Model 클래스 |
 | VO | egovframework.com.dam.map.tea.service.MapTeamVO.java | 지식맵(조직별) 관리를 위한 VO 클래스 |
-| JSP | /WEB-INF/jsp/egovframework/dam/map/tea/EgovComDamMapTeamList.jsp | 지식맵(조직별) 목록조회를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/map/tea/EgovComDamMapTeamRegist.jsp | 지식맵(조직별) 등록를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/map/tea/EgovComDamMapTeamModify.jsp | 지식맵(조직별) 수정를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/map/tea/EgovComDamMapTeamDetail.jsp | 등록된 지식맵(조직별)을 조회하기 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/map/tea/EgovComDamMapTeamList.jsp | 지식맵(조직별) 목록조회를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/map/tea/EgovComDamMapTeamRegist.jsp | 지식맵(조직별) 등록를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/map/tea/EgovComDamMapTeamModify.jsp | 지식맵(조직별) 수정를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/map/tea/EgovComDamMapTeamDetail.jsp | 등록된 지식맵(조직별)을 조회하기 위한 jsp페이지 |
 | Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_altibase.xml | 지식맵(조직별) 관리를 위한 Altibase용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_cubrid.xml | 지식맵(조직별) 관리를 위한 Cubrid용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_maria.xml | 지식맵(조직별) 관리를 위한 MariaDB용 Query XML |

--- a/common-component/digital-asset-management/personal-knowledge-manage.md
+++ b/common-component/digital-asset-management/personal-knowledge-manage.md
@@ -37,10 +37,10 @@ menu:
 | DAO | egovframework.com.dam.per.service.impl.KnoPersonalDAO.java | 개인지식 관리를 위한 데이터처리 클래스 |
 | Model | egovframework.com.dam.per.service.KnoPersonal.java | 개인지식 관리를 위한 Model 클래스 |
 | VO | egovframework.com.dam.per.service.KnoPersonalVO.java | 개인지식 관리를 위한 VO 클래스 |
-| JSP | /WEB-INF/jsp/egovframework/dam/per/EgovComDamPersonalList.jsp | 개인지식 목록조회를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/per/EgovComDamPersonalRegist.jsp | 개인지식 등록를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/per/EgovComDamPersonalModify.jsp | 개인지식 수정를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/per/EgovComDamPersonalDetail.jsp | 등록된 개인지식을 조회하기 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalList.jsp | 개인지식 목록조회를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalRegist.jsp | 개인지식 등록를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalModify.jsp | 개인지식 수정를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalDetail.jsp | 등록된 개인지식을 조회하기 위한 jsp페이지 |
 | Query XML | resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal\_SQL\_altibase.xml | 개인지식 관리를 위한 Altibase용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal\_SQL\_cubrid.xml | 개인지식 관리를 위한 Cubrid용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal\_SQL\_maria.xml | 개인지식 관리를 위한 MariaDB용 Query XML |

--- a/common-component/digital-asset-management/type-knowledge-map-management.md
+++ b/common-component/digital-asset-management/type-knowledge-map-management.md
@@ -38,10 +38,10 @@ menu:
 | DAO | egovframework.com.dam.map.mat.service.impl.MapMaterialDAO.java | 지식맵(유형별) 관리를 위한 데이터처리 클래스 |
 | Model | egovframework.com.dam.map.mat.service.MapMaterial.java | 지식맵(유형별) 관리를 위한 Model 클래스 |
 | VO | egovframework.com.dam.map.mat.service.MapMaterialVO.java | 지식맵(유형별) 관리를 위한 VO 클래스 |
-| JSP | /WEB-INF/jsp/egovframework/dam/map/mat/EgovComDamMapMaterialList.jsp | 지식맵(유형별) 목록조회를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/map/mat/EgovComDamMapMaterialRegist.jsp | 지식맵(유형별) 등록를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/map/mat/EgovComDamMapMaterialModify.jsp | 지식맵(유형별) 수정를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/dam/map/mat/EgovComDamMapMaterialDetail.jsp | 등록된 지식맵(유형별)을 조회하기 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/map/mat/EgovComDamMapMaterialList.jsp | 지식맵(유형별) 목록조회를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/map/mat/EgovComDamMapMaterialRegist.jsp | 지식맵(유형별) 등록를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/map/mat/EgovComDamMapMaterialModify.jsp | 지식맵(유형별) 수정를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/dam/map/mat/EgovComDamMapMaterialDetail.jsp | 등록된 지식맵(유형별)을 조회하기 위한 jsp페이지 |
 | Query XML | resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial\_SQL\_altibase.xml | 지식맵(유형별) 관리를 위한 Altibase용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial\_SQL\_cubrid.xml | 지식맵(유형별) 관리를 위한 Cubrid용 Query XML |
 | Query XML | resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial\_SQL\_maria.xml | 지식맵(유형별) 관리를 위한 MariaDB용 Query XML |

--- a/common-component/elementary-technology/send-receive-monitoring.md
+++ b/common-component/elementary-technology/send-receive-monitoring.md
@@ -38,7 +38,7 @@ menu:
 | Controller | `egovframework.com.utl.sys.trm.web.EgovTrsmrcvMntrngController.java` | 송수신모니터링을 위한 컨트롤러 클래스 |
 | Service | `egovframework.com.utl.sys.trm.service.EgovTrsmrcvMntrngService.java` | 송수신모니터링을 위한 서비스 인터페이스 |
 | ServiceImpl | `egovframework.com.utl.sys.trm.service.impl.EgovTrsmrcvMntrngServiceImpl.java` | 송수신모니터링을 위한 서비스 구현 클래스 |
-| DAO | `egovframework.com.utl.sys.trm.service.impl.TrsmrcvMntrngDAO.java` | 송수신모니터링을 위한 데이터처리 클래스 |
+| DAO | `egovframework.com.utl.sys.trm.service.impl.TrsmrcvMntrngDao.java` | 송수신모니터링을 위한 데이터처리 클래스 |
 | Model | `egovframework.com.utl.sys.trm.service.TrsmrcvMntrng.java` | 송수신모니터링을 위한 Model 클래스 |
 | Model | `egovframework.com.utl.sys.trm.service.TrsmrcvMntrngLog.java` | 송수신모니터링로그정보를 위한 Model 클래스 |
 | JSP | `/WEB-INF/jsp/egovframework/utl/sys/trm/EgovTrsmrcvMntrngList.jsp` | 송수신모니터링목록조회를 위한 JSP 페이지 |

--- a/common-component/system-management/backup-management.md
+++ b/common-component/system-management/backup-management.md
@@ -47,8 +47,8 @@ menu:
 | Service | egovframework.com.sym.sym.bak.service.EgovBackupResultService.java | 백업결과 관리를 위한 서비스 인터페이스 |
 | ServiceImpl | egovframework.com.sym.sym.bak.service.impl.EgovBackupOpertServiceImpl.java | 백업작업 관리를 위한 서비스 구현 클래스 |
 | ServiceImpl | egovframework.com.sym.sym.bak.service.impl.EgovBackupResultServiceImpl.java | 백업결과 관리를 위한 서비스 구현 클래스 |
-| DAO | egovframework.com.sym.sym.bak.service.impl.BackupOpertDAO.java | 백업작업 관리를 위한 데이터처리 클래스 |
-| DAO | egovframework.com.sym.sym.bak.service.impl.BackupResultDAO.java | 백업결과 관리를 위한 데이터처리 클래스 |
+| DAO | egovframework.com.sym.sym.bak.service.impl.BackupOpertDao.java | 백업작업 관리를 위한 데이터처리 클래스 |
+| DAO | egovframework.com.sym.sym.bak.service.impl.BackupResultDao.java | 백업결과 관리를 위한 데이터처리 클래스 |
 | Model | egovframework.com.sym.sym.bak.service.BackupOpert.java | 백업작업 관리를 위한 Model 클래스 |
 | Model | egovframework.com.sym.sym.bak.service.BackupResult.java | 백업결과 관리를 위한 Model 클래스 |
 | JSP | /WEB-INF/jsp/egovframework/com/sym/sym/bak/EgovBackupOpertList.jsp | 백업작업 목록조회를 위한 jsp페이지 |

--- a/common-component/system-management/batch-job-management.md
+++ b/common-component/system-management/batch-job-management.md
@@ -34,7 +34,7 @@ menu:
 | Controller | egovframework.com.sym.bat.web.EgovBatchOpertController.java | 배치작업 관리를 위한 컨트롤러 클래스 |
 | Service | egovframework.com.sym.bat.service.EgovBatchOpertService.java | 배치작업 관리를 위한  서비스 인터페이스 |
 | ServiceImpl | egovframework.com.sym.bat.service.impl.EgovBatchOpertServiceImpl.java | 배치작업 관리를 위한 서비스 구현 클래스 |
-| DAO | egovframework.com.sym.bat.service.impl.BatchOpertDAO.java | 배치작업 관리를 위한 데이터처리 클래스 |
+| DAO | egovframework.com.sym.bat.service.impl.BatchOpertDao.java | 배치작업 관리를 위한 데이터처리 클래스 |
 | Model | egovframework.com.sym.bat.service.BatchOpert.java | 배치작업 관리를 위한 Model 클래스 |
 | JSP | /WEB-INF/jsp/egovframework/com/sym/bat/EgovBatchOpertList.jsp | 배치작업 목록조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/sym/bat/EgovBatchOpertRegist.jsp | 배치작업 등록을 위한 jsp페이지 |

--- a/common-component/system-management/batch-result-management.md
+++ b/common-component/system-management/batch-result-management.md
@@ -32,7 +32,7 @@ menu:
 | Controller | egovframework.com.sym.bat.web.EgovBatchResultController.java | 배치결과 관리를 위한 컨트롤러 클래스 |
 | Service | egovframework.com.sym.bat.service.EgovBatchResultService.java | 배치결과 관리를 위한  서비스 인터페이스 |
 | ServiceImpl | egovframework.com.sym.bat.service.impl.EgovBatchResultServiceImpl.java | 배치결과 관리를 위한 서비스 구현 클래스 |
-| DAO | egovframework.com.sym.bat.service.impl.BatchResultDAO.java | 배치결과 관리를 위한 데이터처리 클래스 |
+| DAO | egovframework.com.sym.bat.service.impl.BatchResultDao.java | 배치결과 관리를 위한 데이터처리 클래스 |
 | Model | egovframework.com.sym.bat.service.BatchResult.java | 배치결과 관리를 위한 Model 클래스 |
 | JSP | /WEB-INF/jsp/egovframework/com/sym/bat/EgovBatchResultList.jsp | 배치결과 목록조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/sym/bat/EgovBatchResultDetail.jsp | 등록된 배치결과를 조회하기 위한 jsp페이지 |

--- a/common-component/system-management/schedule-processing.md
+++ b/common-component/system-management/schedule-processing.md
@@ -36,7 +36,7 @@ menu:
 | Controller | egovframework.com.sym.bat.web.EgovBatchSchdulController.java | 배치스케줄 관리를 위한 컨트롤러 클래스 |
 | Service | egovframework.com.sym.bat.service.EgovBatchSchdulService.java | 배치스케줄 관리를 위한 서비스 인터페이스 |
 | ServiceImpl | egovframework.com.sym.bat.service.impl.EgovBatchSchdulServiceImpl.java | 배치스케줄 관리를 위한 서비스 구현 클래스 |
-| DAO | egovframework.com.sym.bat.service.impl.BatchSchdulDAO.java | 배치스케줄 관리를 위한 데이터처리 클래스 |
+| DAO | egovframework.com.sym.bat.service.impl.BatchSchdulDao.java | 배치스케줄 관리를 위한 데이터처리 클래스 |
 | Model | egovframework.com.sym.bat.service.BatchSchdul.java | 배치스케줄 관리를 위한 Model 클래스 |
 | JSP | /WEB-INF/jsp/egovframework/com/sym/bat/EgovBatchSchdulList.jsp | 배치스케줄 목록조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/sym/bat/EgovBatchSchdulRegist.jsp | 배치스케줄 등록을 위한 jsp페이지 |

--- a/common-component/user-support/login-image.md
+++ b/common-component/user-support/login-image.md
@@ -52,7 +52,7 @@ menu:
 | QUERY XML | resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage\_SQL\_mysql.xml | 로그인화면이미지 MySQL용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage\_SQL\_oracle.xml | 로그인화면이미지 Oracle용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage\_SQL\_postgres.xml | 로그인화면이미지 Postgres용 QUERY XML |
-| QUERY XML | resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage\_SQL\_Tibero.xml | 로그인화면이미지 Tibero용 QUERY XML |
+| QUERY XML | resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage\_SQL\_tibero.xml | 로그인화면이미지 Tibero용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage\_SQL\_goldilocks.xml | 로그인화면이미지 Goldilocks용 QUERY XML |
 | Message properties | resources/egovframework/message/com/uss/ion/lsi/message\_ko.properties | 로그인화면이미지관리를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/uss/ion/lsi/message\_en.properties | 로그인화면이미지관리를 위한 Message properties(영문) |


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

공통컴포넌트 가이드 전체의 관련소스 표를 `egovframe-common-components` 소스 트리와 대소문자까지 정확히 재대조하여, 발견한 불일치를 일괄 정정했습니다 (13개 문서). #707에서 정정된 것과 같은 유형의 잔여분입니다.

- **파일명 대소문자 정정 (8건)** — 실제 소스와 표기가 다른 클래스·매퍼 파일명: `BackupOpertDAO`·`BackupResultDAO`·`BatchOpertDAO`·`BatchResultDAO`·`BatchSchdulDAO`·`TrsmrcvMntrngDAO` → 실제 `~Dao.java`, `EgovSms_SQL_Tibero.xml`·`EgovLoginScrinImage_SQL_Tibero.xml` → 실제 `_tibero.xml`
- **지식관리(dam) JSP 경로 보완 (22건, 6개 문서)** — `/WEB-INF/jsp/egovframework/dam/…` → 실제 `/WEB-INF/jsp/egovframework/com/dam/…` (`com/` 세그먼트 누락)
- 문자메시지서비스: 현행 소스에 없는 Validator XML 행 2건 제외 (Jakarta Bean Validation 전환으로 validator 디렉토리 미존재)

frontmatter는 수정하지 않았습니다.

## 관련 이슈 (Related Issues)

- 없음

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

검증 방법: 검토한 문서의 FQCN·JSP·매퍼 경로를 소스 저장소의 `git ls-files` 목록과 문자열 단위(대소문자 구분)로 대조했습니다.