### PR TITLE
docs: 절이 H1 으로 달려 페이지 목차 구조가 깨지던 문서 7건 수정

### DIFF
--- a/egovframe-development/development-etcdevtool-guide/etcdevtool-intellij.md
+++ b/egovframe-development/development-etcdevtool-guide/etcdevtool-intellij.md
@@ -106,7 +106,7 @@ menu:
   ![project_structure_module_web_setting](./images/project_structure_module_web_setting.png)
 
 
-# STEP4. 서버 설정
+## STEP4. 서버 설정
 
 ※ 커뮤니티 버전의 경우 이 기능을 지원하지 않는다. 무료 IDE인 이클립스를 권장합니다.
 

--- a/egovframe-development/implementation-tool/code-generation-template-configuration-folder/config-gen-cron-trigger.md
+++ b/egovframe-development/implementation-tool/code-generation-template-configuration-folder/config-gen-cron-trigger.md
@@ -19,17 +19,6 @@ menu:
 
 Cron Trigger Configuration 의 설명은 다음 실행환경 가이드를 참조한다.
 
-- [실행환경 Scheduling Configuration Guide]
-# Detail Bean Job Code Generation
-
-## 개요
-
-"JobDetailBean을 이용한 작업 생성"을 Code Generation 기능을 사용하여 쉽게 작성할 수 있다.
-
-## 설명
-
-Detail Bean Job Scheduling Configuration 의 설명은 다음 실행환경 가이드를 참조한다.
-
 - [실행환경 Scheduling Configuration Guide](../../../egovframe-runtime/foundation-layer/scheduling.md)
 
 ## 사용법

--- a/egovframe-development/implementation-tool/code-generation-template-configuration-folder/config-gen-method-invoking-job-scheduling.md
+++ b/egovframe-development/implementation-tool/code-generation-template-configuration-folder/config-gen-method-invoking-job-scheduling.md
@@ -19,17 +19,6 @@ menu:
 
 Method Invoking Job Scheduling Configuration 의 설명은 다음 실행환경 가이드를 참조한다.
 
-- [실행환경 Scheduling Configuration Guide]
-# Detail Bean Job Code Generation
-
-## 개요
-
-"JobDetailBean을 이용한 작업 생성"을 Code Generation 기능을 사용하여 쉽게 작성할 수 있다.
-
-## 설명
-
-Detail Bean Job Scheduling Configuration 의 설명은 다음 실행환경 가이드를 참조한다.
-
 - [실행환경 Scheduling Configuration Guide](../../../egovframe-runtime/foundation-layer/scheduling.md)
 
 ## 사용법

--- a/egovframe-development/implementation-tool/code-generation-template-configuration-folder/config-gen-scheduler.md
+++ b/egovframe-development/implementation-tool/code-generation-template-configuration-folder/config-gen-scheduler.md
@@ -19,17 +19,6 @@ menu:
 
 Scheduler Configuration 의 설명은 다음 실행환경 가이드를 참조한다.
 
-- [실행환경 Scheduling Configuration Guide]
-# Detail Bean Job Code Generation
-
-## 개요
-
-"JobDetailBean을 이용한 작업 생성"을 Code Generation 기능을 사용하여 쉽게 작성할 수 있다.
-
-## 설명
-
-Detail Bean Job Scheduling Configuration 의 설명은 다음 실행환경 가이드를 참조한다.
-
 - [실행환경 Scheduling Configuration Guide](../../../egovframe-runtime/foundation-layer/scheduling.md)
 
 ## 사용법

--- a/egovframe-development/implementation-tool/code-generation-template-configuration-folder/config-gen-simple-trigger.md
+++ b/egovframe-development/implementation-tool/code-generation-template-configuration-folder/config-gen-simple-trigger.md
@@ -19,17 +19,6 @@ menu:
 
 Simple Trigger Configuration 의 설명은 다음 실행환경 가이드를 참조한다.
 
