### PR TITLE
[문서] batch-core-job·vscode-config-generation·server-environment-introduction 링크 .md 확장자 누락 수정

### DIFF
--- a/egovframe-development/intro/development-framework-introduction.md
+++ b/egovframe-development/intro/development-framework-introduction.md
@@ -60,7 +60,7 @@ menu:
 
 전자정부 표준프레임워크에서는 서버 개발환경 역시 프로젝트에서 필수적으로 사용하는 기능과 선택적으로 사용하는 기능으로 구분하였다.
 
-프로젝트 상황에 따라 Deployment Tool과 Conf. & Change Mgt. Tool 중 일부 기능을 선택적으로 사용할 수 있다.([서버 개발환경](./server-environment-introduction))
+프로젝트 상황에 따라 Deployment Tool과 Conf. & Change Mgt. Tool 중 일부 기능을 선택적으로 사용할 수 있다.([서버 개발환경](./server-environment-introduction.md))
 
 ### 개발 프로세스
 

--- a/egovframe-development/vscode-implementation-tool/vscode-config-generation-common.md
+++ b/egovframe-development/vscode-implementation-tool/vscode-config-generation-common.md
@@ -32,7 +32,7 @@ menu:
 | YAML | YAML 설정 파일 | `.yml` |
 | Properties | Properties 설정 파일 | `.properties` |
 
-각 설정 유형에서 지원하는 형식은 [지원 파일 형식 요약](./vscode-config-generation#지원-파일-형식-요약)에서 확인할 수 있다.
+각 설정 유형에서 지원하는 형식은 [지원 파일 형식 요약](./vscode-config-generation.md#지원-파일-형식-요약)에서 확인할 수 있다.
 
 ### 파일 이름 / 클래스 이름
 

--- a/egovframe-runtime/batch-layer/batch-execution-job_runner.md
+++ b/egovframe-runtime/batch-layer/batch-execution-job_runner.md
@@ -103,7 +103,7 @@ Job Parameter 생성 예제는 아래와 같다.
 	jobParameters = egovBatchRunner.addJobParameter(jobParameters, "inputFile", "/egovframework/batch/data/inputs/csvData.csv");
 ```
 
-이렇게 생성된 JobParameters는 XML에서 사용할 수 있다. 자세한 내용은 [Job Parameters](./batch-core-job#jobparameters) 항목을 참조한다.
+이렇게 생성된 JobParameters는 XML에서 사용할 수 있다. 자세한 내용은 [Job Parameters](./batch-core-job.md#jobparameters) 항목을 참조한다.
 
 #### 사용방법
 EgovBatchRunner 예제


### PR DESCRIPTION
## 변경 사유

egovframe-runtime, egovframe-development 문서 3곳에서 `.md` 확장자가 빠진 상대링크가 있어 GitHub 원문 뷰에서 링크가 깨집니다. 오늘 병합된 vscode-implementation-tool 링크 수정(#728)과 동일한 유형의 오타입니다.

## 변경 내용

- `egovframe-runtime/batch-layer/batch-execution-job_runner.md`: `Job Parameters` 링크
- `egovframe-development/vscode-implementation-tool/vscode-config-generation-common.md`: `지원 파일 형식 요약` 링크 (vscode-implementation-tool 디렉토리 안에서 앵커가 붙어있어 지난 수정 때 누락된 건)
- `egovframe-development/intro/development-framework-introduction.md`: `서버 개발환경` 링크

각 링크가 가리키는 대상 파일과 앵커가 실제로 존재하는지 확인 후 수정했습니다. frontmatter는 변경하지 않았습니다.

## 테스트 방법 / 영향 범위

문서 링크 텍스트만 수정한 순수 문서 변경으로 빌드/코드에는 영향이 없습니다.

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 링크 대상 문서·앵커 실존 확인 완료