### PR TITLE
fix: 가이드 관련소스 정정 — 구 경로·축약 표기·미존재 항목 정리

### DIFF
--- a/common-component/collaboration/community-use.md
+++ b/common-component/collaboration/community-use.md
@@ -41,15 +41,14 @@ menu:
 | DAO | egovframework.com.cop.cmy.service.impl.EgovCommuMasterDAO.java | 커뮤니티 관리를 위한 데이터처리 클래스 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/cmy/EgovCommuMain.jsp | 커뮤니티 메인을 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/cmy/EgovCmmntyBaseTmplContents.jsp | 커뮤니티 메인에서 대표 게시판 표시를 위한 jsp페이지 |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuManage_SQL_mysql.xml | 커뮤니티 메인을 위한 MySQL용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuManage_SQL_cubrid.xml | 커뮤니티 메인을 위한 Cubrid용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuManage_SQL_oracle.xml | 커뮤니티 메인을 위한 Oracle용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuManage_SQL_tibero.xml | 커뮤니티 메인을 위한 Tibero용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuManage_SQL_altibase.xml | 커뮤니티 메인을 위한 Altibase용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuManage_SQL_postgres.xml | 커뮤니티 메인을 위한 Postgres용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuManage_SQL_maria.xml | 커뮤니티 메인을 위한 Maria용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuManage_SQL_goldilocks.xml | 커뮤니티 메인을 위한 Goldilocks용 Query |
-| Validator XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuManage_SQL_goldilocks.xml | 커뮤니티 관리를위한 Validator XML |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_mysql.xml | 커뮤니티 메인을 위한 MySQL용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_cubrid.xml | 커뮤니티 메인을 위한 Cubrid용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_oracle.xml | 커뮤니티 메인을 위한 Oracle용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_tibero.xml | 커뮤니티 메인을 위한 Tibero용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_altibase.xml | 커뮤니티 메인을 위한 Altibase용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_postgres.xml | 커뮤니티 메인을 위한 Postgres용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_maria.xml | 커뮤니티 메인을 위한 Maria용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_goldilocks.xml | 커뮤니티 메인을 위한 Goldilocks용 Query |
 | Message properties | resources/egovframework/message/com/cop/cmy/message_ko.properties | 커뮤니티 관리를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/cmy/message_en.properties | 커뮤니티 관리를 위한 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-Cmmnty.xml | 커뮤니티 관리를 위한 Id생성 Idgen XML |
@@ -111,8 +110,8 @@ N/A
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /cop/bbs/selectBBSMasterInfs.do | selectBdMstrListByTrget | “BBSAttributeManageDAO.selectBdMstrListByTrget”, |
-| | | | “BBSAttributeManageDAO.selectBdMstrListCntByTrget” |
+| 목록조회 | /cop/bbs/selectBBSMasterInfs.do | selectBBSMasterInfs | "EgovBBSMasterDAO.selectBBSMasterList", |
+| | | | "EgovBBSMasterDAO.selectBBSMasterListTotCnt" |
 
 게시판관리 목록은 기본적인 페이징 처리가 되며 다음과 같은 정보를 제공한다.
 
@@ -137,7 +136,7 @@ N/A
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
 | 등록화면 | /cop/bbs/insertBBSMasterView.do | insertBBSMasterView | |
-| 등록 | /cop/bbs/insertBBSMaster.do | insertBBSMaster | “BBSMaster.insertBBSMaster” |
+| 등록 | /cop/bbs/insertBBSMaster.do | insertBBSMaster | "BBSMaster.insertBBSMaster" |
 
 게시판관리 목록조회 화면에서 상단의 등록 버튼을 선택하면 다음과 같은 등록화면으로 이동한다.
 
@@ -161,7 +160,7 @@ N/A
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세보기화면 | /cop/bbs/selectBBSMasterDetail.do | selectBBSMasterDetail | “BBSMaster.selectBBSMasterDetail” |
+| 상세보기화면 | /cop/bbs/selectBBSMasterDetail.do | selectBBSMasterDetail | "BBSMaster.selectBBSMasterDetail" |
 
 게시판관리 목록에서 게시판명을 선택하면 게시판에 대한 속성정보를 수정할 수 있는 수정화면으로 이동한다.
 
@@ -181,8 +180,8 @@ N/A
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정화면 | /cop/bbs/updateBBSMasterView.do | updateBBSMasterView | “BBSMaster.selectBBSMasterDetail” |
-| 수정 | /cop/bbs/updateBBSMaster.do | updateBBSMaster | “BBSMaster.updateBBSMaster” |
+| 수정화면 | /cop/bbs/updateBBSMasterView.do | updateBBSMasterView | "BBSMaster.selectBBSMasterDetail" |
+| 수정 | /cop/bbs/updateBBSMaster.do | updateBBSMaster | "BBSMaster.updateBBSMaster" |
 
 게시판관리 목록에서 게시판명을 선택하면 게시판에 대한 속성정보를 수정할 수 있는 수정화면으로 이동한다.
 

