### PR TITLE
fix: 보안·로그인인증 가이드 관련소스 소스 대조 정정 및 인용부호 통일 (12건)

### DIFF
--- a/common-component/security/authority-group-management.md
+++ b/common-component/security/authority-group-management.md
@@ -93,8 +93,8 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /sec/rgm/EgovAuthorGroupList.do | selectAuthorGroupList | “authorGroupDAO” | “selectAuthorGroupList” |
-|  |  |  | “authorGroupDAO” | “selectAuthorGroupListTotCnt” |
+| 목록조회 | /sec/rgm/EgovAuthorGroupList.do | selectAuthorGroupList | "authorGroupDAO" | "selectAuthorGroupList" |
+|  |  |  | "authorGroupDAO" | "selectAuthorGroupListTotCnt" |
 
  ![권한그룹목록 조회](./images/rgm-author_group_manage.png)
 
@@ -116,8 +116,8 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 등록 | /sec/rgm/EgovAuthorGroupInsert.do | insertAuthorGroup | “authorGroupDAO” | “insertAuthorGroup” |
-| 수정 | /sec/rgm/EgovAuthorGroupInsert.do | insertAuthorGroup | “authorGroupDAO” | “updateAuthorGroup” |
+| 등록 | /sec/rgm/EgovAuthorGroupInsert.do | insertAuthorGroup | "authorGroupDAO" | "insertAuthorGroup" |
+| 수정 | /sec/rgm/EgovAuthorGroupInsert.do | insertAuthorGroup | "authorGroupDAO" | "updateAuthorGroup" |
 
  ![권한그룹 등록 및 수정](./images/rgm-author_group_insert_update.png)
 
@@ -138,7 +138,7 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 삭제 | /sec/rgm/EgovAuthorGroupDelete.do | deleteAuthorGroup | “authorGroupDAO” | “deleteAuthorGroup” |
+| 삭제 | /sec/rgm/EgovAuthorGroupDelete.do | deleteAuthorGroup | "authorGroupDAO" | "deleteAuthorGroup" |
 
  ![권한그룹 삭제](./images/rgm-author_group_delete.png)
 
@@ -159,8 +159,8 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 조회 | /sec/gmt/EgovGroupSearchList.do | selectGroupSearchList | “groupManageDAO” | “selectGroupList” |
-|  |  |  | “groupManageDAO” | “selectGroupListTotCnt” |
+| 조회 | /sec/gmt/EgovGroupSearchList.do | selectGroupSearchList | "groupManageDAO" | "selectGroupList" |
+|  |  |  | "groupManageDAO" | "selectGroupListTotCnt" |
 
  ![그룹목록 조회 팝업](./images/rgm-author_group_popup.png)
 

--- a/common-component/security/authority-management-function.md
+++ b/common-component/security/authority-management-function.md
@@ -47,7 +47,6 @@ menu:
 | Query XML          | resources/egovframework/mapper/com/sec/ram/EgovAuthorManage_SQL_maria.xml      | 권한 관리를 위한 Maria용 Query XML       |
 | Query XML          | resources/egovframework/mapper/com/sec/ram/EgovAuthorManage_SQL_postgres.xml   | 권한 관리를 위한 Postgres용 Query XML    |
 | Query XML          | resources/egovframework/mapper/com/sec/ram/EgovAuthorManage_SQL_goldilocks.xml | 권한 관리를 위한 Goldilocks용 Query XML  |
-| Validator XML      | resources/egovframework/validator/com/sec/ram/SecurityManage.xml               | 권한 관리를 위한 Validator XML          |
 | Message properties | resources/egovframework/message/com/sec/ram/message_ko.properties              | 권한 관리를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/sec/ram/message_en.properties              | 권한 관리를 위한 Message properties(영문) |
 

--- a/common-component/security/authority-role-management.md
+++ b/common-component/security/authority-role-management.md
@@ -57,7 +57,6 @@ menu:
 | Query XML          | resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_maria.xml      | 권한별 롤 관리를 위한 Maria용 Query XML       |
 | Query XML          | resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_postgres.xml   | 권한별 롤 관리를 위한 Postgres용 Query XML    |
 | Query XML          | resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_goldilocks.xml | 권한별 롤 관리를 위한 Goldilocks용 Query XML  |
