### PR TITLE
docs: 요소기술 문서의 클래스 표기를 실제 소스에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/file-download.md
+++ b/common-component/elementary-technology/file-download.md
@@ -64,7 +64,7 @@ Globals.fileStorePath = /product/jeus/egovProps/upload/
 #### Controller 구현 예시
 
 ```java
-import egovframework.com.utl.sim.service.EgovFileMngUtil;
+import egovframework.com.cmm.service.EgovFileMngUtil;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/common-component/elementary-technology/social_login_naver_google_kakao.md
+++ b/common-component/elementary-technology/social_login_naver_google_kakao.md
@@ -32,7 +32,7 @@ Social Login은 다음과 같은 기능을 제공한다.
 | 유형 | 대상소스 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Controller | egovframework.com.ext.oauth.web.EgovSignupController.java | 소셜 로그인을 처리하는 컨트롤러 클래스 |  |
-| Service | egovframework.com.ext.oauth.service.NAVERAPI20.java | 네이버 로그인을 돕는 서비스 |  |
+| Service | egovframework.com.ext.oauth.service.NaverAPI20.java | 네이버 로그인을 돕는 서비스 |  |
 | Service | egovframework.com.ext.oauth.service.OAuthConfig.java | 소셜 로그인 인증과 토큰 관련 URL이 있는 서비스 |  |
 | Service | egovframework.com.ext.oauth.service.OAuthLogin.java | 소셜 로그인 인증 및 로그인 정보를 처리하는 서비스 |  |
 | VO | egovframework.com.ext.oauth.service.OAuthUniversalUser.java | 소셜 로그인 계정에 대한 VO |  |


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

관련소스 표와 예제 코드의 클래스 표기가 실제 공통컴포넌트 소스와 다른 곳 두 군데를 맞췄습니다.

- `file-download.md` 의 Controller 예제 import 가 `egovframework.com.utl.sim.service.EgovFileMngUtil` 인데 실제 위치는 `egovframework.com.cmm.service` 입니다. 같은 문서 34행의 관련소스 표와 `file-upload.md` 예제는 이미 `cmm.service` 로 적고 있습니다. 예제를 그대로 복사하면 해당 클래스를 찾지 못합니다.
- `social_login_naver_google_kakao.md` 관련소스 표의 `NAVERAPI20` 을 실제 클래스명 `NaverAPI20` 으로 바꿨습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

`egovframe-common-components` 소스 트리에서 두 클래스의 실제 경로를 확인했습니다.
