### PR TITLE
docs: 공통컴포넌트 - collaboration ID Generation 빈 클래스명 정정

### DIFF
--- a/common-component/collaboration/board-management.md
+++ b/common-component/collaboration/board-management.md
@@ -78,7 +78,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('BBS_ID', 1);
 
 ```xml
 <bean name="egovBBSMstrIdGnrService"
-        class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+        class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
         destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy" ref="bbsMstrStrategy" />
@@ -87,7 +87,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('BBS_ID', 1);
         <property name="tableName"	value="BBS_ID"/>
 </bean>
 <bean name="bbsMstrStrategy"
-		    class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		    class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix" value="BBSMSTR_" />
         <property name="cipers" value="12" />
         <property name="fillChar" value="0" />

--- a/common-component/collaboration/executive-schedule.md
+++ b/common-component/collaboration/executive-schedule.md
@@ -100,14 +100,14 @@ INSERT INTO COMTECOPSEQ (TABLE_NAME, NEXT_ID ) VALUES ('LEADER_SCHDUL_ID','1');
 #### ID Generation 환경설정(context-idgn-LeaderSchdu.xml)
 
 ```xml
- <bean name="egovLeaderSchdulIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService" destroy-method="destroy">
+ <bean name="egovLeaderSchdulIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="LeaderSchdulStrategy" />
     <property name="blockSize"  value="10" />
     <property name="table"      value="COMTECOPSEQ" />
     <property name="tableName"  value="LEADER_SCHDUL_ID" />
 </bean>
-<bean name="LeaderSchdulStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="LeaderSchdulStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix"     value="LDSCHDUL_" />
     <property name="cipers"     value="11" />
     <property name="fillChar"   value="0" />

--- a/common-component/collaboration/scrap-management.md
+++ b/common-component/collaboration/scrap-management.md
@@ -81,7 +81,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('SCRAP_ID', 1);
 
 ```xml
 <bean name="egovScrapIdGnrService"
-      class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+      class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
       destroy-method="destroy">
       <property name="dataSource" ref="egov.dataSource" />
       <property name="strategy" ref="scrapStrategy" />
@@ -90,7 +90,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('SCRAP_ID', 1);
       <property name="tableName"	value="SCRAP_ID"/>
 </bean>
 <bean name="scrapStrategy"
-      class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+      class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
       <property name="prefix" value="SCRIP_" />
       <property name="cipers" value="14" />
       <property name="fillChar" value="0" />

--- a/common-component/collaboration/template-management.md
+++ b/common-component/collaboration/template-management.md
@@ -77,7 +77,7 @@ INSERT INTO COMTECOPSEQ VALUES('TMPLAT_ID','0');
 
 ```xml
 <bean name="egovTmplatIdGnrService"
-      class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+      class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
       destroy-method="destroy">
       <property name="dataSource" ref="egov.dataSource" />
       <property name="strategy" ref="tmplatStrategy" />
@@ -86,7 +86,7 @@ INSERT INTO COMTECOPSEQ VALUES('TMPLAT_ID','0');
       <property name="tableName"	value="TMPLAT_ID"/>
 </bean>
 <bean name="tmplatStrategy"
-      class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+      class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
       <property name="prefix" value="TMPLAT_" />
       <property name="cipers" value="13" />
       <property name="fillChar" value="0" />


### PR DESCRIPTION
egovframework.rte 구버전 패키지/클래스명을 org.egovframe.rte 신버전으로 정정
- EgovTableIdGnrService → EgovTableIdGnrServiceImpl
- 전략 클래스 패키지 egovframework.rte → org.egovframe.rte
- 대상: board-management, executive-schedule, scrap-management, template-management

## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->
<img width="1334" height="177" alt="image" src="https://github.com/user-attachments/assets/169c0c55-9004-4969-a775-45831fdf94d3" />
공통컴포넌트 collaboration 문서의 ID Generation 빈(bean) 설정에서 구버전 패키지/클래스명 → 신버전으로 정정


## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->



## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->