-| Validator XML      | resources/egovframework/validator/com/sec/ram/SecurityManage.xml                   | 권한별 롤 관리를 위한 Validator XML          |
 | Message properties | resources/egovframework/message/com/sec/ram/message_ko.properties                  | 권한별 롤 관리를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/sec/ram/message_en.properties                  | 권한별 롤 관리를 위한 Message properties(영문) |
 

--- a/common-component/security/department-role-management.md
+++ b/common-component/security/department-role-management.md
@@ -91,8 +91,8 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 조회 | /sec/drm/EgovDeptAuthorList.do | selectDeptAuthorList | “deptAuthorDAO” | “selectDeptAuthorList” |
-|  |  |  | “deptAuthorDAO” | “selectDeptAuthorListTotCnt” |
+| 조회 | /sec/drm/EgovDeptAuthorList.do | selectDeptAuthorList | "deptAuthorDAO" | "selectDeptAuthorList" |
+|  |  |  | "deptAuthorDAO" | "selectDeptAuthorListTotCnt" |
 
  ![부서권한목록 조회](./images/drm-dept_author_manage.png)
 
@@ -113,8 +113,8 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 등록 | /sec/drm/EgovDeptAuthorInsert.do | insertDeptAuthor | “deptAuthorDAO” | “insertDeptAuthor” |
-| 수정 | /sec/drm/EgovDeptAuthorInsert.do | insertDeptAuthor | “deptAuthorDAO” | “updateDeptAuthor” |
+| 등록 | /sec/drm/EgovDeptAuthorInsert.do | insertDeptAuthor | "deptAuthorDAO" | "insertDeptAuthor" |
+| 수정 | /sec/drm/EgovDeptAuthorInsert.do | insertDeptAuthor | "deptAuthorDAO" | "updateDeptAuthor" |
 
  ![부서권한 등록 및 수정](./images/drm-dept_author_insert.png)
 
@@ -135,7 +135,7 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 삭제 | /sec/drm/EgovDeptAuthorDelete.do | deleteDeptAuthor | “deptAuthorDAO” | “deleteDeptAuthor” |
+| 삭제 | /sec/drm/EgovDeptAuthorDelete.do | deleteDeptAuthor | "deptAuthorDAO" | "deleteDeptAuthor" |
 
  ![부서권한 삭제](./images/drm-dept_author_delete.png)
 
@@ -156,8 +156,8 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 조회 | /sec/drm/EgovDeptSearchList.do | selectDeptList | “deptAuthorDAO” | “selectDeptList” |
-|  |  |  | “deptAuthorDAO” | “selectDeptListTotCnt” |
+| 조회 | /sec/drm/EgovDeptSearchList.do | selectDeptList | "deptAuthorDAO" | "selectDeptList" |
+|  |  |  | "deptAuthorDAO" | "selectDeptListTotCnt" |
 
  ![부서목록 조회 팝업](./images/drm-dept_author_popup.png)
 

--- a/common-component/security/encrypt_decrypt.md
+++ b/common-component/security/encrypt_decrypt.md
@@ -40,8 +40,6 @@
 | 유형 | 대상소스 | 비고 |
 | --- | --- | --- |
 | Controller | egovframework.com.sec.pki.web.EgovCryptoController.java | 암호화/복호화 테스트를 위한 컨트롤러 클래스 |
-| Service | egovframework.com.sec.pki.service.EgovGPKIService.java | 암호화/복호화를 위한 서비스 인터페이스 |
-| ServiceImpl | egovframework.com.sec.pki.service.impl.EgovGPKIServiceImpl.java | 암호화/복호화를 위한 서비스 구현 클래스 |
 | JSP | /WEB-INF/jsp/egovframework/com/sec/pki/EgovCryptoInfo.jsp | 암호화/복호화 테스트를 위한 jsp페이지 |
 | Message properties | resources/egovframework/message/com/sec/pki/message\_ko.properties | 암호화/복호화를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/sec/pki/message\_en.properties | 암호화/복호화를 위한 Message properties(영문) |
@@ -118,7 +116,7 @@ cryptoService.decryptNone(decrypt); // 복호화전에 URLDecoding 처리 안함
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 테스트조회 | /sec/pki/EgovCryptoInfo.do | displayCryptoInfo | ”“ | ”“ |
+| 테스트조회 | /sec/pki/EgovCryptoInfo.do | displayCryptoInfo | "" | "" |
 
  ![암복호화 테스트화면](./images/sec-ariatest.jpg)
 