--- a/common-component/collaboration/executive-schedule.md
+++ b/common-component/collaboration/executive-schedule.md
@@ -68,9 +68,6 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_postgres.xml | 간부일정관리를 위한 PostgreSQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_tibero.xml | 간부일정관리를 위한 Tibero용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_goldilocks.xml | 간부일정관리를 위한 Goldilocks용 Query XML |
-| Validator Rule XML | resources/egovframework/validator/validator-rules.xml | Validator Rule을 정의한 XML |
-| Validator XML | resources/egovframework/validator/com/cop/smt/lsm/EgovLeaderSchdul.xml | 간부일정관리를 위한 Validator XML |
-| Validator XML | resources/egovframework/validator/com/cop/smt/lsm/EgovLeaderSttus.xml | 간부일정관리를 위한 Validator XML |
 | Message properties | resources/egovframework/message/com/cop/smt/lsm/message_en.properties | 간부일정관리를 위한 Message properties(영문) |
 | Message properties | resources/egovframework/message/com/cop/smt/lsm/message_ko.properties | 간부일정관리를 위한 Message properties(한글) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-LeaderSchdu.xml | 간부일정관리를 위한 Id생성 Idgen XML |
@@ -135,7 +132,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 월별 목록조회 | /cop/smt/lsm/usr/selectLeaderSchdulMonthList.do | selectLeaderSchdulMonthList | “LeaderSchdulDAO” | “selectLeaderSchdulList” |
+| 월별 목록조회 | /cop/smt/lsm/usr/selectLeaderSchdulMonthList.do | selectLeaderSchdulMonthList | "LeaderSchdulDAO" | "selectLeaderSchdulList" |
 
 ![월별 간부일정 목록조회](./images/executive-schedule-month-list.png)
 
@@ -159,7 +156,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 주별 목록조회 | /cop/smt/lsm/usr/selectLeaderSchdulWeekList.do | selectLeaderSchdulWeekList | “LeaderSchdulDAO” | “selectLeaderSchdulList” |
+| 주별 목록조회 | /cop/smt/lsm/usr/selectLeaderSchdulWeekList.do | selectLeaderSchdulWeekList | "LeaderSchdulDAO" | "selectLeaderSchdulList" |
 
 ![주별 간부일정 목록조회](./images/executive-schedule-week-list.png)
 
@@ -183,7 +180,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 일별 목록조회 | /cop/smt/lsm/usr/selectLeaderSchdulDailyList.do | selectLeaderSchdulDailyList | “LeaderSchdulDAO” | “selectLeaderSchdulList” |
+| 일별 목록조회 | /cop/smt/lsm/usr/selectLeaderSchdulDailyList.do | selectLeaderSchdulDailyList | "LeaderSchdulDAO" | "selectLeaderSchdulList" |
 
 ![일별 간부일정 목록조회](./images/executive-schedule-daily-list.png)
 
@@ -206,7 +203,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 등록화면 | /cop/smt/lsm/mng/addLeaderSchdul.do | addLeaderSchdul | | |
-| 등록 | /cop/smt/lsm/mng/insertLeaderSchdul.do | insertLeaderSchdul | “LeaderSchdulDAO” | “insertLeaderSchdul” |
+| 등록 | /cop/smt/lsm/mng/insertLeaderSchdul.do | insertLeaderSchdul | "LeaderSchdulDAO" | "insertLeaderSchdul" |
 
 ![간부일정 등록](./images/executive-schedule-insert.png)
 
@@ -236,7 +233,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 수정 | /cop/smt/lsm/mng/updateLeaderSchdul.do | updateLeaderSchdul | “LeaderSchdulDAO” | “updateLeaderSchdul” |
+| 수정 | /cop/smt/lsm/mng/updateLeaderSchdul.do | updateLeaderSchdul | "LeaderSchdulDAO" | "updateLeaderSchdul" |
 
 ![간부일정 수정](./images/executive-schedule-update.png)
 
@@ -258,8 +255,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /cop/smt/lsm/usr/selectLeaderSchdul.do | selectLeaderSchdul | “LeaderSchdulDAO” | “selectLeaderSchdul” |
-| 삭제 | /cop/smt/lsm/mng/deleteLeaderSchdul.do | deleteLeaderSchdul | “LeaderSchdulDAO” | “deleteLeaderSchdul” |
+| 상세조회 | /cop/smt/lsm/usr/selectLeaderSchdul.do | selectLeaderSchdul | "LeaderSchdulDAO" | "selectLeaderSchdul" |
+| 삭제 | /cop/smt/lsm/mng/deleteLeaderSchdul.do | deleteLeaderSchdul | "LeaderSchdulDAO" | "deleteLeaderSchdul" |
 
 ![간부일정 상세조회](./images/executive-schedule-detail.png)
 

