### PR TITLE
docs(batch): 미사용 runtime-example 경로 제거 — 저장소 내 마지막 2건 (#723, #769)

### DIFF
--- a/egovframe-runtime/batch-layer/batch-core-multidata_process.md
+++ b/egovframe-runtime/batch-layer/batch-core-multidata_process.md
@@ -281,7 +281,5 @@ public class FileItemProcessor implements ItemProcessor<EgovCompositeDataProvide
 
 ## 참고자료
 
-- [CompositItem 예제](/runtime-example/individual-example/batch-layer/batch-example-composite_item.md)
-- [MultiResource예제](/runtime-example/individual-example/batch-layer/batch-example-multi_resource.md)
 - [MultiItemReader](https://docs.spring.io/spring-batch/reference/5.2/readersAndWriters.html#multiFileInput)
 - [CompositeItemWriter](https://docs.spring.io/spring-batch/reference/5.2/readersAndWriters.html#delegatePatternAndRegistering)


### PR DESCRIPTION
## 관련 이슈 / PR
#723, #769 (병합) — #769 에 남겨주신 안내 후속 조치입니다.

## 배경
#769 병합 시 "현재 `runtime-example` 경로는 사용하고 있지 않으므로 관련 경로를 발견하면 제거를 요청드립니다" 라고 안내해 주셔서, 저장소 전체를 다시 확인하고 남아 있던 경로를 제거했습니다.

## 변경 내용
`egovframe-runtime/batch-layer/batch-core-multidata_process.md` 의 `## 참고자료` 에서 미사용 `runtime-example` 절대경로 링크 2건을 제거했습니다.

```diff
-- [CompositItem 예제](/runtime-example/individual-example/batch-layer/batch-example-composite_item.md)
-- [MultiResource예제](/runtime-example/individual-example/batch-layer/batch-example-multi_resource.md)
 - [MultiItemReader](https://docs.spring.io/spring-batch/reference/5.2/readersAndWriters.html#multiFileInput)
 - [CompositeItemWriter](https://docs.spring.io/spring-batch/reference/5.2/readersAndWriters.html#delegatePatternAndRegistering)
```

유효한 Spring Batch 공식 문서 링크 2건은 그대로 두어 `참고자료` 절은 유지됩니다.

## 확인
- 최신 main 기준 저장소 전체 재검색 결과 **`runtime-example` 참조는 이 2건이 마지막**이며, 제거 후 남은 참조는 없습니다.
- `scripts/docs_lint.py .` 실행 결과가 변경 전후 **동일**합니다(673개 파일, 신규 지적 0건).

## 참고 (범위 외)
위 lint 실행 시 기존 지적 2건이 함께 보고됩니다 — `README.md` 의 예시 이미지 경로(이전에 조치 대상 아님으로 안내해 주신 항목)와 `egovframe-runtime/intro.md` 의 frontmatter 누락입니다. 후자는 이력상 이전부터 이어져 온 상태로 확인했고, 필요하시면 별도로 정리하겠습니다.