--- a/common-component/security/group-management.md
+++ b/common-component/security/group-management.md
@@ -53,14 +53,14 @@
 | JSP | /WEB-INF/jsp/egovframework/com/sec/gmt/EgovGroupInsert.jsp | 그룹 등록를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/sec/gmt/EgovGroupUpdate.jsp | 그룹 수정를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/sec/gmt/EgovGroupSearch.jsp | 그룹 조회를 위한 jsp페이지 |
-| QUERY XML | resources/egovframework/mapper/com/sec/gmt/GroupManage\_SQL\_mysql.xml | 그룹 관리를 위한 MySQL용 QUERY XML |
-| QUERY XML | resources/egovframework/mapper/com/sec/gmt/GroupManage\_SQL\_cubrid.xml | 그룹 관리를 위한 Cubrid용 QUERY XML |
-| QUERY XML | resources/egovframework/mapper/com/sec/gmt/GroupManage\_SQL\_oracle.xml | 그룹 관리를 위한 Oracle용 QUERY XML |
-| QUERY XML | resources/egovframework/mapper/com/sec/gmt/GroupManage\_SQL\_tibero.xml | 그룹 관리를 위한 Tibero용 QUERY XML |
-| QUERY XML | resources/egovframework/mapper/com/sec/gmt/GroupManage\_SQL\_altibase.xml | 그룹 관리를 위한 Altibase용 QUERY XML |
-| QUERY XML | resources/egovframework/mapper/com/sec/gmt/GroupManage\_SQL\_maria.xml | 그룹 관리를 위한 Maria용 QUERY XML |
-| QUERY XML | resources/egovframework/mapper/com/sec/gmt/GroupManage\_SQL\_postgres.xml | 그룹 관리를 위한 Postgres용 QUERY XML |
-| QUERY XML | resources/egovframework/mapper/com/sec/gmt/GroupManage\_SQL\_goldilocks.xml | 그룹 관리를 위한 Goldilocks용 QUERY XML |
+| QUERY XML | resources/egovframework/mapper/com/sec/gmt/EgovGroupManage\_SQL\_mysql.xml | 그룹 관리를 위한 MySQL용 QUERY XML |
+| QUERY XML | resources/egovframework/mapper/com/sec/gmt/EgovGroupManage\_SQL\_cubrid.xml | 그룹 관리를 위한 Cubrid용 QUERY XML |
+| QUERY XML | resources/egovframework/mapper/com/sec/gmt/EgovGroupManage\_SQL\_oracle.xml | 그룹 관리를 위한 Oracle용 QUERY XML |
+| QUERY XML | resources/egovframework/mapper/com/sec/gmt/EgovGroupManage\_SQL\_tibero.xml | 그룹 관리를 위한 Tibero용 QUERY XML |
+| QUERY XML | resources/egovframework/mapper/com/sec/gmt/EgovGroupManage\_SQL\_altibase.xml | 그룹 관리를 위한 Altibase용 QUERY XML |
+| QUERY XML | resources/egovframework/mapper/com/sec/gmt/EgovGroupManage\_SQL\_maria.xml | 그룹 관리를 위한 Maria용 QUERY XML |
+| QUERY XML | resources/egovframework/mapper/com/sec/gmt/EgovGroupManage\_SQL\_postgres.xml | 그룹 관리를 위한 Postgres용 QUERY XML |
+| QUERY XML | resources/egovframework/mapper/com/sec/gmt/EgovGroupManage\_SQL\_goldilocks.xml | 그룹 관리를 위한 Goldilocks용 QUERY XML |
 | Message properties | resources/egovframework/message/com/sec/gmt/message\_ko.properties | 그룹 관리 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/sec/gmt/message\_en.properties | 그룹 관리 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-Group.xml | 그룹 관리 Id생성 Idgen XML |
@@ -128,8 +128,8 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 조회 | /sec/gmt/EgovGroupList.do | selectGroupList | “groupManageDAO” | “selectGroupList” |
-|  |  |  | “groupManageDAO” | “selectGroupListTotCnt” |
+| 조회 | /sec/gmt/EgovGroupList.do | selectGroupList | "groupManageDAO" | "selectGroupList" |
+|  |  |  | "groupManageDAO" | "selectGroupListTotCnt" |
 
  ![그룹 목록조회](./images/gmt-group_manage_list.png)
 
