### PR TITLE
docs(runtime): 미변환 실행환경 예제·모바일 frontend를 가리키는 깨진 링크 제거 (#723)

### DIFF
--- a/egovframe-runtime/batch-layer/batch-core-parallel_process.md
+++ b/egovframe-runtime/batch-layer/batch-core-parallel_process.md
@@ -44,10 +44,6 @@ TaskExecutor 예제에서 TaskExecutor 인터페이스를 구현하기 위해 �
 
 ✔ DataSource 처럼 Step에서 사용되는 풀이 리소스들에 의해 대체될 수 있다. 그러므로 Step에서 병행처리 되는 쓰레드 수를 원하는 만큼 최대한 풀을 설정해야 한다.
 
-#### 관련 예제
-
-[멀티쓰레드 예제](./batch-example-multi_process.md)
-
 ### Parallel Steps
 
 병행처리가 필요한 응용프로그램 로직은 서로 다른 책임으로 분할될 뿐만 아니라, 각 단계에서 할당되면 그것이 한 프로세스에서 병행처리가 될 수 있다. Parallel Step 수행은 사용하고 구성하기 쉽다.
@@ -76,10 +72,6 @@ task-executor 속성은 각각의 흐름을 실행하는데 필요한 TaskExecut
 
 
 ![parallelstep1](./images/parallelstep1.png)
-
-#### 관련 예제
-
-[Parallel 예제](./batch-example-multi_process.md)
 
 ### 파티셔닝(Partitioning)
 

--- a/egovframe-runtime/batch-layer/batch-core-skip_repeat_retry.md
+++ b/egovframe-runtime/batch-layer/batch-core-skip_repeat_retry.md
@@ -69,10 +69,6 @@ Skip, Retry, Repeat은 효율적인 배치수행을 위해 필요한 기능들�
 </step>
 ```
 
-#### 관련예제
-
- [건너뛰기(Skip) 기능 예제](../../runtime-example/individual-example/batch-layer/batch-example-skip_mgmt.md)
-
 ### Retry
 
  Retry는 데이터를 Processing, Writing 하는 동안 설정된 Exception이 발생했을 경우, 지정한 정책에 따라 데이터 처리를 재시도하는 기능이다. Skip 과 마찬가지로 Retry를 함으로써, 배치수행의 빈번한 실패를 줄일 수 있게 한다.
@@ -315,10 +311,6 @@ public interface RetryListener {
 ```
 
  이 예에서는 인터셉터 내에 있는 기본 RetryTemplate을 사용한다. 리스너나 정책을 변경하기 위해 인터셉터에 RetryTemplate을 적용하는 것이 필요하다.
-
-#### 관련예제
-
- [재시도(Retry) 예제](../../runtime-example/individual-example/batch-layer/batch-example-retry_mgmt.md)
 
 ### Repeat
 

--- a/egovframe-runtime/batch-layer/batch-example-sync_async_v3.7.md
+++ b/egovframe-runtime/batch-layer/batch-example-sync_async_v3.7.md
@@ -45,7 +45,7 @@ Job 수행시, 동기와 비동기 방식으로 데이터를 처리할 수 있�
 
 ##### 동기/비동기 처리 예제의 Job 설정 파일인 delegatingJob.xml을 확인한다.
 
-동기/비동기 처리 예제를 위해 특별히 Job을 설정하는 내용은 없다. 이 예제에서 제공하는 Job의 상세 내용은 [기존 업무 재사용 예제](./batch-example-job-reuse.md)의 Job 설정과 같으므로 이를 참고한다.
+동기/비동기 처리 예제를 위해 특별히 Job을 설정하는 내용은 없다. 이 예제에서 제공하는 Job의 상세 내용은 기존 업무 재사용 예제의 Job 설정과 같으므로 이를 참고한다.
 
 ```xml
 <job id="delegateJob" xmlns="http://www.springframework.org/schema/batch">

--- a/egovframe-runtime/foundation-layer/file-upload-download-service.md
+++ b/egovframe-runtime/foundation-layer/file-upload-download-service.md
@@ -79,6 +79,3 @@ multiple files with a single file(한단 샘플)에서 사용한 JavaScript를 �
 - [Spring Framework 6.2 - Multipart Resolver](https://docs.spring.io/spring-framework/reference/6.2/web/webmvc/mvc-controller/multipart.html): 파일 업로드(Multipart), CommonsMultipartResolver
 - [Spring Framework 6.2 - Spring MVC](https://docs.spring.io/spring-framework/reference/6.2/web/webmvc.html): DispatcherServlet, Annotated Controllers
 - [Apache Commons FileUpload](https://commons.apache.org/fileupload/)
-
-## 예제
-- [파일업로드 예제](../../runtime-example/individual-example/foundation-layer/file-upload-example.md)

--- a/egovframe-runtime/foundation-layer/file-upload-service.md
+++ b/egovframe-runtime/foundation-layer/file-upload-service.md
@@ -172,6 +172,3 @@ return "success";
 ```
 
 Tomcat에서는 일반적으로 웹 어플리케이션이 GET과 POST 방식으로 파라미터를 넘겨 받을 때 request.setCharacterEncoding()을 통한 문자셋 인코딩이 필요하다.
-
-## 예제
-- [파일업로드 예제](../../runtime-example/individual-example/foundation-layer/file-upload-example.md)

--- a/egovframe-runtime/foundation-layer/mail.md
+++ b/egovframe-runtime/foundation-layer/mail.md
@@ -215,6 +215,3 @@ src 폴더 아래에 Index.jsp를 선택하여 마우스 오른쪽 클릭하여 
 
 - [Spring Framework 6.2 - Email](https://docs.spring.io/spring-framework/reference/6.2/integration/email.html): JavaMailSender, 메일 발송
 - [Apache Commons Email User Guide](https://commons.apache.org/proper/commons-email/userguide.html)
-
-## 예제
-[mail-example](../../runtime-example/individual-example/foundation-layer/mail-example.md)

--- a/egovframe-runtime/foundation-layer/marshalling-unmarshalling.md
+++ b/egovframe-runtime/foundation-layer/marshalling-unmarshalling.md
@@ -466,6 +466,3 @@ public void testUnmarshalling()
 - [Spring Framework 6.2 - Marshalling XML by Using Object-XML Mappers](https://docs.spring.io/spring-framework/reference/6.2/data-access/oxm.html): Marshaller/Unmarshaller 추상화
 - [Castor](http://castor.codehaus.org/)
 - [Apache XMLBeans](https://xmlbeans.apache.org/documentation/tutorial_getstarted.html)
-
-## 예제
-- [marshalling/unmarshalling 예제](../../runtime-example/individual-example/foundation-layer/marshalling-unmarshalling-example.md)

--- a/egovframe-runtime/intro.md
+++ b/egovframe-runtime/intro.md
@@ -118,8 +118,6 @@
 * [bootstrap](./presentation-layer/bootstrap.md)
 
 ### UX처리
-* [UX/UI Controller Component](./presentation-layer/uxui-controller-component.md)
-* [HTML5+CSS3.0+JavaScript Module App Framework 기본 활용](./presentation-layer/html5-css3.0-javascript-module-app-framework-basic.md)
 * [UI - bootstrap](./presentation-layer/bootstrap.md)
 
 ### 업무처리


### PR DESCRIPTION
## 관련 이슈
#723 (3번 항목 — 미제공 파일로 인한 미사용 경로 삭제)

## 배경
#723 에서 보고한 깨진 상대링크 13건에 대해 유지관리자님이 다음과 같이 정리해 주셨습니다.

- README 예시 이미지 1건: 예시코드용 경로로 조치 대상 아님
- `batch-layer/batch-centercut-intro.md` 1건: 원본 위키가 존재 -> 문서 추가 대상(별도 PR)
- 미제공(미변환) 파일로 인한 깨진 링크 10건: 5.0부터 실행환경 예제 및 HTML 모바일 frontend 미제공에 따라 전부 미사용

이 PR 은 위 **3번(미사용 경로 삭제)**을 반영합니다. centercut 가이드 문서 추가는 별도 PR 로 진행합니다.

## 변경 내용 (8개 문서)
- `egovframe-runtime/intro.md` — UX처리 목록의 미변환 모바일 frontend 링크 2건 제거 (UX/UI Controller Component, HTML5+CSS3.0+JavaScript Module App Framework). 유효한 `UI - bootstrap` 항목은 유지
- `foundation-layer/file-upload-service.md`, `file-upload-download-service.md`, `mail.md`, `marshalling-unmarshalling.md` — 미변환 `runtime-example/individual-example/...` 예제 링크만 있던 `## 예제` 섹션 제거
- `batch-layer/batch-core-skip_repeat_retry.md` — Skip/Retry 관련예제 링크 제거
- `batch-layer/batch-core-parallel_process.md` — 멀티쓰레드/Parallel 관련 예제 링크 제거
- `batch-layer/batch-example-sync_async_v3.7.md` — 문장 중간의 `batch-example-job-reuse.md` 링크를 평문으로 변경(문장 의미 유지)

제거 대상은 모두 저장소에 존재하지 않는 문서를 가리켜 렌더링 사이트에서 404 가 발생하던 링크입니다.

## 참고 (범위 외)
정리 중 `batch-layer/batch-core-multidata_process.md` 에 동일 성격의 깨진 **절대경로** 링크 2건(`/runtime-example/.../batch-example-composite_item.md`, `.../batch-example-multi_resource.md`)이 추가로 확인되었습니다. #723 에 보고된 13건(상대링크)에는 포함되지 않아 이 PR 범위에서는 제외했으며, 원하시면 함께 정리하겠습니다.