--- a/common-component/collaboration/template-management.md
+++ b/common-component/collaboration/template-management.md
@@ -53,7 +53,6 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_goldilocks.xml | 템플릿 관리를 위한 Goldilocks용 Query XML |
 | Message properties | resources/egovframework/message/com/cop/tpl/message_ko.properties | 템플릿 관리 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/tpl/message_en.properties | 템플릿 관리 Message properties(영문) |
-| Validator Rule XML | resources/egovframework/validator/validator-rules.xml | Validator Rule을 정의한 XML |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-Tmplat.xml | 템플릿 관리를위한 Id생성 Idgen XML |
 
 ### 클래스 다이어그램
@@ -118,9 +117,9 @@ N/A
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /cop/tpl/selectTemplateInfs.do | selectTemplateInfs | “TemplateManageDAO.selectTemplateInfs”, |
-| | | | “TemplateManageDAO.selectTemplateInfsCnt” |
-| 팝업 목록조회 | /cop/tpl/selectTemplateInfsPop.do | selectTemplateInfsPop | “TemplateManageDAO.selectTemplateInfs” |
+| 목록조회 | /cop/tpl/selectTemplateInfs.do | selectTemplateInfs | "TemplateManageDAO.selectTemplateInfs", |
+| | | | "TemplateManageDAO.selectTemplateInfsCnt" |
+| 팝업 목록조회 | /cop/tpl/selectTemplateInfsPop.do | selectTemplateInfsPop | "TemplateManageDAO.selectTemplateInfs" |
 
 ![템플릿 목록조회](./images/template-management-list.png)
 
@@ -138,9 +137,9 @@ N/A
 
 #### 템플릿 경로설정
 
-동호회 및 커뮤니티 템플릿 등록 시 해당 템플릿(JSP 파일)의 경로를 “egovframework/com/cop/tpl/” 아래로 지정한다.
+동호회 및 커뮤니티 템플릿 등록 시 해당 템플릿(JSP 파일)의 경로를 "egovframework/com/cop/tpl/" 아래로 지정한다.
 