@@ -152,7 +152,7 @@
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 등록화면 | /sec/gmt/EgovGroupInsertView.do | insertGroupView |  |  |
-| 등록 | /sec/gmt/EgovGroupInsert.do | insertGroup | “groupManageDAO” | “insertGroup” |
+| 등록 | /sec/gmt/EgovGroupInsert.do | insertGroup | "groupManageDAO" | "insertGroup" |
 
  ![그룹 등록](./images/gmt-group_manage_regist.png)
 
@@ -173,8 +173,8 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 수정화면 | /sec/gmt/EgovGroup.do | selectGroup | “groupManageDAO” | “selectGroup” |
-| 수정 | /sec/gmt/EgovGroupUpdate.do | updateGroup | “groupManageDAO” | “updateGroup” |
+| 수정화면 | /sec/gmt/EgovGroup.do | selectGroup | "groupManageDAO" | "selectGroup" |
+| 수정 | /sec/gmt/EgovGroupUpdate.do | updateGroup | "groupManageDAO" | "updateGroup" |
 
  ![그룹 속성정보 수정](./images/gmt-group_manage_update.png)
 
@@ -196,7 +196,7 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 삭제 | /sec/gmt/EgovGroupDelete.do | deleteGroup | “groupManageDAO” | “deleteGroup” |
+| 삭제 | /sec/gmt/EgovGroupDelete.do | deleteGroup | "groupManageDAO" | "deleteGroup" |
 
  ![그룹삭제](./images/gmt-group_manage_delete.png)
 

--- a/common-component/security/pw_expiration_management.md
+++ b/common-component/security/pw_expiration_management.md
@@ -30,10 +30,10 @@
 | Controller | egovframework.com.cmm.web.EgovComIndexController.java | 초기 컨텐츠표시 Controller | 시간관리 표시 |
 | Service | egovframework.com.uat.uia.service.EgovLoginService | 비밀번호 만료 및 로그인 관련 서비스 인터페이스 |  |
 | ServiceImpl | egovframework.com.uat.uia.service.impl.EgovLoginServiceImpl | 비밀번호 만료 및 로그인 관련 서비스 구현 클래스 |  |
-| DAO | egovframework.com.uat.uia.service.impl.EgovLoginServiceImpl | 비밀번호 만료 및 로그인위한 데이터처리 클래스 |  |
+| DAO | egovframework.com.uat.uia.service.impl.LoginDAO | 비밀번호 만료 및 로그인을 위한 데이터처리 클래스 |  |
 | JSP | /WEB-INF/jsp/egovframework/com/cmm/EgovUnitContent.jsp | 초기 컨텐츠표시 페이지 | 시간관리 표시 팝업호출 |
 | JSP | /WEB-INF/jsp/egovframework/com/uat/uia/EgovExpirePwd.jsp | 비밀번호 만료 안내 페이지 | 시간관리 표시 팝업 |
-| Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_mysql.xml | 비밀번호 만료 및 로그인을위한 MySQL용 Query XML |
+| Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_mysql.xml | 비밀번호 만료 및 로그인을 위한 MySQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_oracle.xml | 비밀번호 만료 및 로그인을 위한 Oracle용 Query XML |
 | Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_tibero.xml | 비밀번호 만료 및 로그인을 위한 Tibero용 Query XML |
 | Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_altibase.xml | 비밀번호 만료 및 로그인을 위한 Altibase용 Query XML |