-- [실행환경 Scheduling Configuration Guide]
-# Detail Bean Job Code Generation
-
-## 개요
-
-"JobDetailBean을 이용한 작업 생성"을 Code Generation 기능을 사용하여 쉽게 작성할 수 있다.
-
-## 설명
-
-Detail Bean Job Scheduling Configuration 의 설명은 다음 실행환경 가이드를 참조한다.
-
 - [실행환경 Scheduling Configuration Guide](../../../egovframe-runtime/foundation-layer/scheduling.md)
 
 ## 사용법

--- a/egovframe-runtime/persistence-layer/sql-rule.md
+++ b/egovframe-runtime/persistence-layer/sql-rule.md
@@ -27,7 +27,7 @@ menu:
 8. 자주하는 질문 FAQ
 <br>
 
-# SQL 규칙 정리
+## SQL 규칙 정리
 
 | 번호 | 구분 | SQL 규칙 |
 | --- | --- | ------ |
@@ -47,38 +47,38 @@ menu:
 | 14 | Static | Static Embeded SQL 사용을 원칙으로 함 <br> Precompiler 제약에 의해서 반드시 Dynamic SQL로 구현되야 하는 `MERGE INTO` 문은 허용 <br> 임시 테이블이 생성되는 `WITH` 문은 Online 환경(센터컷 포함)에서는 허용하지 않음 ( 배치에서만 허용 ) |
 <br>
 
-# SQL 작성 규칙 예시
+## SQL 작성 규칙 예시
 | SQL 예시 | SQL 규칙 |
 | ---------- | ---------- |
 | ![SQL 예시01](./images/sql-rule01.png) |  SELECT 이후 반드시 공백 1칸을 주고 칼럼을 기술 <br> 1줄에 1개 컬럼 기술을 원칙으로 함 <br> 컬럼명 이후 공백을 주고  주석을 추가 <br> 컬럼명,테이블명의 구분 콤마(,)는 앞쪽에 기술<br> 콤마 와 칼럼/테이블 명 사이에 공백 한 칸을 둠<br> FROM 절에 나타난 순서대로 알파벳 대문자 A , B ,… 순서로 사용<br> 테이블 별칭 이후 공백을 주고 주석을 추가<br> SELECT , FROM, WHER , AND 가 오른쪽 맞춤이 되도록 정렬  ( SELECT의 “T”알파벳을 기준으로 정렬 )<br> WHERE 절의 조인 조건에 대해서는 주석은 필수가 아님 <br> WHERE 절에서 조인 조건을 먼저 기술함    테이블 lookup 조건은 조인조건 이후에 기술 |
 | ![SQL 예시02](./images/sql-rule02.png)  | FROM 절 테이블 별칭은 알파벳 대문자 A , B, C …  순서대로  기술 <br> 서브쿼리는 3개 이내로 사용 권장 <br> 칼럼 별칭은 반드시 AS를 사용한 후 별칭을 사용함 <br> 스칼라 서브쿼리 결과는 항상 칼럼 별칭을 사용함 <br> EXISTS 절에서는 괄호 다음에 한 라인을 부여한다 |
 <br>
 
-# SELECT SQL 작성 예시
+## SELECT SQL 작성 예시
 | SQL 예시 |
 | ---------- |
 | ![SELECT SQL 예시01](./images/sql-select01.png) <br> ![SELECT SQL 예시02](./images/sql-select02.png) |
 <br>
 
