### PR TITLE
docs: 요소기술 문서의 WEB_INF 표기를 WEB-INF 로 정정

### DIFF
--- a/common-component/elementary-technology/client-info-check.md
+++ b/common-component/elementary-technology/client-info-check.md
@@ -41,7 +41,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovClntInfo.java` | 클라이언트 정보확인 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovClntInfo.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovClntInfo.jsp` | 테스트 페이지 | |
 
 ### 메소드
 

--- a/common-component/elementary-technology/directory-attribute-check.md
+++ b/common-component/elementary-technology/directory-attribute-check.md
@@ -46,7 +46,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | egovframework.com.utl.sim.service.EgovFileTool.java | 파일관리 요소기술 클래스 | |
-| JSP | WEB_INF/jsp/egovframework/cmm/utl/EgovDrctryInfoCeck.jsp | 테스트 페이지 | |
+| JSP | WEB-INF/jsp/egovframework/cmm/utl/EgovDrctryInfoCeck.jsp | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/directory-copy.md
+++ b/common-component/elementary-technology/directory-copy.md
@@ -51,7 +51,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDrctryCopy.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovDrctryCopy.jsp` | 테스트 페이지 | |
 
 ### 메소드 설명
 

--- a/common-component/elementary-technology/directory-create.md
+++ b/common-component/elementary-technology/directory-create.md
@@ -49,7 +49,7 @@ menu:
 | 유형 | 대상 소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDrctryCreate.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovDrctryCreate.jsp` | 테스트 페이지 | |
 
 ### 메소드
 

--- a/common-component/elementary-technology/directory-date-check.md
+++ b/common-component/elementary-technology/directory-date-check.md
@@ -41,7 +41,7 @@ menu:
 | 유형 | 대상 소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDrctryCreate.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovDrctryCreate.jsp` | 테스트 페이지 | |
 
 ### 메소드
 

--- a/common-component/elementary-technology/directory-exist-check.md
+++ b/common-component/elementary-technology/directory-exist-check.md
@@ -40,7 +40,7 @@ menu:
 | 유형 | 대상 소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDrctryExst.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovDrctryExst.jsp` | 테스트 페이지 | |
 
 ### 메소드
 

--- a/common-component/elementary-technology/directory-move.md
+++ b/common-component/elementary-technology/directory-move.md
@@ -30,7 +30,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDrctryMvmn.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovDrctryMvmn.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/directory-permission-check.md
+++ b/common-component/elementary-technology/directory-permission-check.md
@@ -29,7 +29,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileAuthor.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFileAuthor.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/directory-watch.md
+++ b/common-component/elementary-technology/directory-watch.md
@@ -30,7 +30,7 @@ menu:
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 시스템 정보 확인 요소기술 클래스 | |
 | Service | `egovframework.com.utl.sim.service.EgovFileMntrg.java` | 디렉토리 감시 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDrctryMntrg.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovDrctryMntrg.jsp` | 테스트 페이지 | |
 
 ### 메소드
 

--- a/common-component/elementary-technology/disk-attribute-check.md
+++ b/common-component/elementary-technology/disk-attribute-check.md
@@ -28,7 +28,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDiskAttrCeck.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovDiskAttrCeck.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/disk-capacity-check.md
+++ b/common-component/elementary-technology/disk-capacity-check.md
@@ -31,7 +31,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovSysInfo.java` | 시스템 정보 확인 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDiskCpcty.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovDiskCpcty.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/disk-exist-check.md
+++ b/common-component/elementary-technology/disk-exist-check.md
@@ -24,7 +24,7 @@ menu:
 | 유형 | 대상 소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.service.EgovSysInfo.java` | 시스템 정보 확인 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDiskExst.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovDiskExst.jsp` | 테스트 페이지 | |
 
 ### 메서드
 