@@ -122,7 +122,7 @@ public String setContent(ModelMap model) throws Exception {
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 초기 컨텐츠 화면 | /EgovContent.do | setContent | “LoginUsr” | “selectPassedDayChangePWD” |
+| 초기 컨텐츠 화면 | /EgovContent.do | setContent | "LoginUsr" | "selectPassedDayChangePWD" |
 
 ## 관련화면
 
@@ -177,7 +177,7 @@ public String noticeExpirePwd(@RequestParam Map<String, Object> commandMap, Mode
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 비밀번호 만료 팝업 | /uat/uia/noticeExpirePwd.do | noticeExpirePwd | “LoginUsr” | “selectPassedDayChangePWD” |
+| 비밀번호 만료 팝업 | /uat/uia/noticeExpirePwd.do | noticeExpirePwd | "LoginUsr" | "selectPassedDayChangePWD" |
 
  ![image](./images/sec-pw_expiration_management_01.png)
 

--- a/common-component/security/role-management.md
+++ b/common-component/security/role-management.md
@@ -151,8 +151,8 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 조회 | /sec/rmt/EgovRoleList.do | selectRoleList | “roleManageDAO” | “selectRoleList” |
-|  |  |  | “roleManageDAO” | “selectAuthorListTotCnt” |
+| 조회 | /sec/rmt/EgovRoleList.do | selectRoleList | "roleManageDAO" | "selectRoleList" |
+|  |  |  | "roleManageDAO" | "selectAuthorListTotCnt" |
 
  ![롤목록 조회](./images/rmt-role_manage_list.png)
 
@@ -175,7 +175,7 @@
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 등록화면 | /sec/rmt/EgovRoleInsertView.do | insertRoleView |  |  |
-| 등록 | /sec/rmt/EgovRoleInsert.do | insertRole | “roleManageDAO” | “insertRole” |
+| 등록 | /sec/rmt/EgovRoleInsert.do | insertRole | "roleManageDAO" | "insertRole" |
 
  ![롤목록 등록](./images/rmt-role_manage_insert.png)
 
@@ -196,9 +196,9 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 수정화면 | /sec/rmt/EgovRole.do | selectRole | “roleManageDAO” | “selectRoleList” |
-| 수정 | /sec/rmt/EgovRoleUpdate.do | updateRole | “roleManageDAO” | “updateRole” |
-| 삭제 | /sec/rmt/EgovRoleDelete.do | deleteRole | “roleManageDAO” | “deleteRole” |
+| 수정화면 | /sec/rmt/EgovRole.do | selectRole | "roleManageDAO" | "selectRoleList" |
+| 수정 | /sec/rmt/EgovRoleUpdate.do | updateRole | "roleManageDAO" | "updateRole" |
+| 삭제 | /sec/rmt/EgovRoleDelete.do | deleteRole | "roleManageDAO" | "deleteRole" |
 
  ![롤 수정](./images/rmt-role_manage_updt.png)
 
@@ -220,7 +220,7 @@
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 삭제 | /sec/rmt/EgovRoleListDelete.do | deleteRoleList | “roleManageDAO” | “deleteRole” |
+| 삭제 | /sec/rmt/EgovRoleListDelete.do | deleteRoleList | "roleManageDAO" | "deleteRole" |
 
  ![롤 삭제](./images/rmt-role_manage_delete.png)
 

--- a/common-component/user-authentication/certificate-login.md
+++ b/common-component/user-authentication/certificate-login.md
@@ -45,7 +45,7 @@ menu:
 | Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_maria.xml | 일반 로그인, 인증서 로그인을 위한 Maria용 Query XML |
 | Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_postgres.xml | 일반 로그인, 인증서 로그인을 위한 Postgres용 Query XML |
 | Query XML | resources/egovframework/mapper/com/uat/uia/EgovLoginUsr\_SQL\_goldilocks.xml | 일반 로그인, 인증서 로그인을 위한 Goldilocks용 Query XML |
-| Message properties | resources/egovframework/message/com/message-common\_ko\_KR.properties | 일반 로그인, 인증서 로그인을 위한 Message properties |
+| Message properties | resources/egovframework/message/com/message-common\_ko.properties | 일반 로그인, 인증서 로그인을 위한 Message properties |
 
  위의 클래스 중 Controller의 경우는 전자정부 표준프레임워크에서의 테스트 수행을 위한 컨트롤러 클래스로서 실제 적용시에는 해당 기능들을 적용 Web MVC 프레임워크 기반으로 전환하면 된다. 혹 MVC 프레임워크가 적용되어 있지 않더라고 servlet 기반 또는 해당되는 JSP로 쉽게 전환할 수 있다.
 
@@ -155,7 +155,7 @@ export PATH=$PATH:/product/jeus/egovProps/libgpkiapi/gpkiapi
 
 #### 프로퍼티 파일 설정
 
- 다음의 dsjdf.properties 파일의 경우는 사용자 홈 디렉토리에 위치시킨다. Windows의 경우는 보통 “C:\\Documents and Settings\\\[사용자계정\]“가, Unix 계정은 로그인 시 들어가는 디렉토리(보통 ”/home/\[사용자계정\]”)가 홈 디렉토리가 된다.
+ 다음의 dsjdf.properties 파일의 경우는 사용자 홈 디렉토리에 위치시킨다. Windows의 경우는 보통 "C:\\Documents and Settings\\\[사용자계정\]"가, Unix 계정은 로그인 시 들어가는 디렉토리(보통 "/home/\[사용자계정\]")가 홈 디렉토리가 된다.
 
  또는 WAS 기동 스크립트 상에 다음과 같이 특정 위치의 dsjdf.properties 파일을 지정할 수 있다.
 
@@ -242,8 +242,8 @@ GPKISecureWeb.TrustedROOTCACert.FilePathName.2 = /product/jeus/egovProps/gpkisec
 
 | Action | URL | Controller method | JSP |
 | --- | --- | --- | --- |
-| 로그인화면 | /uat/uia/egovLoginUsr.do | loginUsrView | “egovframework/com/uat/uia/EgovLoginUsr.jsp” |
-| 인증서로그인 | /uat/uia/actionCrtfctLogin.do | actionCrtfctLogin | “egovframework/com/uat/uia/EgovLoginUsr.jsp” |
-| 인증서안내화면 | /uat/uia/egovGpkiIssu.do | gpkiIssuView | “egovframework/com/uat/uia/EgovGpkiIssu.jsp” |
+| 로그인화면 | /uat/uia/egovLoginUsr.do | loginUsrView | "egovframework/com/uat/uia/EgovLoginUsr.jsp" |
+| 인증서로그인 | /uat/uia/actionCrtfctLogin.do | actionCrtfctLogin | "egovframework/com/uat/uia/EgovLoginUsr.jsp" |
+| 인증서안내화면 | /uat/uia/egovGpkiIssu.do | gpkiIssuView | "egovframework/com/uat/uia/EgovGpkiIssu.jsp" |
 
  ![인증서로그인 화면](./images/utl-cert.jpg)

--- a/common-component/user-authentication/login-policy-management.md
+++ b/common-component/user-authentication/login-policy-management.md
@@ -56,8 +56,6 @@ menu:
 | QUERY XML | resources/egovframework/mapper/com/uat/uap/EgovLoginPolicy\_SQL\_maria.xml | 로그인정책 Maria용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/uat/uap/EgovLoginPolicy\_SQL\_postgres.xml | 로그인정책 Postgres용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/uat/uap/EgovLoginPolicy\_SQL\_goldilocks.xml | 로그인정책 Goldilocks용 QUERY XML |
-| Validator Rule XML | resources/egovframework/validator/validator-rules.xml | Validator Rule을 정의한 XML |
-| Validator XML | resources/egovframework/validator/com/uat/uap/EgovLoginPolicy.xml | 로그인정책 Validator XML |
 | Message properties | resources/egovframework/message/com/uat/uap/message\_ko.properties | 로그인정책을 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/uat/uap/message\_en.properties | 로그인정책을 위한 Message properties(영문) |
 
@@ -105,7 +103,7 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /uat/uap/selectLoginPolicyList.do | selectLoginPolicyList | “loginPolicyDAO.selectLoginPolicyList”, <br> “loginPolicyDAO.selectLoginPolicyListTotCnt” |
+| 목록조회 | /uat/uap/selectLoginPolicyList.do | selectLoginPolicyList | "loginPolicyDAO.selectLoginPolicyList", <br> "loginPolicyDAO.selectLoginPolicyListTotCnt" |
 
  ![로그인정책 목록조회](./images/uia-loginpolicyimg1.jpg)
 
@@ -127,9 +125,9 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /uat/uap/getLoginPolicy.do | selectLoginPolicy | “loginPolicyDAO.selectLoginPolicy” |
-| 수정 | /uat/uap/updtLoginPolicy.do | updateLoginPolicy | “loginPolicyDAO.updateLoginPolicy” |
-| 삭제 | /uat/uap/removeLoginPolicy.do | deleteLoginPolicy | “loginPolicyDAO.deleteLoginPolicy” |
+| 상세조회 | /uat/uap/getLoginPolicy.do | selectLoginPolicy | "loginPolicyDAO.selectLoginPolicy" |
+| 수정 | /uat/uap/updtLoginPolicy.do | updateLoginPolicy | "loginPolicyDAO.updateLoginPolicy" |
+| 삭제 | /uat/uap/removeLoginPolicy.do | deleteLoginPolicy | "loginPolicyDAO.deleteLoginPolicy" |
 
  ![로그인정책 수정](./images/uia-loginpolicyimg3.jpg)
 

--- a/common-component/user-authentication/login.md
+++ b/common-component/user-authentication/login.md
@@ -244,7 +244,7 @@ public Boolean isAuthenticated() {
 | Action     | URL                      | Controller method | SQL Namespace | SQL QueryID           |
 | ---------- | ------------------------ | ----------------- | ------------- | --------------------- |
 | 로그인화면 | /uat/uia/egovLoginUsr.do | loginUsrView      |               |                       |
-| 일반로그인 | /uat/uia/actionLogin.do  | actionLogin       | “LoginUsr”  | “actionCrtfctLogin” |
+| 일반로그인 | /uat/uia/actionLogin.do  | actionLogin       | "LoginUsr"  | "actionCrtfctLogin" |
 
  ![image](./images/uat-egovloginusr.jpg)
 

--- a/common-component/user-authentication/sso_service.md
+++ b/common-component/user-authentication/sso_service.md
@@ -31,9 +31,9 @@
 
 | 유형 | 대상소스명 | 비고 |
 | --- | --- | --- |
-| Service | egovframework.com.uat.uia.sso.service.EgovSSOService.java | SSO연계 서비스 인터페이스를 정의하는 클래스 |
-| Filter | egovframework.com.uat.uia.sso.filter.EgovSSOLoginFilter.java | SSO서버와 연계를 통해 SSO 인증을 실행하는 필터 클래스 |
-| Filter | egovframework.com.uat.uia.sso.filter.EgovSSOLogoutFilter.java | 로그아웃 요청시 SSO서버의 글로벌 로그아웃을 처리해 주는 필터 클래스 |
+| Service | egovframework.com.uat.sso.service.EgovSSOService.java | SSO연계 서비스 인터페이스를 정의하는 클래스 |
+| Filter | egovframework.com.uat.sso.filter.EgovSSOLoginFilter.java | SSO서버와 연계를 통해 SSO 인증을 실행하는 필터 클래스 |
+| Filter | egovframework.com.uat.sso.filter.EgovSSOLogoutFilter.java | 로그아웃 요청시 SSO서버의 글로벌 로그아웃을 처리해 주는 필터 클래스 |
 
 ### 클래스다이어그램
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

보안(security)·로그인인증(user-authentication) 영역 가이드의 관련소스 표를 `egovframe-common-components` 소스 트리와 대조하여, 실제 소스와 불일치하는 표기를 정정했습니다 (12개 문서).

- **비밀번호 만료 관리** — DAO 행이 ServiceImpl과 동일한 `EgovLoginServiceImpl`로 기재되어 있어 실제 `egovframework.com.uat.uia.service.impl.LoginDAO`로 정정, 띄어쓰기 정리(`로그인위한`→`로그인을 위한`)
- **그룹관리** — Query XML 파일명 `GroupManage_SQL_*.xml` → 실제 `EgovGroupManage_SQL_*.xml` (Egov 접두 누락, 8건)
- **SSO 서비스** — 클래스 패키지 `egovframework.com.uat.uia.sso.*` → 실제 `egovframework.com.uat.sso.*` (3건)
- **암호화/복호화** — 현재 소스에 없는 `EgovGPKIService`·`EgovGPKIServiceImpl` 행 제외 (GPKI 연동은 별도 배포 모듈로, 저장소의 `sec.pki` 패키지에는 `EgovCryptoController`만 존재)
- **권한관리 기능·권한 롤 관리·로그인정책관리** — 현행 소스에 없는 Validator XML 행 제외 (Jakarta Bean Validation 전환)
- **인증서 로그인** — Message properties `message-common_ko_KR.properties` → 실제 파일명 `message-common_ko.properties`
- **표기 통일** — 두 영역 12개 문서의 인용부호를 곧은따옴표로 통일

frontmatter는 수정하지 않았습니다

## 관련 이슈 (Related Issues)

- 없음

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)