-# INSERT SQL 작성 예시
+## INSERT SQL 작성 예시
 | SQL 예시 | SQL 규칙 |
 | ---------- | ---------- |
 | ![INSERT SQL 예시01](./images/sql-insert01.png) <br> ![INSERT SQL 예시02](./images/sql-insert02.png) | INTO, VALUES, SELECT, FROM, WHERE, AND, OR, 괄호, 콤마(,)등은 INSERT의 “T”자 기준으로 정렬한다. <br> INSERT 대상 칼럼 및 VALUES 절의 값들은 새로운 라인에서 시작괄호 ‘(‘ 다음에 빈칸 없이 바로 시작되고, <br> INSERT 기술이 모두 끝난 후 새로운 라인에 ‘(‘ 괄호가 위치하는 위치에 ‘)’를 정렬한다. <br> 한 라인에 하나의 칼럼/값만 기술하고 콤마(,)는 새로운 라인에 기술 |
 <br>
 
-# UPDATE SQL 작성 예시
+## UPDATE SQL 작성 예시
 | SQL 예시 | SQL 규칙 |
 | ---------- | ---------- |
 | ![UPDATE SQL 예시01](./images/sql-update01.png) | SET, FROM, WHERE, AND, OR, 콤마(,)등은 UPDATE의 “E”자 기준으로 정렬한다. <br> 한 라인에 하나의 업데이트될 칼럼만 기술하고 콤마(,)는 새로운 라인에 기술한다. <br> 업데이트될 컬럼은 첫 번째만 제외하고 콤마로 시작하고 콤마 뒤에 한 칸 띄운 후 칼럼과 변경 값을 기술한다. |
 <br>
 
-# DELETE SQL 작성 예시
+## DELETE SQL 작성 예시
 | SQL 예시 | SQL 규칙 |
 | ---------- | ---------- |
 | ![DELETE SQL 예시01](./images/sql-delete01.png) | 주석은 SQL  상단에 표기 <br> FROM, WHERE, AND, OR, 콤마(,)등은 DELETE의 끝문자 “E”자 기준으로 정렬 <br> WHERE절은 생략하지 않고 반드시 표기 |
 <br>
 
-# 성능을 고려한 SQL 작성 원칙
+## 성능을 고려한 SQL 작성 원칙
 | 번호 | 내용 |
 | ---------- | ---------- |
 | 1 | 조회 , 변경에서 view를 통한 액세스는 허용하지 않음 |
@@ -101,7 +101,7 @@ menu:
 | 18 | Scalar Sub Query는 10,000건 이하의 테이블에서만 사용 |
 <br>
 
-# 자주하는 질문 FAQ
+## 자주하는 질문 FAQ
 | 번호 | 구분 | 내용 |
 | ---------- | ---------- | ---------- |
 | 1 | 질문 | COUNT(*)와 COUNT(1) 중 어느 것이 빠른가? |

--- a/egovframe-runtime/presentation-layer/ui-adaptor-service.md
+++ b/egovframe-runtime/presentation-layer/ui-adaptor-service.md
@@ -331,7 +331,7 @@ public class RiaView extends AbstractView {
 }
 ```
 
-# 참고자료
+## 참고자료
 
 - [Spring Framework 6.2 - Web on Servlet Stack](https://docs.spring.io/spring-framework/reference/6.2/web.html)
 - [Annotated Controllers](https://docs.spring.io/spring-framework/reference/6.2/web/servlet/mvc/controller/ann-methods.html), [View Resolution](https://docs.spring.io/spring-framework/reference/6.2/web/servlet/mvc/views.html)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

절을 `#`(H1)으로 단 문서 7건을 `##`으로 맞췄습니다. 배포 사이트의 `hugo.toml`이 `[markup.tableOfContents]`에 `startLevel = 2`, `endLevel = 2`를 두어 목차에 H2만 싣기 때문에, 절이 H1이면 그 절이 페이지 목차에서 통째로 빠집니다.

H1을 가진 문서 592개 중 584개는 문서 제목 하나만 H1이고, 둘 이상인 것이 8개였습니다. 그중 문서 제목이 없는 루트 `_index.md`를 뺀 7건을 고쳤습니다. 원인은 둘로 갈리지만 잘못 놓인 H1이 페이지 목차 구조를 깨뜨린다는 점이 같아 함께 냈습니다.

### (1) Eclipse Config Generation 4건 — 다른 문서의 머리 블록이 섞였습니다

`config-gen-simple-trigger.md`·`config-gen-cron-trigger.md`·`config-gen-scheduler.md`·`config-gen-method-invoking-job-scheduling.md`는 22행 참조 링크에서 대상이 사라진 자리에 형제 문서 `config-gen-detail-bean-job-scheduling.md`의 머리 블록(제목 H1 + 개요 + 설명)이 통째로 끼어 있습니다. 네 파일의 22~33행은 바이트 단위로 같습니다.

그 결과 페이지에 제목이 둘 뜨고, 22행은 링크가 아니라 `[실행환경 Scheduling Configuration Guide]`라는 대괄호 문자열로 렌더됩니다. 목차도 끼어든 제목을 경계로 두 묶음으로 쪼개져, 두 번째 묶음의 개요·설명이 `개요-1`·`설명-1`이라는 중복 id를 받습니다.

끼어든 블록을 걷어내고 대상이 붙은 링크 한 줄로 되돌렸습니다. 링크 대상 `egovframe-runtime/foundation-layer/scheduling.md`는 실재하며, 정상 형제인 `config-gen-detail-bean-job-scheduling.md`가 쓰는 것과 같은 경로입니다.

### (2) 절 헤딩 3건

- `egovframe-runtime/persistence-layer/sql-rule.md` — 15행 `## 개요`가 "아래의 순서로"라며 예고한 8개 절이 전부 H1(30·50·57·63·69·75·81·104행)이라, 목차에 개요만 남습니다.
- `egovframe-runtime/presentation-layer/ui-adaptor-service.md:334` — `# 참고자료`입니다. 같은 절이 다른 290개 문서에서는 `##`이고, H1인 것은 이 한 건뿐입니다.
- `egovframe-development/development-etcdevtool-guide/etcdevtool-intellij.md:109` — STEP1~3(34·78·88행)은 `##`인데 STEP4만 `#`입니다.

열 줄을 `##`으로 내렸습니다.

`sql-rule.md`의 8개 절을 모두 `##`으로 맞춘 것은 문서가 스스로 선언한 구조를 따른 것입니다. 19~27행이 "아래의 순서로 SQL 예시와 해당 규칙을 설명하는 방식으로 진행된다"며 여덟 절을 번호 목록 하나로 나열하는데, SELECT·INSERT·UPDATE·DELETE 예시가 3~6번으로 나머지와 같은 층에 있습니다. 덧붙여 `endLevel = 2`라 `###`으로 내리면 목차에 실리지 않습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

배포된 문서 페이지에서 증상을 확인했습니다. 목차는 페이지의 "이 페이지의 구성" 블록입니다.

| 페이지 | 목차에 실린 절 | 빠지거나 어긋난 절 |
| --- | --- | --- |
| Simple Trigger (나머지 3건 동일) | 개요, 설명 · **개요-1, 설명-1, 사용법** | — (두 묶음으로 쪼개짐) |
| Detail Bean Job (정상 형제) | 개요, 설명, 사용법 | — |
| SQL 작성 규칙 | 개요 | 8개 절 전부 |
| UI Adaptor Service | 개요, 설명 | 참고자료 |
| Intellij 사용 가이드 | 개요, 들어가기 전에, STEP1~3 | STEP4 |

코드블록을 제외하고 세면 H1이 둘 이상인 md는 수정 전 8개, 수정 후 1개입니다. 남은 하나는 문서 제목이 없는 루트 `_index.md`로 이 수정의 대상이 아닙니다.

저장소 검사기 `scripts/docs_lint.py`는 수정 전후 모두 `files scanned: 674 / findings: 5`로 같습니다. 이 검사기의 L4는 레벨 건너뜀만 보므로 H1 중복은 검사 대상이 아닙니다.

바꾼 헤딩을 가리키는 앵커 링크는 저장소 전체에 없습니다.