--- a/common-component/elementary-technology/encoding-decoding.md
+++ b/common-component/elementary-technology/encoding-decoding.md
@@ -29,7 +29,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.fcc.service.EgovStringUtil.java` | 문자열 처리 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovEncdDcd.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovEncdDcd.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-attribute-check.md
+++ b/common-component/elementary-technology/file-attribute-check.md
@@ -46,7 +46,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileAttrCeck.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFileAttrCeck.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-conversion.md
+++ b/common-component/elementary-technology/file-conversion.md
@@ -31,7 +31,7 @@ OpenOffice와 JODConverter 라이브러리를 활용하여 서버 환경에서 �
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileConverter.java` | 파일변환 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileCnvr.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFileCnvr.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-copy.md
+++ b/common-component/elementary-technology/file-copy.md
@@ -33,7 +33,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileCopy.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFileCopy.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-create.md
+++ b/common-component/elementary-technology/file-create.md
@@ -30,7 +30,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileCre.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFileCre.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-date-check.md
+++ b/common-component/elementary-technology/file-date-check.md
@@ -30,7 +30,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileDtCeck.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFileDtCeck.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-delete.md
+++ b/common-component/elementary-technology/file-delete.md
@@ -30,7 +30,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDrctryFileDelete.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovDrctryFileDelete.jsp` | 테스트 페이지 | |
 
 ### 메소드 설명
 

--- a/common-component/elementary-technology/file-download.md
+++ b/common-component/elementary-technology/file-download.md
@@ -32,7 +32,7 @@ menu:
 | --- | --- | --- | --- |
 | Controller | `egovframework.com.cmm.web.EgovFileDownloadController.java` | 파일다운로드 컨트롤러 | |
 | Util | `egovframework.com.cmm.service.EgovFileMngUtil.java` | 파일 처리 유틸리티 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileDownload.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFileDownload.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-exist-check.md
+++ b/common-component/elementary-technology/file-exist-check.md
@@ -33,7 +33,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileExst.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFileExst.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-move.md
+++ b/common-component/elementary-technology/file-move.md
@@ -28,7 +28,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovDrctryMvmn.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovDrctryMvmn.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-parsing.md
+++ b/common-component/elementary-technology/file-parsing.md
@@ -31,7 +31,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFilePars.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFilePars.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-permission-check.md
+++ b/common-component/elementary-technology/file-permission-check.md
@@ -29,7 +29,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileTool.java` | 파일관리 툴 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileAuthor.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFileAuthor.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-security.md
+++ b/common-component/elementary-technology/file-security.md
@@ -33,7 +33,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFileScrty.java` | 파일 암호화/복호화 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFileScrty.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFileScrty.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/file-send-receive.md
+++ b/common-component/elementary-technology/file-send-receive.md
@@ -30,7 +30,7 @@ FTP 프로토콜을 사용하여 파일을 송수신하는 기능을 제공한�
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovFtpTool.java` | 파일송수신 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovFtpTool.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFtpTool.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/main-menu.md
+++ b/common-component/elementary-technology/main-menu.md
@@ -30,7 +30,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovMenuGov.java` | 메인메뉴 요소기술 클래스 | 메뉴파일 생성 |
-| JSP | `WEB_INF/jsp/egovframework/cmm/EgovMenuGov.jsp` | 테스트 페이지 | 직접 생성 (사용방법 참고) |
+| JSP | `WEB-INF/jsp/egovframework/cmm/EgovMenuGov.jsp` | 테스트 페이지 | 직접 생성 (사용방법 참고) |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/network-info-check.md
+++ b/common-component/elementary-technology/network-info-check.md
@@ -30,7 +30,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovNetworkState.java` | 네트워크정보 확인 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovNetworkInfo.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovNetworkInfo.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/network-status-check.md
+++ b/common-component/elementary-technology/network-status-check.md
@@ -28,7 +28,7 @@ Ping Test를 통해 네트워크 통신가능 여부를 확인하는 기능을 �
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovNetworkState.java` | 네트워크 상태 체크 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovNetworkState.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovNetworkState.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/process-id-check.md
+++ b/common-component/elementary-technology/process-id-check.md
@@ -41,7 +41,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovSysInfo.java` | 시스템 정보 확인 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovProcsInfo.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovProcsInfo.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/property.md
+++ b/common-component/elementary-technology/property.md
@@ -41,7 +41,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.cmm.service.EgovProperties.java` | 프로퍼티 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovProperty.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovProperty.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/server-info-check.md
+++ b/common-component/elementary-technology/server-info-check.md
@@ -32,7 +32,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovSysInfo.java` | 시스템 정보 확인 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovSysInfo.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovSysInfo.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/social_login_naver_google_kakao.md
+++ b/common-component/elementary-technology/social_login_naver_google_kakao.md
@@ -37,9 +37,9 @@ Social Login은 다음과 같은 기능을 제공한다.
 | Service | egovframework.com.ext.oauth.service.OAuthLogin.java | 소셜 로그인 인증 및 로그인 정보를 처리하는 서비스 |  |
 | VO | egovframework.com.ext.oauth.service.OAuthUniversalUser.java | 소셜 로그인 계정에 대한 VO |  |
 | VO | egovframework.com.ext.oauth.service.OAuthVO.java | 소셜 로그인 인증을 받기 위한 VO |  |
