### PR TITLE
fix: 협업 가이드 관련소스 소스 대조 정정 및 인용부호 통일

### DIFF
--- a/common-component/collaboration/all-schedule.md
+++ b/common-component/collaboration/all-schedule.md
@@ -81,8 +81,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /cop/smt/sam/EgovAllSchdulManageList.do | egovAllSchdulManageList | “AllSchdulManage” | “selectIndvdlSchdulManage” |
-| | | | “AllSchdulManage” | “selectIndvdlSchdulManageCnt” |
+| 목록조회 | /cop/smt/sam/EgovAllSchdulManageList.do | egovAllSchdulManageList | "AllSchdulManage" | "selectIndvdlSchdulManage" |
+| | | | "AllSchdulManage" | "selectIndvdlSchdulManageCnt" |
 
 전체일정 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 검색조건은 등록자, 일정명, 일정내용에 대해서 수행된다.
 

--- a/common-component/collaboration/blog-management.md
+++ b/common-component/collaboration/blog-management.md
@@ -31,7 +31,7 @@ menu:
 
 | 유형 | 대상소스 | 비고 |
 | --- | --- | --- |
-| Controller | egovframework.com.cop.bbs.EgovBBSMasterController.java | 블로그 관리를 위한 컨트롤러 클래스 |
+| Controller | egovframework.com.cop.bbs.web.EgovBBSMasterController.java | 블로그 관리를 위한 컨트롤러 클래스 |
 | Service | egovframework.com.cop.bbs.service.EgovBBSMasterService.java | 블로그 관리를 위한 서비스 인터페이스 |
 | ServiceImpl | egovframework.com.cop.bbs.service.impl.EgovBBSMasterServiceImpl.java | 블로그 관리를 위한 서비스 구현 클래스 |
 | Model | egovframework.com.cop.bbs.service.BoardMaster.java | 블로그 관리를 위한 모델 클래스 |
@@ -56,7 +56,6 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_goldilocks.xml | 블로그 관리를 위한 Goldilocks용 Query XML |
 | Message properties | resources/egovframework/message/com/cop/bbs/message_ko.properties | 블로그 관리를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/bbs/message_en.properties | 블로그 관리를 위한 Message properties(영문) |
-| Validator XML | resources/egovframework/validator/com/cop/bbs/EgovBBSMasterRegist.xml | 블로그 관리를 위한 Validator XML |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-bbs.xml | 블로그 관리를 위한 Id 생성 Idgen XML |
 
 ### ID Generation
@@ -123,8 +122,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /cop/bbs/selectBlogList.do | selectBlogMasterList | “BBSMaster” | “selectBlogMasterList” |
-| | | | “BBSMaster” | “selectBlogMasterListTotCnt” |
+| 목록조회 | /cop/bbs/selectBlogList.do | selectBlogMasterList | "BBSMaster" | "selectBlogMasterList" |
+| | | | "BBSMaster" | "selectBlogMasterListTotCnt" |
 
 블로그 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
 
@@ -153,7 +152,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 등록화면 | /cop/bbs/insertBlogMasterView.do | insertBlogMasterView | | |
-| 등록 | /cop/bbs/insertBlogMaster.do | insertBlogMaster | “BBSMaster” | “insertBlogMaster” |
+| 등록 | /cop/bbs/insertBlogMaster.do | insertBlogMaster | "BBSMaster" | "insertBlogMaster" |
 
 ![블로그 게시판 생성](./images/blog-management-insert.jpg)
 
@@ -177,8 +176,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 수정화면 | /cop/bbs/updateBBSMasterView.do | updateBBSMasterView | “BBSMaster” | “selectBBSMasterDetail” |
-| 수정 | /cop/bbs/updateBBSMaster.do | updateBBSMaster | “BBSMaster” | “updateBBSMaster” |
+| 수정화면 | /cop/bbs/updateBBSMasterView.do | updateBBSMasterView | "BBSMaster" | "selectBBSMasterDetail" |
+| 수정 | /cop/bbs/updateBBSMaster.do | updateBBSMaster | "BBSMaster" | "updateBBSMaster" |
 
 ![블로그 게시판 카테고리 수정](./images/blog-management-update.jpg)
 

--- a/common-component/collaboration/board-guestbook.md
+++ b/common-component/collaboration/board-guestbook.md
@@ -48,7 +48,6 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_maria.xml | 방명록 관리를 위한 MariaDB용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_postgres.xml | 방명록 관리를 위한 PostgreSQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_goldilocks.xml | 방명록 관리를 위한 Goldilocks용 Query XML |
-| Validator XML | resources/egovframework/validator/com/cop/bbs/EgovArticleRegist.xml | 방명록 관리를 위한 Validator XML |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-bbs.xml | 방명록 등록 Id생성 Idgen XML |
 | Message properties | resources/egovframework/message/com/cop/bbs/message_ko.properties | 방명록 관리를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/bbs/message_en.properties | 방명록 관리를 위한 Message properties(영문) |
@@ -111,8 +110,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /cop/bbs/selectGuestArticleList.do | selectGuestArticleList | “BBSArticle” | “selectGuestArticle” |
-| | | | “BBSArticle” | “selectGuestArticleListCnt” |
+| 목록조회 | /cop/bbs/selectGuestArticleList.do | selectGuestArticleList | "BBSArticle" | "selectGuestArticle" |
+| | | | "BBSArticle" | "selectGuestArticleListCnt" |
 
 게시판 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
 
@@ -138,7 +137,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 등록 | /cop/bbs/insertGuestArticle.do | insertGuestList | “BBSArticle” | “insertArticle” |
+| 등록 | /cop/bbs/insertGuestArticle.do | insertGuestList | "BBSArticle" | "insertArticle" |
 
 ![방명록 등록](./images/board-guestbook-insert.jpg)
 
@@ -159,7 +158,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 수정화면 | /cop/bbs/updateGuestArticleView.do | updateGuestArticleView | | |
-| 수정 | /cop/bbs/updateGuestArticle.do | updateGuestArticle | “BBSArticle” | “updateArticle” |
+| 수정 | /cop/bbs/updateGuestArticle.do | updateGuestArticle | "BBSArticle" | "updateArticle" |
 
 ![방명록 수정](./images/board-guestbook-update.jpg)
 

