### PR TITLE
chore: 기여자용 문서 정합성 검사 스크립트 scripts/docs_lint.py 추가 (#725)

### DIFF
--- a/scripts/docs_lint.py
+++ b/scripts/docs_lint.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""docs-lint: egovframe-docs 문서 정합성 검사 (표준 라이브러리만 사용)
+
+검사 항목
+L1 truncated-summary : 목차 요약이 '…'로 절단된 라인 (마침표 단위 발췌 규칙 위반)
+L2 broken-rel-link   : 상대링크 대상 파일 부재 (렌더링 사이트 전용 링크 패턴은 정보로만 표시)
+L3 frontmatter       : frontmatter 부재/title·url 누락 (README·docs/ 제외)
+L4 heading-level     : H1 부재 또는 레벨 건너뜀(h2→h4 등)
+L5 source-ref        : 관련소스 클래스 참조가 실제 저장소에 없음 (--src 로 소스 저장소 지정 시)
+
+사용법: python3 docs_lint.py <docs-root> [--src <java-src-root>] [--json]
+"""
+import re, os, sys, glob, json, urllib.parse
+from collections import defaultdict
+
+
+USAGE = 'usage: python3 docs_lint.py <docs-root> [--src <java-src-root>] [--json]'
+
+
+def parse_args(argv):
+    if len(argv) < 2 or argv[1].startswith('-'):
+        print(USAGE); sys.exit(2)
+    root = argv[1]; src = None; as_json = False
+    if not os.path.isdir(root):
+        print('error: not a directory: ' + root); print(USAGE); sys.exit(2)
+    if '--src' in argv:
+        i = argv.index('--src') + 1
+        if i >= len(argv):
+            print('error: --src requires a path'); print(USAGE); sys.exit(2)
+        src = argv[i]
+    if '--json' in argv: as_json = True
+    return root, src, as_json
+
+
+def main():
+    ROOT, SRC, AS_JSON = parse_args(sys.argv)
+    findings = []
+    mds = [m for m in glob.glob(ROOT + '/**/*.md', recursive=True) if '/.git/' not in m]
+
+    cls_index = set()
+    if SRC:
+        for p in glob.glob(SRC + '/**/*.java', recursive=True):
+            if '/main/' in p:
+                rel = p.split('/src/main/java/')[-1][:-5]
+                cls_index.add(rel.replace('/', '.'))
+
+    for md in mds:
+        rel = os.path.relpath(md, ROOT)
+        text = open(md, encoding='utf-8', errors='replace').read()
+        body = re.sub(r'```.*?```', '', text, flags=re.S)
+
+        # L1 truncated summary
+        for i, l in enumerate(text.split('\n'), 1):
+            if re.search(r'\)\s*(?:—|-)\s.*…\s*$', l.strip()):
+                findings.append((rel, i, 'L1', '요약 말줄임(…) — 문장 단위 발췌 필요'))
+
+        # L2 relative links
+        d = os.path.dirname(md)
+        for m in re.finditer(r'\[[^\]]*\]\(([^)\s]+)\)', body):
+            href = m.group(1)
+            if href.startswith(('http', 'mailto:', '#', '/')): continue
+            path = urllib.parse.unquote(href.split('#')[0])
+            if not path: continue
+            t = os.path.normpath(os.path.join(d, path))
+            ok = os.path.exists(t) or os.path.exists(t + '.md') or os.path.exists(os.path.join(t, '_index.md'))
+            if not ok:
+                kind = 'L2' if not href.endswith('/') else 'L2-info'
+                # 사이트 렌더 인지: 상위 섹션의 images/ 에 동일 파일명이 있으면 렌더링 사이트에서 정상 (GitHub 뷰 한정 문제)
+                base = os.path.basename(path)
+                cur = d
+                for _ in range(4):
+                    cur = os.path.dirname(cur)
+                    if cur and os.path.exists(os.path.join(cur, 'images', base)):
+                        kind = 'L2-siteok'; break
+                if kind != 'L2-siteok' and href.rstrip('/').count('/') <= 2 and href.endswith('/'):
+                    t2 = os.path.normpath(os.path.join(d, path.rstrip('/')))
+                    if os.path.exists(t2 + '.md'): kind = 'L2-siteok'
+                findings.append((rel, 0, kind, '상대링크 대상 부재: ' + href))
+
+        # L3 frontmatter
+        if not rel.startswith(('docs/', 'README')) and rel != '_index.md':
+            fm = re.match(r'^---\r?\n(.*?)\r?\n---', text, re.S)
+            if not fm:
+                findings.append((rel, 1, 'L3', 'frontmatter 없음'))
+            else:
+                if not re.search(r'^\s*title\s*:', fm.group(1), re.M):
+                    findings.append((rel, 1, 'L3', 'frontmatter title 누락'))
+
+        # L4 heading levels
+        levels = [len(m.group(1)) for m in re.finditer(r'^(#{1,6})\s', body, re.M)]
+        if levels:
+            prev = levels[0]
+            for lv in levels[1:]:
+                if lv > prev + 1:
+                    findings.append((rel, 0, 'L4', f'제목 레벨 건너뜀 h{prev}->h{lv}'))
+                    break
+                prev = lv
+
+        # L5 source refs
+        if cls_index:
+            for m in re.finditer(r'`((?:egovframework|org\.egovframe)\.[A-Za-z0-9_.]*?[A-Z][A-Za-z0-9_]*)(?:\.java)?`', body):
+                ref = m.group(1)
+                if ref not in cls_index and ref.split('.')[-1][0].isupper():
+                    simple = ref.split('.')[-1]
+                    if not any(c.endswith('.' + simple) for c in cls_index):
+                        findings.append((rel, 0, 'L5', '실소스 부재 참조: ' + ref))
+
+    by = defaultdict(int)
+    for f in findings: by[f[2]] += 1
+    if AS_JSON:
+        print(json.dumps({'total': len(findings), 'byRule': dict(by),
+                          'findings': [{'file': f[0], 'line': f[1], 'rule': f[2], 'msg': f[3]} for f in findings]},
+                         ensure_ascii=False, indent=1))
+    else:
+        print(f'files scanned: {len(mds)} / findings: {len(findings)} {dict(by)}')
+        for f in findings[:50]: print(f'{f[2]} {f[0]}:{f[1]} {f[3]}')
+
+
+if __name__ == '__main__': main()
+


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [ ] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [x] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

#725에서 말씀해 주신 대로 스크립트를 작성해 PR로 올립니다. 기여자가 **제출 전에 스스로 돌려보는 로컬 검사 도구**이며, 문서 파일은 하나도 건드리지 않습니다.

`scripts/docs_lint.py` 1개 파일만 추가합니다 (119줄).

| 규칙 | 검사 내용 |
| --- | --- |
| L1 | 목차 요약이 `…`로 절단됨 (#716에서 지적된 문장 단위 발췌 규칙) |
| L2 | 상대링크 대상 파일 부재 |
| L3 | frontmatter 부재 / `title` 누락 |
| L4 | 제목 레벨 건너뜀 (h2 → h4 등) |
| L5 | 관련소스 클래스 참조가 실제 소스에 없음 (`--src` 지정 시에만) |

```
python3 scripts/docs_lint.py .
python3 scripts/docs_lint.py . --json
python3 scripts/docs_lint.py . --src ../egovframe-common-components
```

## 관련 이슈 (Related Issues)

Refs #725

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [x] 기타 (`README`, 설정 파일 등) — `scripts/` 신규

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다. (문서 변경 없음)
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다. (문서 변경 없음)
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 실행 결과 (현재 main 전수 검사)

```
$ python3 scripts/docs_lint.py .
files scanned: 672 / findings: 157 {'L2': 13, 'L3': 1, 'L2-siteok': 142, 'L4': 1}
```

157건 중 **142건은 `L2-siteok`(정보성)** 입니다. `./images/foo.png`처럼 상위 섹션의 `images/`를 참조하는 패턴은 Hugo 렌더링 사이트에서는 정상이고 GitHub 뷰에서만 깨져 보이므로, 오탐으로 보고하지 않고 따로 분류합니다. 과거 link-check CI가 이런 패턴 때문에 소음이 컸던 점을 반영한 설계입니다.

실제로 확인이 필요한 것은 **15건**이며, 전부 수동으로 실존 여부를 대조했습니다(오탐 0건).

| 규칙 | 건수 | 예시 |
| --- | --- | --- |
| L2 | 13 | `egovframe-runtime/intro.md` → `./presentation-layer/uxui-controller-component.md` (해당 파일 없음), foundation-layer·batch-layer 4개 문서 → `../../runtime-example/...` (`runtime-example/` 디렉토리 자체가 없음) |
| L3 | 1 | `egovframe-runtime/intro.md` frontmatter 없음 |
| L4 | 1 | `common-component/user-authentication/find-id-password.md` — `## 개요` 다음이 `#### 기능흐름` (h2→h4) |

이번 PR은 **스크립트 추가만** 다루며 위 15건 수정은 포함하지 않았습니다. 필요하시면 별도 PR로 정리하겠습니다.

## 검증 (Validation)

- 실행 환경: Python 3.10.12 / Ubuntu. 표준 라이브러리만 사용하고 설치·의존성이 없습니다 (`import re, os, sys, glob, json, urllib.parse` + `collections.defaultdict`).
- 현재 main 전수 실행(672개 `.md`) 정상 완료, 종료 코드 0.
- `--json` 출력 파싱 정상, `--src` 경로 지정 시 L5 동작 확인.
- 인자 오류 처리 확인: 인자 없음 / 존재하지 않는 경로 / `--src` 값 누락 → usage 출력 후 종료 코드 2.

## 추가 참고 사항 (Additional Notes)

- **CI는 건드리지 않았습니다.** `.github/workflows/`에 변경이 없고, 워크플로에서 이 스크립트를 호출하지도 않습니다. 실행은 전적으로 기여자 수동입니다.
- 자동 머지 워크플로(`merge-on-pr.yaml`)의 `paths`는 `**.md`와 이미지 확장자만 대상으로 하므로, `.py` 파일만 있는 이 PR은 워크플로가 트리거되지 않고 Open 상태로 남습니다. 말씀하신 대로 센터 확인 후 처리 부탁드립니다.
- 기본 동작은 **보고 전용(종료 코드 0)** 입니다. 게이트로 쓰실 의향이 있으시면 하드 결함 발견 시 1을 반환하는 `--strict` 옵션을 후속 PR로 추가하겠습니다. 이번에는 제안 범위대로 두었습니다.
- 규칙 임계값이나 분류 방식에 조정이 필요하면 알려 주시면 반영하겠습니다. 감사합니다.