-| JSP | WEB_INF/jsp/egovframework/com/uat/uia/EgovLoginUsr.jsp | 소셜 로그인을 연동하는 페이지 |  |
-| JSP | WEB_INF/jsp/egovframework/com/uat/uia/EgovLoginUsrOauth.jsp | 소셜 로그인을 처리하는 페이지 |  |
-| JSP | WEB_INF/jsp/egovframework/com/uat/uia/EgovLoginUsrOauthResult.jsp | 소셜 로그인 결과를 출력하는 페이지 |  |
+| JSP | WEB-INF/jsp/egovframework/com/uat/uia/EgovLoginUsr.jsp | 소셜 로그인을 연동하는 페이지 |  |
+| JSP | WEB-INF/jsp/egovframework/com/uat/uia/EgovLoginUsrOauth.jsp | 소셜 로그인을 처리하는 페이지 |  |
+| JSP | WEB-INF/jsp/egovframework/com/uat/uia/EgovLoginUsrOauthResult.jsp | 소셜 로그인 결과를 출력하는 페이지 |  |
 | XML | resources/egovframework/spring/com/context-oauth.xml | 소셜 로그인의 ID, Secret 등 인증값을 설정하는 XML |  |
 
 ## 설정방법

--- a/common-component/elementary-technology/system-info-check.md
+++ b/common-component/elementary-technology/system-info-check.md
@@ -32,7 +32,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovSysInfo.java` | 시스템정보 확인 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovSysInfo.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovSysInfo.jsp` | 테스트 페이지 | |
 
 > ※ 해당 파일은 보안상의 이유로 배포되지 않는다. 필요시 표준프레임워크 지원 이메일(egovframesupport@gmail.com)로 요청하면 관련 파일을 전달받을 수 있다.
 

--- a/common-component/elementary-technology/tree-menu.md
+++ b/common-component/elementary-technology/tree-menu.md
@@ -28,7 +28,7 @@ menu:
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovMenuGov.java` | 메인메뉴 요소기술 클래스 | 메뉴파일 생성 |
 | JS | `/js/egovframework/cmm/utl/EgovMenuGov.js` | 트리생성 JavaScript | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/EgovTreeMenu.jsp` | 테스트 페이지 | 직접 생성 (사용방법 참고) |
+| JSP | `WEB-INF/jsp/egovframework/cmm/EgovTreeMenu.jsp` | 테스트 페이지 | 직접 생성 (사용방법 참고) |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/valid-memory-check.md
+++ b/common-component/elementary-technology/valid-memory-check.md
@@ -29,7 +29,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovSysInfo.java` | 시스템정보 확인 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovSysInfo.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovSysInfo.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/webeditor_20.md
+++ b/common-component/elementary-technology/webeditor_20.md
@@ -29,7 +29,7 @@ menu:
 | --- | --- | --- | --- |
 | HTML | /html/egovframework/cmm/utl/htmlarea3.0 | HTMLAREA3.0 웹에디터 |  |
 | JS | /html/egovframework/cmm/utl/htmlarea3.0/htmlarea.js | 웹에디터 동작 스크립트 |  |
-| JSP | WEB_INF/jsp/egovframework/cmm/utl/EgovWebEditor.jsp | 테스트 페이지 |  |
+| JSP | WEB-INF/jsp/egovframework/cmm/utl/EgovWebEditor.jsp | 테스트 페이지 |  |
 
 
 #### 메소드

--- a/common-component/elementary-technology/xml-data-assembly.md
+++ b/common-component/elementary-technology/xml-data-assembly.md
@@ -30,7 +30,7 @@ XML 데이터조립에서 제공하는 기능은 다음과 같다.
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovXMLDoc.java` | XML파싱/조립 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovXMLDoc.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovXMLDoc.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 

--- a/common-component/elementary-technology/xml-data-parsing.md
+++ b/common-component/elementary-technology/xml-data-parsing.md
@@ -30,7 +30,7 @@ XML 데이터파싱에서 제공하는 기능은 다음과 같다.
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovXMLDoc.java` | XML파싱/조립 요소기술 클래스 | |
-| JSP | `WEB_INF/jsp/egovframework/cmm/utl/EgovXMLDoc.jsp` | 테스트 페이지 | |
+| JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovXMLDoc.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

서블릿 규격상 디렉터리명은 `WEB-INF` 입니다. 저장소 마크다운에서 `WEB-INF` 표기가 729곳인데 `WEB_INF` 가 41곳(39파일) 남아 있어 맞췄습니다. 전부 `common-component/elementary-technology/` 의 관련소스 표입니다.

디렉터리명 표기만 바꿨고 다른 변경은 없습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

`scripts/docs_lint.py .` 결과는 변경 전후 모두 `findings: 5` 로 같습니다.