-게시판 템플릿 등록 시 해당 템플릿(CSS 파일)의 경로를 ”/css/egovframework/com/cop/tpl/” 아래로 지정한다.
+게시판 템플릿 등록 시 해당 템플릿(CSS 파일)의 경로를 "/css/egovframework/com/cop/tpl/" 아래로 지정한다.
 
 ```text
 동호회 기본템플릿 경로: "egovframework/com/cop/tpl/EgovClbBaseTmpl" 
@@ -157,7 +156,7 @@ N/A
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
 | 등록화면 | /cop/tpl/addTemplateInf.do | addTemplateInf | |
-| 등록 | /cop/tpl/insertTemplateInf.do | insertTemplateInf | “TemplateManageDAO.insertTemplateInf” |
+| 등록 | /cop/tpl/insertTemplateInf.do | insertTemplateInf | "TemplateManageDAO.insertTemplateInf" |
 
 ![템플릿 등록](./images/template-management-insert.png)
 
@@ -181,7 +180,7 @@ N/A
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /cop/tpl/updateTemplateInf.do | updateTemplateInf | “TemplateManageDAO.updateTemplateInf” |
+| 수정 | /cop/tpl/updateTemplateInf.do | updateTemplateInf | "TemplateManageDAO.updateTemplateInf" |
 
 ![템플릿 수정](./images/template-management-update.png)
 

--- a/common-component/elementary-technology/proxy-service.md
+++ b/common-component/elementary-technology/proxy-service.md
@@ -36,26 +36,24 @@ menu:
 | DAO | egovframework.com.utl.sys.pxy.service.impl.ProxySvcDAO.java | 정보관리 DAO |
 | Model | egovframework.com.utl.sys.pxy.service.ProxySvc.java | 정보관리 모델 |
 | Model | egovframework.com.utl.sys.pxy.service.ProxyLog.java | 로그관리 모델 |
-| VO | egovframework.com.utl.sys.pxy.service.ProxySvcVO.java | 정보관리 VO |
-| VO | egovframework.com.utl.sys.pxy.service.ProxyLogVO.java | 로그관리 VO |
+| Model | egovframework.com.utl.sys.pxy.service.ProxySvc.java | 정보관리 Model |
+| Model | egovframework.com.utl.sys.pxy.service.ProxyLog.java | 로그관리 Model |
 | JSP | /WEB-INF/jsp/egovframework/com/utl/sys/pxy/EgovProxyLogList.jsp | 로그조회 화면 |
 | JSP | /WEB-INF/jsp/egovframework/com/utl/sys/pxy/EgovProxySvcList.jsp | 목록조회 화면 |
 | JSP | /WEB-INF/jsp/egovframework/com/utl/sys/pxy/EgovProxySvcDetail.jsp | 상세조회 화면 |
 | JSP | /WEB-INF/jsp/egovframework/com/utl/sys/pxy/EgovProxySvcRegist.jsp | 등록 화면 |
 | JSP | /WEB-INF/jsp/egovframework/com/utl/sys/pxy/EgovProxySvcUpdt.jsp | 수정 화면 |
-| Query XML | resources/.../EgovProxySvc_SQL_altibase.xml | Altibase용 Query XML |
-| Query XML | resources/.../EgovProxySvc_SQL_cubrid.xml | Cubrid용 Query XML |
-| Query XML | resources/.../EgovProxySvc_SQL_maria.xml | MariaDB용 Query XML |
-| Query XML | resources/.../EgovProxySvc_SQL_mysql.xml | MySQL용 Query XML |
-| Query XML | resources/.../EgovProxySvc_SQL_oracle.xml | Oracle용 Query XML |
-| Query XML | resources/.../EgovProxySvc_SQL_postgres.xml | PostgreSQL용 Query XML |
-| Query XML | resources/.../EgovProxySvc_SQL_tibero.xml | Tibero용 Query XML |
-| Query XML | resources/.../EgovProxySvc_SQL_goldilocks.xml | Goldilocks용 Query XML |
-| Validator Rule | resources/egovframework/validator/validator-rules.xml | Validator Rule XML |
-| Validator XML | resources/.../validator/com/utl/sys/pxy/EgovProxySvc.xml | Validator XML |
-| Message prop | resources/.../message/com/utl/sys/pxy/message_en.properties | 영문 Message |
-| Message prop | resources/.../message/com/utl/sys/pxy/message_ko.properties | 한글 Message |
-| Idgen XML | resources/.../spring/com/idgn/context-idgn-ProxySvc.xml | Idgen XML |
+| Query XML | resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_altibase.xml | Altibase용 Query XML |
+| Query XML | resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_cubrid.xml | Cubrid용 Query XML |
+| Query XML | resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_maria.xml | MariaDB용 Query XML |
+| Query XML | resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_mysql.xml | MySQL용 Query XML |
+| Query XML | resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_oracle.xml | Oracle용 Query XML |
+| Query XML | resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_postgres.xml | PostgreSQL용 Query XML |
+| Query XML | resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_tibero.xml | Tibero용 Query XML |
+| Query XML | resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_goldilocks.xml | Goldilocks용 Query XML |
+| Message prop | resources/egovframework/message/com/utl/sys/pxy/message_en.properties | 영문 Message |
+| Message prop | resources/egovframework/message/com/utl/sys/pxy/message_ko.properties | 한글 Message |
+| Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-ProxySvc.xml | Idgen XML |
 
 ### 클래스 다이어그램
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

공통컴포넌트 가이드의 관련소스 표를 `egovframe-common-components` 소스 트리와 대조하여, 실제 소스와 불일치하는 표기를 정정했습니다 (4개 문서).

- **커뮤니티사용** — Query XML 경로 구 iBatis `sqlmap` → 현행 `mapper` (9건), 매퍼 경로가 잘못 기재된 Validator XML 행 1건 제외, 목록조회 기능의 Controller method·QueryID `selectBdMstrListByTrget`(미존재) → 실제 `selectBBSMasterInfs`·`EgovBBSMasterDAO.selectBBSMasterList(+TotCnt)`로 정정- **프록시서비스** — `resources/.../` 축약 표기 11건을 실제 경로(`mapper/com/utl/sys/pxy/` 등)로 전개, 현재 소스에 없는 `ProxySvcVO`·`ProxyLogVO` → 실제 클래스 `ProxySvc`·`ProxyLog`(Model)로 정정, 미존재 Validator XML 행 2건 제외
- **간부일정관리·템플릿관리** — 현행 소스에 없는 Validator XML 행 제외 (Jakarta Bean Validation 전환으로 validator 디렉토리 미존재)
- 표기 정리: 세 문서의 인용부호를 곧은따옴표로 통일

frontmatter는 수정하지 않았으며, 정정 항목은 소스 저장소 대소문자 단위로 대조해 실존을 확인했습니다

## 관련 이슈 (Related Issues)

- 없음

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

**가이드 페이지**
- [커뮤니티사용](https://egovframework.github.io/egovframe-docs/common-component/collaboration/community/community-use/) · [간부일정관리](https://egovframework.github.io/egovframe-docs/common-component/collaboration/schedule-manage/executive-schedule/) · [템플릿관리](https://egovframework.github.io/egovframe-docs/common-component/collaboration/board/template-management/)
- [프록시서비스](https://egovframework.github.io/egovframe-docs/common-component/elementary-technology/system/proxy-service/)