--- a/common-component/collaboration/board-integrated.md
+++ b/common-component/collaboration/board-integrated.md
@@ -44,7 +44,7 @@ menu:
 | JSP | /WEB-INF/jsp/egovframework/com/cop/bbs/EgovArticleList.jsp | 생성된 게시물 조회를 위한 jsp 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/bbs/EgovArticleDetail.jsp | 생성된 게시물 상세 조회를 위한 jsp 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/bbs/EgovArticleReply.jsp | 생성된 게시물에 대한 답변을 등록하기 위한 jsp 페이지 |
-| JSP | /WEB-INF/jsp/egovframework/com/cop/bbs/EgovArticleCommentList.jsp | 댓글 등록/조회를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/cop/cmt/EgovArticleCommentList.jsp | 댓글 등록/조회를 위한 jsp페이지 |
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_mysql.xml | 게시물 관리를 위한 MySQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_oracle.xml | 게시물 관리를 위한 Oracle용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_tibero.xml | 게시물 관리를 위한 Tibero용 Query XML |
@@ -53,7 +53,6 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_maria.xml | 게시물 관리를 위한 MariaDB용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_postgres.xml | 게시물 관리를 위한 PostgreSQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_goldilocks.xml | 게시물 관리를 위한 Goldilocks용 Query XML |
-| Validator XML | resources/egovframework/validator/com/cop/bbs/EgovArticleRegist.xml | 게시물 관리를 위한 Validator XML |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-bbs.xml | 게시물 등록 Id 생성 Idgen XML |
 | Message properties | resources/egovframework/message/com/cop/bbs/message_ko.properties | 게시물 관리를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/bbs/message_en.properties | 게시물 관리를 위한 Message properties(영문) |
@@ -117,8 +116,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /cop/bbs/selectArticleList.do | selectArticleList | “BBSArticle” | “selectArticleList” |
-| | | | “BBSArticle” | “selectArticleListCnt” |
+| 목록조회 | /cop/bbs/selectArticleList.do | selectArticleList | "BBSArticle" | "selectArticleList" |
+| | | | "BBSArticle" | "selectArticleListCnt" |
 
 ![게시물 목록 조회](./images/board-integrated-list.jpg)
 
@@ -141,7 +140,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 등록화면 | /cop/bbs/insertArticleView.do | insertArticleView | | |
-| 등록 | /cop/bbs/insertArticle.do | insertArticle | “BBSArticle” | “insertArticle” |
+| 등록 | /cop/bbs/insertArticle.do | insertArticle | "BBSArticle" | "insertArticle" |
 
 ![게시물 등록](./images/board-integrated-insert.jpg)
 
@@ -163,7 +162,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /cop/bbs/selectArticleDetail.do | selectArticleDetail | “BBSArticle” | “selectArticleDetail” |
+| 상세조회 | /cop/bbs/selectArticleDetail.do | selectArticleDetail | "BBSArticle" | "selectArticleDetail" |
 
 ![게시물 상세 조회](./images/board-integrated-detail.jpg)
 
@@ -186,7 +185,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 수정화면 | /cop/bbs/updateArticleView.do | updateArticleView | | |
-| 수정 | /cop/bbs/updateArticle.do | updateArticle | “BBSArticle” | “updateArticle” |
+| 수정 | /cop/bbs/updateArticle.do | updateArticle | "BBSArticle" | "updateArticle" |
 
 ![게시물 수정](./images/board-integrated-update.jpg)
 
@@ -207,7 +206,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 답변 작성 화면 | /cop/bbs/replyArticleView.do | addReplyBoardArticle | | |
-| 답변 | /cop/bbs/replyArticle.do | replyBoardArticle | “BBSArticle” | “replyArticle” |
+| 답변 | /cop/bbs/replyArticle.do | replyBoardArticle | "BBSArticle" | "replyArticle" |
 
 ![답변 작성](./images/board-integrated-reply.jpg)
 

--- a/common-component/collaboration/board-management.md
+++ b/common-component/collaboration/board-management.md
@@ -31,7 +31,7 @@ menu:
 
 | 유형 | 대상소스 | 비고 |
 | --- | --- | --- |
-| Controller | egovframework.com.cop.bbs.EgovBBSMasterController.java | 게시판 관리를 위한 컨트롤러 클래스 |
+| Controller | egovframework.com.cop.bbs.web.EgovBBSMasterController.java | 게시판 관리를 위한 컨트롤러 클래스 |
 | Service | egovframework.com.cop.bbs.service.EgovBBSMasterService.java | 게시판 관리를 위한 서비스 인터페이스 |
 | ServiceImpl | egovframework.com.cop.bbs.service.impl.EgovBBSMasterServiceImpl.java | 게시판 관리를 위한 서비스 구현 클래스 |
 | Model | egovframework.com.cop.bbs.service.BoardMaster.java | 게시판 관리를 위한 모델 클래스 |
@@ -50,7 +50,6 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_maria.xml | 게시판 관리를 위한 MariaDB용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_postgres.xml | 게시판 관리를 위한 PostgreSQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_goldilocks.xml | 게시판 관리를 위한 Goldilocks용 Query XML |
-| Validator XML | resources/egovframework/validator/com/cop/bbs/EgovBBSMasterRegist.xml | 게시판 관리를위한 Validator XML |
 | Message properties | resources/egovframework/message/com/cop/bbs/message_ko.properties | 게시판 관리를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/bbs/message_en.properties | 게시판 관리를 위한 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-bbs.xml | 게시판 관리를 위한 Id생성 Idgen XML |
@@ -135,8 +134,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /cop/bbs/selectBBSMasterInfs.do | selectBBSMasterInfs | “BBSMaster” | “selectBBSMasterList” |
-| | | | “BBSMaster” | “selectBBSMasterListTotCnt” |
+| 목록조회 | /cop/bbs/selectBBSMasterInfs.do | selectBBSMasterInfs | "BBSMaster" | "selectBBSMasterList" |
+| | | | "BBSMaster" | "selectBBSMasterListTotCnt" |
 
 게시판 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
 
@@ -169,7 +168,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 등록화면 | /cop/bbs/insertBBSMasterView.do | insertBBSMasterView | | |
-| 등록 | /cop/bbs/insertBBSMaster.do | insertBBSMaster | “BBSMaster” | “insertBBSMaster” |
+| 등록 | /cop/bbs/insertBBSMaster.do | insertBBSMaster | "BBSMaster" | "insertBBSMaster" |
 
 ![게시판 생성](./images/board-management-insert.png)
 
