### PR TITLE
docs: ETL 문서에 DOCX·HWP·HWPX 리더 3종 추가

### DIFF
--- a/egovframe-runtime/ai-layer/springai-sample-etl.md
+++ b/egovframe-runtime/ai-layer/springai-sample-etl.md
@@ -28,6 +28,9 @@ menu:
 |--------|------|-----------|
 | **EgovMarkdownReader** | Markdown 파일 읽기 | DocumentReader |
 | **EgovPdfReader** | PDF 파일 읽기 (페이지별 분할) | DocumentReader |
+| **EgovDocxReader** | DOCX 파일 읽기 (Apache POI) | DocumentReader |
+| **EgovHwpReader** | HWP 파일 읽기 (hwplib) | DocumentReader |
+| **EgovHwpxReader** | HWPX 파일 읽기 (hwpxlib) | DocumentReader |
 | **EgovContentFormatTransformer** | HTML 태그 제거, 공백/줄바꿈 정규화, 특수문자 정리 | DocumentTransformer |
 | **EgovEnhancedDocumentTransformer** | 문서 분할, 키워드 추출, 요약 생성 | DocumentTransformer |
 | **EgovVectorStoreWriter** | Vector Store에 적재 (Embedding 포함) | DocumentWriter |
@@ -123,6 +126,100 @@ public class EgovPdfReader implements DocumentReader {
         }
 
         return allDocuments;
+    }
+}
+```
+
+---
+
+## EgovDocxReader
+
+Apache POI의 `XWPFWordExtractor`를 사용하여 DOCX 파일에서 텍스트를 추출한다.
+
+```java
+@Slf4j
+@Component
+public class EgovDocxReader implements DocumentReader {
+
+    @Value("${spring.ai.document.docx-path:#{null}}")
+    private String docxDocumentPath;
+
+    @Override
+    public List<Document> get() {
+        // 경로를 설정하지 않으면 건너뛴다
+        if (docxDocumentPath == null || docxDocumentPath.isBlank()) {
+            log.info("DOCX 문서 경로가 설정되지 않아 건너뜁니다.");
+            return List.of();
+        }
+
+        PathMatchingResourcePatternResolver resolver =
+            new PathMatchingResourcePatternResolver();
+        Resource[] resources = resolver.getResources(docxDocumentPath);
+
+        // XWPFWordExtractor로 본문을 추출하여 Document 생성
+        // ...
+    }
+}
+```
+
+---
+
+## EgovHwpReader
+
+hwplib를 사용하여 HWP(한글) 문서에서 텍스트를 추출한다. 공공기관에서 널리 쓰는 문서 형식을 그대로 색인할 수 있다.
+
+```java
+@Slf4j
+@Component
+public class EgovHwpReader implements DocumentReader {
+
+    @Value("${spring.ai.document.hwp-path:#{null}}")
+    private String hwpDocumentPath;
+
+    @Override
+    public List<Document> get() {
+        if (hwpDocumentPath == null || hwpDocumentPath.isBlank()) {
+            log.info("HWP 문서 경로가 설정되지 않아 건너뜁니다.");
+            return List.of();
+        }
+
+        HWPFile hwpFile = HWPReader.fromInputStream(inputStream);
+        String content = TextExtractor.extract(
+            hwpFile, TextExtractMethod.AppendControlTextAfterParagraphText);
+
+        // file_name·source 메타데이터와 함께 Document 생성
+        // ...
+    }
+}
+```
+
+---
+
+## EgovHwpxReader
+
+hwpxlib를 사용하여 HWPX(개방형 한글 문서) 파일에서 텍스트를 추출한다.
+
+```java
+@Slf4j
+@Component
+public class EgovHwpxReader implements DocumentReader {
+
+    @Value("${spring.ai.document.hwpx-path:#{null}}")
+    private String hwpxDocumentPath;
+
+    @Override
+    public List<Document> get() {
+        if (hwpxDocumentPath == null || hwpxDocumentPath.isBlank()) {
+            log.info("HWPX 문서 경로가 설정되지 않아 건너뜁니다.");
+            return List.of();
+        }
+
+        HWPXFile hwpxFile = HWPXReader.fromInputStream(inputStream);
+        String content = TextExtractor.extract(
+            hwpxFile, TextExtractMethod.InsertControlTextBetweenParagraphText);
+
+        // file_name·source 메타데이터와 함께 Document 생성
+        // ...
     }
 }
 ```
@@ -315,6 +412,9 @@ spring:
       # 문서 경로
       path: file:C:/workspace-test/upload/data/**/*.md
       pdf-path: file:C:/workspace-test/upload/data/**/*.pdf
+      docx-path: file:C:/workspace-test/upload/data/**/*.docx
+      hwp-path: file:C:/workspace-test/upload/data/**/*.hwp
+      hwpx-path: file:C:/workspace-test/upload/data/**/*.hwpx
 
       # 청킹 설정
       chunk-size: 4000              # 청크 크기 (토큰)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [x] 기존 문서 보완 (docs/update)
- [ ] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

`springai-sample-etl.md`의 ETL 구성 요소 안내가 현재 코드와 어긋나 있어 보완합니다.

현재 문서는 리더를 `EgovMarkdownReader`·`EgovPdfReader` **2종**만 안내하지만, `egovframe-ai-rag` main에는 **5종**이 있습니다.

| 리더 | 라이브러리 | 설정 키 |
| --- | --- | --- |
| EgovMarkdownReader | - | `spring.ai.document.path` |
| EgovPdfReader | Spring AI PagePdfDocumentReader | `pdf-path` |
| **EgovDocxReader** | Apache POI | `docx-path` |
| **EgovHwpReader** | hwplib 1.1.9 | `hwp-path` |
| **EgovHwpxReader** | hwpxlib 1.0.8 | `hwpx-path` |

문서만 보면 이 샘플이 Markdown·PDF만 색인한다고 이해하게 되어, 특히 공공기관 문서 표준인 HWP/HWPX 지원을 찾지 못하는 문제가 있습니다.

변경한 내용은 다음 세 가지입니다.

1. ETL 구성 요소 표에 DOCX·HWP·HWPX 리더 3행 추가
2. 각 리더 절 추가 — 기존 Markdown·PDF 절과 동일한 형식(설명 + 코드 발췌)
3. `application.yml` 예시에 `docx-path`·`hwp-path`·`hwpx-path` 추가

각 경로 속성은 선택이며, 설정하지 않으면 해당 리더가 로그를 남기고 건너뛴다는 동작도 코드 발췌에 담았습니다.

## 관련 이슈 (Related Issues)

없음

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다. (변경 없음)
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다. (이미지·링크 변경 없음)
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

- 코드는 `egovframe-ai-rag` main 기준으로 확인했습니다(라이브러리 버전·설정 키·미설정 시 스킵 동작·텍스트 추출 API).
- 업로드 API가 지원하는 확장자와 리더(색인)가 지원하는 형식은 별개입니다. 본 PR은 **리더(색인) 문서화**만 다룹니다.