### PR TITLE
docs: AOP 문서 패키지 경로 org.egovframe으로 변경

### DIFF
--- a/egovframe-runtime/foundation-layer-core/aop-aspectj.md
+++ b/egovframe-runtime/foundation-layer-core/aop-aspectj.md
@@ -40,7 +40,7 @@ public class AspectUsingAnnotation {
 
 ### 포인트컷(Pointcut) 정의하기
 
- 포인트컷은 결합점(Join points)을 지정하여 충고(Advice)가 언제 실행될지를 지정하는데 사용된다. Spring AOP는 Spring 빈에 대한 메소드 실행 결합점만을 지원하므로, Spring에서 포인트컷은 빈의 메소드 실행점을 지정하는 것으로 생각할 수 있다. 다음 예제는 egovframework.rte.fdl.aop.sample 패키지 하위의 Sample 명으로 끝나는 클래스의 모든 메소드 수행과 일치할 'targetMethod' 라는 이름의 pointcut을 정의한다.
+ 포인트컷은 결합점(Join points)을 지정하여 충고(Advice)가 언제 실행될지를 지정하는데 사용된다. Spring AOP는 Spring 빈에 대한 메소드 실행 결합점만을 지원하므로, Spring에서 포인트컷은 빈의 메소드 실행점을 지정하는 것으로 생각할 수 있다. 다음 예제는 org.egovframe.rte.fdl.aop.sample 패키지 하위의 Sample 명으로 끝나는 클래스의 모든 메소드 수행과 일치할 'targetMethod' 라는 이름의 pointcut을 정의한다.
 
  ```java
 @Aspect
@@ -215,7 +215,7 @@ public class AspectUsingAnnotation {
 
 #### 정상 실행의 경우
 
- testAnnotationAspect() 함수는 대상 메소드가 정상 수행되는 사례를 보여준다. egovframework.rte.fdl.aop.sample 패키지에 속하는 AnnotationAdviceSample 클래스의 someMethod() 메소드는 before, after returning, after finally, around 충고(Advice)가 적용된다.
+ testAnnotationAspect() 함수는 대상 메소드가 정상 수행되는 사례를 보여준다. org.egovframe.rte.fdl.aop.sample 패키지에 속하는 AnnotationAdviceSample 클래스의 someMethod() 메소드는 before, after returning, after finally, around 충고(Advice)가 적용된다.
 
  ```java
  public class AnnotationAspectTest {
@@ -259,7 +259,7 @@ AspectUsingAnnotation.afterReturningTargetMethod executed. return value is [some
 
 #### 예외 발생의 경우
 
- testAnnotationAspectWithException() 함수는 대상 메소드에 오류가 발생한 사례를 보여준다. egovframework.rte.fdl.aop.sample 패키지에 속하는 AnnotationAdviceSample 클래스의 someMethod() 메소드는 before, after throwing, after finally, around 충고(Advice)가 적용된다.
+ testAnnotationAspectWithException() 함수는 대상 메소드에 오류가 발생한 사례를 보여준다. org.egovframe.rte.fdl.aop.sample 패키지에 속하는 AnnotationAdviceSample 클래스의 someMethod() 메소드는 before, after throwing, after finally, around 충고(Advice)가 적용된다.
 
  ```java
  public class AnnotationAspectTest {

--- a/egovframe-runtime/foundation-layer-core/aop-guide.md
+++ b/egovframe-runtime/foundation-layer-core/aop-guide.md
@@ -26,7 +26,7 @@ description: "표준프레임워크 실행환경은 XML Schema 기반의 AOP 방
 
 #### 관점(Aspect) 정의
 
- 예외 처리를 위한 Spring 설정 파일(resources/egovframework.spring/context-aspect.xml) 내에 관점(Aspect) 클래스를 빈으로 정의한 뒤, 해당 관점(Aspect)에 대한 포인트컷과 충고(Advice)를 정의한다.
+ 예외 처리를 위한 Spring 설정 파일(resources/org.egovframe.spring/context-aspect.xml) 내에 관점(Aspect) 클래스를 빈으로 정의한 뒤, 해당 관점(Aspect)에 대한 포인트컷과 충고(Advice)를 정의한다.
 
 ```xml
 <bean id="exceptionTransfer" class="org.egovframe.rte.fdl.cmmn.aspect.ExceptionTransfer">
@@ -103,7 +103,7 @@ public class ExceptionTransfer {
 
 ### 트랜잭션 처리
 
- 실행환경에서 트랜잭션 설정은 “resources/egovframework.spring/context-transaction.xml” 파일을 참조한다. 다음은 context-transaction.xml 설정 파일을 일부이다.
+ 실행환경에서 트랜잭션 설정은 “resources/org.egovframe.spring/context-transaction.xml” 파일을 참조한다. 다음은 context-transaction.xml 설정 파일을 일부이다.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -135,7 +135,7 @@ public class ExceptionTransfer {
 ```
 
 - txAdvice는 메소드에서 예외 발생시 트랜잭션 롤백을 수행한다.
-- requiredTx는 egovframework.rte.sample 패키지 하위 impl 패키지에서 Impl로 끝나는 모든 클래스의 메소드를 포인트컷으로 지정한다.
+- requiredTx는 org.egovframe.rte.sample 패키지 하위 impl 패키지에서 Impl로 끝나는 모든 클래스의 메소드를 포인트컷으로 지정한다.
 
 ## 참고 문서
 

--- a/egovframe-runtime/foundation-layer-core/aop-xmlschema.md
+++ b/egovframe-runtime/foundation-layer-core/aop-xmlschema.md
@@ -34,7 +34,7 @@ description: "Java 5 버전을 사용할 수 없거나 XML 기반 설정을 선�
 
 ### 포인트컷(Pointcut) 정의하기
 
- 포인트컷은 결합점(Join points)을 지정하여 충고(Advice)가 언제 실행될지를 지정하는데 사용된다. Spring AOP는 Spring 빈에 대한 메소드 실행 결합점만을 지원하므로, Spring에서 포인트컷은 빈의 메소드 실행점을 지정하는 것으로 생각할 수 있다. 다음 예제는 egovframework.rte.fdl.aop.sample 패키지 하위의 Sample 명으로 끝나는 클래스의 모든 메소드 수행과 일치할 'targetMethod' 라는 이름의 pointcut을 정의한다. 포인트컷은 &lt;aop:config&gt; 요소 내에 정의한다. 포인트컷 표현식은 AspectJ 포인트컷 표현 언어와 동일하게 사용할 수 있다.
+ 포인트컷은 결합점(Join points)을 지정하여 충고(Advice)가 언제 실행될지를 지정하는데 사용된다. Spring AOP는 Spring 빈에 대한 메소드 실행 결합점만을 지원하므로, Spring에서 포인트컷은 빈의 메소드 실행점을 지정하는 것으로 생각할 수 있다. 다음 예제는 org.egovframe.rte.fdl.aop.sample 패키지 하위의 Sample 명으로 끝나는 클래스의 모든 메소드 수행과 일치할 'targetMethod' 라는 이름의 pointcut을 정의한다. 포인트컷은 &lt;aop:config&gt; 요소 내에 정의한다. 포인트컷 표현식은 AspectJ 포인트컷 표현 언어와 동일하게 사용할 수 있다.
 
  ```xml
 <aop:config>
@@ -181,7 +181,7 @@ description: "Java 5 버전을 사용할 수 없거나 XML 기반 설정을 선�
 
 #### 정상 실행의 경우
 
- testAdvice() 함수는 대상 메소드가 정상 수행되는 사례를 보여준다. egovframework.rte.fdl.aop.sample 패키지에 속하는 AdviceSample 클래스의 someMethod() 메소드는 before, after returning, after finally, around 충고(Advice)가 적용된다.
+ testAdvice() 함수는 대상 메소드가 정상 수행되는 사례를 보여준다. org.egovframe.rte.fdl.aop.sample 패키지에 속하는 AdviceSample 클래스의 someMethod() 메소드는 before, after returning, after finally, around 충고(Advice)가 적용된다.
 
  ```java
  public class AdviceTest{
@@ -226,7 +226,7 @@ AdviceUsingXML.aroundTargetMethod end. Time(12)
 
 #### 예외 발생의 경우
 
- testAnnotationAspectWithException() 함수는 대상 메소드에 오류가 발생한 사례를 보여준다. egovframework.rte.fdl.aop.sample 패키지에 속하는 AnnotationAdviceSample 클래스의 someMethod() 메소드는 before, after throwing, after finally, around 충고(Advice)가 적용된다.
+ testAnnotationAspectWithException() 함수는 대상 메소드에 오류가 발생한 사례를 보여준다. org.egovframe.rte.fdl.aop.sample 패키지에 속하는 AnnotationAdviceSample 클래스의 someMethod() 메소드는 before, after throwing, after finally, around 충고(Advice)가 적용된다.
 
  ```java
  public class AdviceTest{


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)
AOP 관련 문서에 남아 있던 이전 패키지 경로인 `egovframework` 표기를 현재 패키지 경로인 `org.egovframe`으로 변경

## 관련 이슈 (Related Issues)
없음

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)
없음