@@ -193,8 +192,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 수정화면 | /cop/bbs/updateBBSMasterView.do | updateBBSMasterView | “BBSMaster” | “selectBBSMasterDetail” |
-| 수정 | /cop/bbs/updateBBSMaster.do | updateBBSMaster | “BBSMaster” | “updateBBSMaster” |
+| 수정화면 | /cop/bbs/updateBBSMasterView.do | updateBBSMasterView | "BBSMaster" | "selectBBSMasterDetail" |
+| 수정 | /cop/bbs/updateBBSMaster.do | updateBBSMaster | "BBSMaster" | "updateBBSMaster" |
 
 ![게시판 수정](./images/board-management-update.png)
 

--- a/common-component/collaboration/comment-management.md
+++ b/common-component/collaboration/comment-management.md
@@ -40,8 +40,8 @@ menu:
 | Controller | egovframework.com.cop.cmt.web.EgovArticleCommentController.java | 댓글관리를 위한 컨트롤러 클래스 |
 | Service | egovframework.com.cop.cmt.service.EgovArticleCommentService.java | 댓글관리를 위한 서비스 인터페이스 |
 | ServiceImpl | egovframework.com.cop.cmt.service.impl.EgovArticleCommentServiceImpl.java | 댓글관리를 위한 서비스 구현 클래스 |
-| Model | egovframework.com.cop.bbs.service.Comment.java | 댓글관리를 위한 모델 클래스 |
-| VO | egovframework.com.cop.bbs.service.CommentVO.java | 댓글관리를 위한 VO 클래스 |
+| Model | egovframework.com.cop.cmt.service.Comment.java | 댓글관리를 위한 모델 클래스 |
+| VO | egovframework.com.cop.cmt.service.CommentVO.java | 댓글관리를 위한 VO 클래스 |
 | DAO | egovframework.com.cop.cmt.service.impl.EgovArticleCommentDAO.java | 댓글관리를 위한 데이터처리 클래스 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/cmt/EgovArticleCommentList.jsp | 댓글관리를 위한 jsp페이지 |
 | Query XML | resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_mysql.xml | 댓글관리를 위한 MySQL용 Query XML 파일 |
@@ -52,7 +52,6 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_maria.xml | 댓글관리를 위한 MariaDB용 Query XML 파일 |
 | Query XML | resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_postgres.xml | 댓글관리를 위한 PostgreSQL용 Query XML 파일 |
 | Query XML | resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_goldilocks.xml | 댓글관리를 위한 Goldilocks용 Query XML 파일 |
-| Validator XML | resources/egovframework/validator/com/cop/cmt/EgovArticleCommentRegist.xml | 댓글관리를 위한 Validator XML |
 | Message properties | resources/egovframework/message/com/cop/cmt/message_ko.properties | 댓글관리를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/cmt/message_en.properties | 댓글관리를 위한 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-AnswerNo.xml | 댓글관리를 위한 Id생성 Idgen XML |
@@ -115,9 +114,9 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /cop/cmt/selectArticleCommentList.do | selectArticleCommentList | “ArticleComment” | “selectArticleCommentList” |
-| | | | “ArticleComment” | “selectArticleCommentListCnt” |
-| 등록 | /cop/cmt/insertArticleComment.do | insertArticleComment | “ArticleComment” | “insertArticleComment” |
+| 목록조회 | /cop/cmt/selectArticleCommentList.do | selectArticleCommentList | "ArticleComment" | "selectArticleCommentList" |
+| | | | "ArticleComment" | "selectArticleCommentListCnt" |
+| 등록 | /cop/cmt/insertArticleComment.do | insertArticleComment | "ArticleComment" | "insertArticleComment" |
 
 댓글 목록은 페이지당 5건씩 조회되며 페이징은 10페이지씩 이루어진다.
 
@@ -139,9 +138,9 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 수정화면 | /cop/cmt/updateArticleCommentView.do | updateArticleCommentView | “ArticleComment” | “selectArticleCommentDetail” |
-| 수정 | /cop/cmt/updateArticleComment.do | updateArticleComment | “ArticleComment” | “updateArticleComment” |
-| 삭제 | /cop/cmt/deleteArticleComment.do | deleteArticleComment | “ArticleComment” | “deleteArticleComment” |
+| 수정화면 | /cop/cmt/updateArticleCommentView.do | updateArticleCommentView | "ArticleComment" | "selectArticleCommentDetail" |
+| 수정 | /cop/cmt/updateArticleComment.do | updateArticleComment | "ArticleComment" | "updateArticleComment" |
+| 삭제 | /cop/cmt/deleteArticleComment.do | deleteArticleComment | "ArticleComment" | "deleteArticleComment" |
 
 ![댓글 수정 및 삭제](./images/comment-management-update.png)
 

--- a/common-component/collaboration/community-creation.md
+++ b/common-component/collaboration/community-creation.md
@@ -42,15 +42,14 @@ menu:
 | JSP | /WEB-INF/jsp/egovframework/com/cop/cmy/EgovCommuMasterUpdt.jsp | 커뮤니티 정보 수정을 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/cmy/EgovCommuMasterDetail.jsp | 커뮤니티 상세정보 조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/cmy/EgovCommuMasterListPortlet.jsp | 포털(예제) 메인화면 목록 조회를 위한 jsp 페이지 |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuMaster_SQL_mysql.xml | 커뮤니티 관리를 위한 MySQL용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuMaster_SQL_cubrid.xml | 커뮤니티 관리를 위한 Cubrid용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuMaster_SQL_oracle.xml | 커뮤니티 관리를 위한 Oracle용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuMaster_SQL_tibero.xml | 커뮤니티 관리를 위한 Tibero용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuMaster_SQL_altibase.xml | 커뮤니티 관리를 위한 Altibase용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuMaster_SQL_postgres.xml | 커뮤니티 관리를 위한 Postgres용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuMaster_SQL_maria.xml | 커뮤니티 관리를 위한 Maria용 Query |
-| Query XML | resources/egovframework/sqlmap/com/cop/cmy/EgovCommuMaster_SQL_goldilocks.xml | 커뮤니티 관리를 위한 Goldilocks용 Query |
-| Validator XML | resources/egovframework/validator/com/cop/cmy/EgovCommuMasterRegist.xml | 커뮤니티 관리를위한 Validator XML |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_mysql.xml | 커뮤니티 관리를 위한 MySQL용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_cubrid.xml | 커뮤니티 관리를 위한 Cubrid용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_oracle.xml | 커뮤니티 관리를 위한 Oracle용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_tibero.xml | 커뮤니티 관리를 위한 Tibero용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_altibase.xml | 커뮤니티 관리를 위한 Altibase용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_postgres.xml | 커뮤니티 관리를 위한 Postgres용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_maria.xml | 커뮤니티 관리를 위한 Maria용 Query |
+| Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_goldilocks.xml | 커뮤니티 관리를 위한 Goldilocks용 Query |
 | Message properties | resources/egovframework/message/com/cop/cmy/message_ko.properties | 커뮤니티 관리를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/cmy/message_en.properties | 커뮤니티 관리를 위한 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-Cmmnty.xml | 커뮤니티 관리를 위한 Id생성 Idgen XML |
@@ -114,8 +113,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /cop/cmy/selectCommuMasterList.do | selectCommuMasterList | “CommuMaster” | “selectCommuMasterList” |
-| | | | “CommuMaster” | “selectCommuMasterListCnt” |
+| 목록조회 | /cop/cmy/selectCommuMasterList.do | selectCommuMasterList | "CommuMaster" | "selectCommuMasterList" |
+| | | | "CommuMaster" | "selectCommuMasterListCnt" |
 
 페이지 당 검색 범위를 변경하고자 하는 경우 context-properties.xml 파일의 pageUnit, pageSize를 변경한다.(단 해당 설정은 전체 공통서비스 기능에 영향을 미친다.)
 
@@ -142,7 +141,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 등록화면 | /cop/cmy/insertCommuMasterView.do | insertCommuMasterView | | |
-| 등록 | /cop/cmy/insertCommuMaster.do | insertCommuMaster | “CommuMaster” | “insertCommuMaster” |
+| 등록 | /cop/cmy/insertCommuMaster.do | insertCommuMaster | "CommuMaster" | "insertCommuMaster" |
 
 ![커뮤니티 목록조회](./images/community-creation-insert.jpg)
 
@@ -164,7 +163,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /cop/cmy/selectCommuMasterDetail.do | selectCommuMasterDetail | “CommuMaster” | “selectCommuMasterDetail” |
+| 상세조회 | /cop/cmy/selectCommuMasterDetail.do | selectCommuMasterDetail | "CommuMaster" | "selectCommuMasterDetail" |
 
 ![커뮤니티 상세조회](./images/community-creation-detail.jpg)
 
@@ -186,8 +185,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 수정화면 | /cop/cmy/updateCommuMasterView.do | updateCommuMasterView | “CommuMaster” | “selectCommuMasterDetail” |
-| 수정 | /cop/cmy/updateCommuMaster.do | updateCommuMaster | “CommuMaster” | “updateCommuMaster” |
+| 수정화면 | /cop/cmy/updateCommuMasterView.do | updateCommuMasterView | "CommuMaster" | "selectCommuMasterDetail" |
+| 수정 | /cop/cmy/updateCommuMaster.do | updateCommuMaster | "CommuMaster" | "updateCommuMaster" |
 
 ![커뮤니티 수정](./images/community-creation-update.jpg)
 

--- a/common-component/collaboration/community-member.md
+++ b/common-component/collaboration/community-member.md
@@ -31,12 +31,12 @@ menu:
 
 | 유형 | 대상소스 | 비고 |
 | --- | --- | --- |
-| Controller | egovframework.com.cop.cmy.EgovCommuManageController.java | 커뮤니티 사용자 및 승인정보 관리를 위한 컨트롤러 클래스 |
+| Controller | egovframework.com.cop.cmy.web.EgovCommuManageController.java | 커뮤니티 사용자 및 승인정보 관리를 위한 컨트롤러 클래스 |
 | Service | egovframework.com.cop.cmy.service.EgovCommuManageService.java | 커뮤니티 사용자 및 승인정보를 관리하기 위한 서비스 클래스 |
 | ServiceImpl | egovframework.com.cop.cmy.service.impl.EgovCommuManageServiceImpl.java | 커뮤니티 사용자 및 승인정보를 관리하기 위한 서비스 구현 클래스 |
 | Model | egovframework.com.cop.cmy.service.CommunityUserVO.java | 커뮤니티 사용자 및 승인정보를 관리하기 위한 모델 클래스 |
 | DAO | egovframework.com.cop.cmy.service.impl.EgovCommuManageDAO.java | 커뮤니티 사용자 및 승인정보 관리를 위한 데이터 접근 클래스 |
-| JSP | /WEB-INF/jsp/egovframework/com/cop/com/EgovCommuUserList.jsp | 커뮤니티 사용자 및 승인 목록 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/cop/cmy/EgovCommuUserList.jsp | 커뮤니티 사용자 및 승인 목록 jsp페이지 |
 | Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_mysql.xml | 커뮤니티 사용자 및 승인정보 관리를 위한 MySQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_oracle.xml | 커뮤니티 사용자 및 승인정보 관리를 위한 Oracle용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_tibero.xml | 커뮤니티 사용자 및 승인정보 관리를 위한 Tibero용 Query XML |
@@ -77,8 +77,8 @@ N/A
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /cop/cmy/selectCommuUserList.do | selectCommuUserList | “CommuManage.selectCommuUserList”, |
-| | | | “CommuManage.selectCommuUserListCnt” |
+| 목록조회 | /cop/cmy/selectCommuUserList.do | selectCommuUserList | "CommuManage.selectCommuUserList", |
+| | | | "CommuManage.selectCommuUserListCnt" |
 
 페이지 당 검색 범위를 변경하고자 하는 경우 context-properties.xml 파일의 pageUnit, pageSize를 변경한다.(단 해당 설정은 전체 공통서비스 기능에 영향을 미친다.)
 

--- a/common-component/collaboration/department-schedule.md
+++ b/common-component/collaboration/department-schedule.md
@@ -54,10 +54,9 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_postgres.xml | 부서일정관리를 위한 PostgreSQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_tibero.xml | 부서일정관리를 위한 Tibero용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_goldilocks.xml | 부서일정관리를 위한 Goldilocks용 Query XML |
-| Validator XML | resources/egovframework/validator/com/cop/smt/sdm/EgovDeptSchdulManage.xml | 부서일정관리 Validator XML |
 | Message properties | resources/egovframework/message/com/cop/smt/sdm/message_ko.properties | 마이페이지 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/smt/sdm/message_en.properties | 마이페이지 Message properties(영문) |
-| Idgen XML | resources/egovframework/spring/com/idgn/context-idgen-deptSchdulManage.xml | 부서일정관리 Id생성 Idgen XML |
+| Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-deptSchdulManage.xml | 부서일정관리 Id생성 Idgen XML |
 
 ### 클래스 다이어그램
 
@@ -77,7 +76,7 @@ CREATE TABLE COMTECOPSEQ (TABLE_NAME VARCHAR(20) NOT NULL,
 INSERT INTO COMTECOPSEQ VALUES('SCHDUL_ID','1');
 ```
 
-#### ID Generation 환경설정(context-idgen-deptSchdulManage.xml)
+#### ID Generation 환경설정(context-idgn-deptSchdulManage.xml)
 
 ```xml
 <bean name="deptSchdulManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
@@ -118,7 +117,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 월별목록조회 | /cop/smt/sdm/EgovDeptSchdulManageMonthList.do | egovDeptSchdulManageMonthList | “DeptSchdulManage” | “selectDeptSchdulManageRetrieve” |
+| 월별목록조회 | /cop/smt/sdm/EgovDeptSchdulManageMonthList.do | egovDeptSchdulManageMonthList | "DeptSchdulManage" | "selectDeptSchdulManageRetrieve" |
 
 ![부서일정관리 월별목록](./images/department-schedule-month-list.jpg)
 
@@ -142,7 +141,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 주간별 목록조회 | /cop/smt/sdm/EgovDeptSchdulManageWeekList.do | egovDeptSchdulManageWeekList | “DeptSchdulManage” | “selectDeptSchdulManageRetrieve” |
+| 주간별 목록조회 | /cop/smt/sdm/EgovDeptSchdulManageWeekList.do | egovDeptSchdulManageWeekList | "DeptSchdulManage" | "selectDeptSchdulManageRetrieve" |
 
 ![부서일정관리 주간별목록](./images/department-schedule-week-list.jpg)
 
@@ -162,7 +161,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 일별 목록조회 | /cop/smt/sdm/EgovDeptSchdulManageDailyList.do | egovDeptSchdulManageDailyList | “DeptSchdulManage” | “selectDeptSchdulManageRetrieve” |
+| 일별 목록조회 | /cop/smt/sdm/EgovDeptSchdulManageDailyList.do | egovDeptSchdulManageDailyList | "DeptSchdulManage" | "selectDeptSchdulManageRetrieve" |
 
 ![부서일정관리 일별목록](./images/department-schedule-daily-list.jpg)
 
@@ -182,8 +181,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /cop/smt/sdm/EgovDeptSchdulManageDetail.do | egovDeptSchdulManageDetail | “DeptSchdulManage” | “selectDeptSchdulManageDetailVO” |
-| 부서일정 삭제 | /cop/smt/sdm/EgovDeptSchdulManageDetail.do | egovDeptSchdulManageDetail | “DeptSchdulManage” | “deleteDeptSchdulManage” |
+| 상세조회 | /cop/smt/sdm/EgovDeptSchdulManageDetail.do | egovDeptSchdulManageDetail | "DeptSchdulManage" | "selectDeptSchdulManageDetailVO" |
+| 부서일정 삭제 | /cop/smt/sdm/EgovDeptSchdulManageDetail.do | egovDeptSchdulManageDetail | "DeptSchdulManage" | "deleteDeptSchdulManage" |
 
 ![부서일정관리 상세조회 및 삭제](./images/department-schedule-detail.jpg)
 
@@ -210,7 +209,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 등록화면 | /cop/smt/sdm/EgovDeptSchdulManageRegist.do | deptSchdulManageRegist | | |
-| 등록 | /cop/smt/sdm/EgovDeptSchdulManageRegistActor.do | deptSchdulManageRegistActor | “DeptSchdulManage” | “insertDeptSchdulManage” |
+| 등록 | /cop/smt/sdm/EgovDeptSchdulManageRegistActor.do | deptSchdulManageRegistActor | "DeptSchdulManage" | "insertDeptSchdulManage" |
 
 ![부서일정관리 등록](./images/department-schedule-regist.jpg)
 
@@ -233,7 +232,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 수정화면 | /cop/smt/sdm/EgovDeptSchdulManageModify.do | deptSchdulManageModify | | |
-| 수정 | /cop/smt/sdm/EgovDeptSchdulManageModifyActor.do | deptSchdulManageModifyActor | “DeptSchdulManage” | “updateDeptSchdulManage” |
+| 수정 | /cop/smt/sdm/EgovDeptSchdulManageModifyActor.do | deptSchdulManageModifyActor | "DeptSchdulManage" | "updateDeptSchdulManage" |
 
 ![부서일정관리 수정](./images/department-schedule-modify.jpg)
 

--- a/common-component/collaboration/journal-management.md
+++ b/common-component/collaboration/journal-management.md
@@ -47,8 +47,6 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_postgres.xml | 일지관리를 위한 PostgreSQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_tibero.xml | 일지관리를 위한 Tibero용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_goldilocks.xml | 일지관리를 위한 Goldilocks용 Query XML |
-| Validator Rule XML | resources/egovframework/validator/validator-rules.xml | Validator Rule을 정의한 XML |
-| Validator XML | resources/egovframework/validator/com/cop/smt/dsm/EgovDiaryManage.xml | 일지관리 Validator XML |
 | Message properties | resources/egovframework/message/com/message-common_ko.properties | 일지관리 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/message-common_en.properties | 일지관리 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-diaryManage.xml | 일지관리 Id생성 Idgen XML |
@@ -112,8 +110,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /cop/smt/dsm/EgovDiaryManageList.do | egovDiaryManageList | “DiaryManage” | “selectDiaryManage” |
-| | | | “DiaryManage” | “selectDiaryManageCnt” |
+| 목록조회 | /cop/smt/dsm/EgovDiaryManageList.do | egovDiaryManageList | "DiaryManage" | "selectDiaryManage" |
+| | | | "DiaryManage" | "selectDiaryManageCnt" |
 
 일지관리 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 검색조건은 등록자, 외부인사명에 대해서 수행된다.
 
@@ -143,8 +141,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /cop/smt/dsm/EgovDiaryManageDetail.do | egovDiaryManageDetail | “DiaryManage” | “selectDiaryManageDetail” |
-| 삭제 | /cop/smt/dsm/EgovDiaryManageDetail.do | egovDiaryManageDetail | “DiaryManage” | “deleteDiaryManage” |
+| 상세조회 | /cop/smt/dsm/EgovDiaryManageDetail.do | egovDiaryManageDetail | "DiaryManage" | "selectDiaryManageDetail" |
+| 삭제 | /cop/smt/dsm/EgovDiaryManageDetail.do | egovDiaryManageDetail | "DiaryManage" | "deleteDiaryManage" |
 
 ![일지관리 상세조회](./images/journal-management-detail.jpg)
 
@@ -169,7 +167,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 등록화면 | /cop/smt/dsm/EgovDiaryManageRegist.do | diaryManageRegist | | |
-| 등록 | /cop/smt/dsm/EgovDiaryManageRegistActor.do | diaryManageRegistActor | “DiaryManage” | “insertDiaryManage” |
+| 등록 | /cop/smt/dsm/EgovDiaryManageRegistActor.do | diaryManageRegistActor | "DiaryManage" | "insertDiaryManage" |
 
 ![일지관리 등록](./images/journal-management-regist.jpg)
 
@@ -192,7 +190,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 수정화면 | /cop/smt/dsm/EgovDiaryManageModify.do | diaryManageModify | | |
-| 수정 | /cop/smt/dsm/EgovDiaryManageModifyActor.do | diaryManageModifyActor | “DiaryManage” | “updateDiaryManage” |
+| 수정 | /cop/smt/dsm/EgovDiaryManageModifyActor.do | diaryManageModifyActor | "DiaryManage" | "updateDiaryManage" |
 
 ![일지관리 수정](./images/journal-management-modify.jpg)
 

--- a/common-component/collaboration/satisfaction-survey.md
+++ b/common-component/collaboration/satisfaction-survey.md
@@ -36,7 +36,7 @@ menu:
 | 유형 | 대상소스 | 비고 |
 | --- | --- | --- |
 | Controller | egovframework.com.cop.stf.web.EgovBBSSatisfactionController.java | 만족도조사를 위한 컨트롤러 클래스 |
-| Service | egovframework.com.cop.stf.service.EgovBBSSatisfactionService.java | 만족도조사를 위한 서비스 인터페이스 |
+| Service | egovframework.com.cop.bbs.service.EgovBBSSatisfactionService.java | 만족도조사를 위한 서비스 인터페이스 |
 | ServiceImpl | egovframework.com.cop.stf.service.impl.EgovBBSSatisfactionServiceImpl.java | 만족도조사를 위한 서비스 구현 클래스 |
 | Model | egovframework.com.cop.bbs.service.Satisfaction.java | 만족도조사를 위한 모델 클래스 |
 | VO | egovframework.com.cop.bbs.service.SatisfactionVO.java | 만족도조사를 위한 VO 클래스 |
@@ -50,7 +50,6 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_maria.xml | 만족도조사를 위한 MariaDB용 Query XML 파일 |
 | Query XML | resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_postgres.xml | 만족도조사를 위한 PostgreSQL용 Query XML 파일 |
 | Query XML | resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_goldilocks.xml | 만족도조사를 위한 Goldilocks용 Query XML 파일 |
-| Validator Rule XML | resources/egovframework/validator/validator-rules.xml | Validator Rule을 정의한 XML |
 | Message properties | resources/egovframework/message/com/cop/stf/message_ko.properties | 만족도조사를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/stf/message_en.properties | 만족도조사를 위한 Message properties(영문) |
 
@@ -82,9 +81,9 @@ N/A
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /cop/stf/selectSatisfactionList.do | selectSatisfactionList | “BBSSatisfactionDAO.selectSatisfactionList”, |
-| | | | “BBSSatisfactionDAO.selectSatisfactionListCnt” |
-| 등록 | /cop/stf/insertSatisfaction.do | insertSatisfaction | “BBSSatisfactionDAO.insertSatisfaction” |
+| 목록조회 | /cop/stf/selectSatisfactionList.do | selectSatisfactionList | "BBSSatisfactionDAO.selectSatisfactionList", |
+| | | | "BBSSatisfactionDAO.selectSatisfactionListCnt" |
+| 등록 | /cop/stf/insertSatisfaction.do | insertSatisfaction | "BBSSatisfactionDAO.insertSatisfaction" |
 
 만족도 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
 
@@ -111,8 +110,8 @@ N/A
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
 | 수정화면 | /cop/stf/selectSingleSatisfaction.do | selectSingleSatisfaction | |
-| 수정 | /cop/stf/updateSatisfaction.do | updateSatisfaction | “BBSSatisfactionDAO.updateSatisfaction” |
-| 삭제 | /cop/stf/deleteSatisfaction.do | deleteSatisfaction | “BBSSatisfactionDAO.deleteSatisfaction” |
+| 수정 | /cop/stf/updateSatisfaction.do | updateSatisfaction | "BBSSatisfactionDAO.updateSatisfaction" |
+| 삭제 | /cop/stf/deleteSatisfaction.do | deleteSatisfaction | "BBSSatisfactionDAO.deleteSatisfaction" |
 
 ![만족도 수정 및 삭제](./images/satisfaction-survey-update.png)
 

--- a/common-component/collaboration/schedule-management.md
+++ b/common-component/collaboration/schedule-management.md
@@ -51,7 +51,6 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_postgres.xml | 일정관리를 위한 PostgreSQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_tibero.xml | 일정관리를 위한 Tibero용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_goldilocks.xml | 일정관리를 위한 Goldilocks용 Query XML |
-| Validator XML | resources/egovframework/validator/com/cop/smt/sim/EgovIndvdlSchdulManage.xml | 일정관리 Validator XML |
 | Message properties | resources/egovframework/message/com/cop/smt/sim/message_ko.properties | 마이페이지 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/smt/sim/message_en.properties | 마이페이지 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-diaryManage.xml | 일정관리 Id생성 Idgen XML |
@@ -115,7 +114,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 월별 목록조회 | /cop/smt/sim/EgovIndvdlSchdulManageList.do | egovIndvdlSchdulManageMonthList | “IndvdlSchdulManage” | “selectIndvdlSchdulManageRetrieve” |
+| 월별 목록조회 | /cop/smt/sim/EgovIndvdlSchdulManageList.do | egovIndvdlSchdulManageMonthList | "IndvdlSchdulManage" | "selectIndvdlSchdulManageRetrieve" |
 
 ![일정관리 월별목록](./images/schedule-management-month-list.png)
 
@@ -137,7 +136,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 주간별 목록조회 | /cop/smt/sim/EgovIndvdlSchdulManageWeekList.do | egovIndvdlSchdulManageWeekList | “IndvdlSchdulManage” | “selectIndvdlSchdulManageRetrieve” |
+| 주간별 목록조회 | /cop/smt/sim/EgovIndvdlSchdulManageWeekList.do | egovIndvdlSchdulManageWeekList | "IndvdlSchdulManage" | "selectIndvdlSchdulManageRetrieve" |
 
 ![일정관리 주간별목록](./images/schedule-management-week-list.png)
 
@@ -157,7 +156,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 일별 목록조회 | /cop/smt/sim/EgovIndvdlSchdulManageDailyList.do | egovIndvdlSchdulManageDailyList | “IndvdlSchdulManage” | “selectIndvdlSchdulManageRetrieve” |
+| 일별 목록조회 | /cop/smt/sim/EgovIndvdlSchdulManageDailyList.do | egovIndvdlSchdulManageDailyList | "IndvdlSchdulManage" | "selectIndvdlSchdulManageRetrieve" |
 
 ![일정관리 일별목록](./images/schedule-management-daily-list.png)
 
@@ -177,8 +176,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /cop/smt/sim/EgovIndvdlSchdulManageDetail.do | egovIndvdlSchdulManageDetail | “IndvdlSchdulManage” | “selectIndvdlSchdulManageDetailVO” |
-| 일정삭제 | /cop/smt/sim/EgovIndvdlSchdulManageDetail.do | egovIndvdlSchdulManageDetail | “IndvdlSchdulManage” | “deleteIndvdlSchdulManage” |
+| 상세조회 | /cop/smt/sim/EgovIndvdlSchdulManageDetail.do | egovIndvdlSchdulManageDetail | "IndvdlSchdulManage" | "selectIndvdlSchdulManageDetailVO" |
+| 일정삭제 | /cop/smt/sim/EgovIndvdlSchdulManageDetail.do | egovIndvdlSchdulManageDetail | "IndvdlSchdulManage" | "deleteIndvdlSchdulManage" |
 
 ![일정관리 상세조회 및 삭제](./images/schedule-management-detail.png)
 
@@ -205,7 +204,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 등록화면 | /cop/smt/sim/EgovIndvdlSchdulManageRegist.do | indvdlSchdulManageRegist | | |
-| 등록 | /cop/smt/sim/EgovIndvdlSchdulManageRegistActor.do | indvdlSchdulManageRegistActor | “IndvdlSchdulManage” | “insertIndvdlSchdulManage” |
+| 등록 | /cop/smt/sim/EgovIndvdlSchdulManageRegistActor.do | indvdlSchdulManageRegistActor | "IndvdlSchdulManage" | "insertIndvdlSchdulManage" |
 
 ![일정관리 등록](./images/department-schedule-regist.jpg)
 
@@ -228,7 +227,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 수정화면 | /cop/smt/sim/EgovIndvdlSchdulManageModify.do | indvdlSchdulManageModify | | |
-| 수정 | /cop/smt/sim/EgovIndvdlSchdulManageModifyActor.do | indvdlSchdulManageModifyActor | “IndvdlSchdulManage” | “updateIndvdlSchdulManage” |
+| 수정 | /cop/smt/sim/EgovIndvdlSchdulManageModifyActor.do | indvdlSchdulManageModifyActor | "IndvdlSchdulManage" | "updateIndvdlSchdulManage" |
 
 ![일정관리 수정](./images/schedule-management-modify.png)
 

--- a/common-component/collaboration/scrap-management.md
+++ b/common-component/collaboration/scrap-management.md
@@ -38,8 +38,8 @@ menu:
 | Controller | egovframework.com.cop.scp.web.EgovArticleScrapController.java | 스크랩기능을 위한 컨트롤러 클래스 |
 | Service | egovframework.com.cop.scp.service.EgovArticleScrapService.java | 스크랩기능을 위한 서비스 인터페이스 |
 | ServiceImpl | egovframework.com.cop.scp.service.impl.EgovArticleScrapServiceImpl.java | 스크랩기능을 위한 서비스 구현 클래스 |
-| VO | egovframework.com.cop.bbs.service.Scrap.java | 스크랩기능을 위한 모델 클래스 |
-| VO | egovframework.com.cop.bbs.service.ScrapVO.java | 스크랩기능을 위한 VO 클래스 |
+| VO | egovframework.com.cop.scp.service.Scrap.java | 스크랩기능을 위한 모델 클래스 |
+| VO | egovframework.com.cop.scp.service.ScrapVO.java | 스크랩기능을 위한 VO 클래스 |
 | DAO | egovframework.com.cop.scp.service.impl.EgovArticleScrapDAO.java | 스크랩기능을 위한 데이터처리 클래스 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/scp/EgovArticleScrapList.jsp | 스크랩기능을 위한 목록조회 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/scp/EgovArticleScrapRegist.jsp | 스크랩기능을 위한 등록 jsp페이지 |
@@ -53,7 +53,6 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_maria.xml | 스크랩기능을 위한 MariaDB용 Query XML 파일 |
 | Query XML | resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_postgres.xml | 스크랩기능을 위한 PostgreSQL용 Query XML 파일 |
 | Query XML | resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_goldilocks.xml | 스크랩기능을 위한 Goldilocks용 Query XML 파일 |
-| Validator XML | resources/egovframework/validator/com/cop/scp/EgovArticleScrapRegist.xml | 스크랩기능을 위한 Validator XML |
 | Message properties | resources/egovframework/message/com/cop/scp/message_ko.properties | 스크랩기능을 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/scp/message_en.properties | 스크랩기능을 위한 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-Scrap.xml | 스크랩기능을 위한 Id생성 Idgen XML |
@@ -121,8 +120,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 등록화면 | /cop/scp/insertArticleScrapView.do | insertArticleScrapView | “BBSArticle” | “selectArticleDetail” |
-| 등록 | /cop/scp/insertArticleScrap.do | insertArticleScrap | “ArticleScrap” | “insertArticleScrap” |
+| 등록화면 | /cop/scp/insertArticleScrapView.do | insertArticleScrapView | "BBSArticle" | "selectArticleDetail" |
+| 등록 | /cop/scp/insertArticleScrap.do | insertArticleScrap | "ArticleScrap" | "insertArticleScrap" |
 
 ![스크랩 등록](./images/scrap-management-scrap.png)
 
@@ -148,8 +147,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /cop/scp/selectArticleScrapList.do | selectArticleScrapList | “ArticleScrap” | “selectArticleScrapList” |
-| | | | “ArticleScrap” | “selectArticleScrapListCnt” |
+| 목록조회 | /cop/scp/selectArticleScrapList.do | selectArticleScrapList | "ArticleScrap" | "selectArticleScrapList" |
+| | | | "ArticleScrap" | "selectArticleScrapListCnt" |
 
 스크랩 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
 
@@ -175,8 +174,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /cop/scp/selectArticleScrapDetail.do | selectArticleScrapDetail | “ArticleScrap” | “selectArticleScrapDetail” |
-| 삭제 | /cop/scp/deleteArticleScrap.do | deleteArticleScrap | “ArticleScrap” | “deleteArticleScrap” |
+| 상세조회 | /cop/scp/selectArticleScrapDetail.do | selectArticleScrapDetail | "ArticleScrap" | "selectArticleScrapDetail" |
+| 삭제 | /cop/scp/deleteArticleScrap.do | deleteArticleScrap | "ArticleScrap" | "deleteArticleScrap" |
 
 ![스크랩 상세조회](./images/scrap-management-detail.png)
 
@@ -200,8 +199,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 수정화면 | /cop/scp/updateArticleScrapView.do | updateArticleScrapView | “ArticleScrap” | “selectArticleScrapDetail” |
-| 수정 | /cop/scp/updateArticleScrap.do | updateArticleScrap | “ArticleScrap” | “updateArticleScrap” |
+| 수정화면 | /cop/scp/updateArticleScrapView.do | updateArticleScrapView | "ArticleScrap" | "selectArticleScrapDetail" |
+| 수정 | /cop/scp/updateArticleScrap.do | updateArticleScrap | "ArticleScrap" | "updateArticleScrap" |
 
 ![스크랩 수정](./images//scrap-management-update.png)
 

--- a/common-component/collaboration/sms-service.md
+++ b/common-component/collaboration/sms-service.md
@@ -33,7 +33,7 @@ menu:
 
 ② 이용통보 : 검토 결과를 접수일로부터 15일 이내에 이용신청기관에게 서면으로 통보
 
-③ 서비스준비 : 이용신청기관은 센터에서 제공하는 “M-Gov 연동 API“를 사용하여 연동
+③ 서비스준비 : 이용신청기관은 센터에서 제공하는 "M-Gov 연동 API"를 사용하여 연동
 
 ④ 서비스개통 : 이용신청기관은 승인 후 60일 이내에 서비스 개통을 하지 않을 경우 센터는 이용통보를 취소할 수 있음
 
@@ -41,7 +41,7 @@ menu:
 
 ## 설명
 
-공통컴포넌트에서 제공하는 문자메시지서비스는 “M-Gov 연동 API“를 통해 SMS서비스를 제공할 뿐만 아니라 전송에 대한 이력 관리를 제공한다. (이력 관리가 필요없는 경우를 위해 별도의 메소드를 제공하고 있으나 송신 결과에 대한 내용을 확인할 수 없음)
+공통컴포넌트에서 제공하는 문자메시지서비스는 "M-Gov 연동 API"를 통해 SMS서비스를 제공할 뿐만 아니라 전송에 대한 이력 관리를 제공한다. (이력 관리가 필요없는 경우를 위해 별도의 메소드를 제공하고 있으나 송신 결과에 대한 내용을 확인할 수 없음)
 
 ### 패키지 참조 관계
 
@@ -125,7 +125,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('SMS_ID', 1);
 
 ### 환경설정
 
-본 문자메시지서비스를 사용하기 위해서는 “M-Gov 연동 API“에서 제공하는 “SMEConfig.properties” 파일을 지정되어야 한다.
+본 문자메시지서비스를 사용하기 위해서는 "M-Gov 연동 API"에서 제공하는 "SMEConfig.properties" 파일을 지정되어야 한다.
 
 이를 지정하기 위해서는 globals.properties 속성 파일에 추가 속성을 설정하여야 한다.
 
@@ -190,8 +190,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /cop/sms/selectSmsList.do | selectSmsList | “SmsDAO” | “selectSmsInfs”, |
-| | | | “SmsDAO” | “selectSmsInfsCnt” |
+| 목록조회 | /cop/sms/selectSmsList.do | selectSmsList | "SmsDAO" | "selectSmsInfs", |
+| | | | "SmsDAO" | "selectSmsInfsCnt" |
 
 문자메시지 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 페이지당 검색 범위를 변경하고자 하는 경우 context-properties.xml 파일의 pageUnit, pageSize를 변경한다.(단 해당 설정은 전체 공통서비스 기능에 영향을 미친다.)
 
@@ -215,7 +215,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /cop/sms/selectSms.do | selectSms | “SmsDAO” | “selectSmsInf” |
+| 상세조회 | /cop/sms/selectSms.do | selectSms | "SmsDAO" | "selectSmsInf" |
 
 ![문자메시지 상세조회](./images/sms-service-detail.jpg)
 
@@ -236,7 +236,7 @@ N/A
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
 | 등록화면 | /cop/sms/addSms.do | addSms | | |
-| 전송 | /cop/sms/insertSms.do | insertSms | “SmsDAO” | “insertSmsInf” |
+| 전송 | /cop/sms/insertSms.do | insertSms | "SmsDAO" | "insertSmsInf" |
 
 ![문자메시지 전송](./images/sms-service-insert.jpg)
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

협업(collaboration) 영역 가이드의 관련소스 표를 `egovframe-common-components` 소스 트리와 대조하여, 실제 소스와 불일치하는 표기를 일제 정정했습니다 

**클래스 패키지 정정 (7건)**
- 블로그관리·게시판관리: `cop.bbs.EgovBBSMasterController` → 실제 `cop.bbs.web.EgovBBSMasterController` (`web` 세그먼트 누락)
- 댓글관리: `Comment`·`CommentVO`의 패키지 `cop.bbs.service` → 실제 `cop.cmt.service`
- 스크랩관리: `Scrap`·`ScrapVO`의 패키지 `cop.bbs.service` → 실제 `cop.scp.service`
- 만족도조사: `EgovBBSSatisfactionService`의 패키지 `cop.stf.service` → 실제 `cop.bbs.service`
- 커뮤니티회원관리: Controller의 `web` 세그먼트 누락 보완

**경로 정정 (12건)**
- 통합게시판 `EgovArticleCommentList.jsp` 소재 `cop/bbs/` → 실제 `cop/cmt/`, 커뮤니티회원 `EgovCommuUserList.jsp` `cop/com/` → 실제 `cop/cmy/`
- 부서일정관리 Idgen 파일명 `context-idgen-…` → 실제 `context-idgn-…` (2곳)
- 커뮤니티생성 Query XML 구 iBatis `sqlmap` → 현행 `mapper` (8건)

**기타**
- 현행 소스에 없는 Validator XML 행 12건 제외 (Jakarta Bean Validation 전환)
- 협업 영역 문서의 인용부호를 곧은따옴표로 통일 (286곳, 코드블록은 무변경)

frontmatter는 수정하지 않았습니다

## 관련 이슈 (Related Issues)

- 없음

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)
