### PR TITLE
docs: 파일변환 문서의 클래스·메소드·설정을 실제 소스에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/file-conversion.md
+++ b/common-component/elementary-technology/file-conversion.md
@@ -30,38 +30,39 @@ OpenOffice와 JODConverter 라이브러리를 활용하여 서버 환경에서 �
 
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
-| Service | `egovframework.com.utl.sim.service.EgovFileConverter.java` | 파일변환 요소기술 클래스 | |
+| Service | `egovframework.com.utl.sim.service.EgovPdfCnvr.java` | 파일변환 요소기술 클래스 | |
 | JSP | `WEB-INF/jsp/egovframework/cmm/utl/EgovFileCnvr.jsp` | 테스트 페이지 | |
 
 ### 클래스 및 메소드 설명
 
-파일변환 기능은 `EgovFileConverter` 클래스의 메소드를 활용하여 제공한다.
+파일변환 기능은 `EgovPdfCnvr` 클래스의 메소드를 활용하여 제공한다.
 
 | 결과값 | 메소드명 | 설명 | 내용 |
 | --- | --- | --- | --- |
-| boolean | `convertFileToPdf(src, target)` | 파일 PDF 변환 | 지정한 소스 파일을 PDF로 변환하여 대상 경로에 저장한다. 성공 시 true, 실패 시 false 리턴 |
+| boolean | `getPDF(targetPdf, request, response)` | 파일 PDF 변환 | 요청에 첨부된 파일을 PDF로 변환한다. 성공 시 true, 실패 시 false 리턴 |
 
 #### 파라미터 정의 (Input)
 
-- `sourcePath`: 변환할 원본 파일의 절대경로 (String 타입)
-  (예: `/product/jeus/files/report.doc`)
-- `targetPath`: 변환된 PDF 파일이 저장될 절대경로 (String 타입)
-  (예: `/product/jeus/files/report.pdf`)
+- `targetPdf`: 생성할 PDF 파일명 (확장자 제외, String 타입)
+  (예: `report`)
+- `request`: 변환할 파일이 첨부된 요청 (`HttpServletRequest` 타입)
+- `response`: 응답 객체 (`HttpServletResponse` 타입)
 
 #### 반환값 정의 (Output)
 
 - boolean 타입: 변환 성공 여부 (`true` / `false`)
+- 메소드가 `throws Exception`으로 선언되어 있어 호출부에서 예외를 처리해야 한다.
 
 ### 환경 설정
 
-파일변환 기능은 서버에 OpenOffice가 설치되어 있어야 하며, `globals.properties`에 OpenOffice 설치 경로 및 접속 포트를 등록한다.
+파일변환 기능은 서버에 OpenOffice가 포트 8100으로 기동되어 있어야 한다. 접속 포트는 소스에 고정되어 있어 별도로 등록하지 않는다.
+첨부된 파일을 임시로 저장할 경로는 `globals.properties`의 `Globals.fileStorePath`를 사용한다.
 
 #### globals.properties
 
 ```properties
-# OpenOffice 설정
-Globals.openoffice.home = /usr/lib/openoffice
-Globals.openoffice.port = 8100
+# 파일 저장 경로
+Globals.fileStorePath = /upload/allinone
 ```
 
 #### 의존 라이브러리
@@ -71,25 +72,26 @@ Globals.openoffice.port = 8100
 <dependency>
     <groupId>com.artofsolving</groupId>
     <artifactId>jodconverter</artifactId>
-    <version>2.2.2</version>
+    <version>2.2.1</version>
 </dependency>
 ```
 
 ### 사용 방법
 
 ```java
-import egovframework.com.utl.sim.service.EgovFileConverter;
+import egovframework.com.utl.sim.service.EgovPdfCnvr;
 
-String sourcePath = "/product/jeus/files/report.doc";
-String targetPath = "/product/jeus/files/report.pdf";
+// 요청에 첨부된 파일을 report.pdf 로 변환한다.
+try {
+    boolean result = EgovPdfCnvr.getPDF("report", request, response);
 
-// 파일 변환 수행 (DOC → PDF)
-boolean result = EgovFileConverter.convertFileToPdf(sourcePath, targetPath);
-
-if (result) {
-    System.out.println("파일 변환 성공: " + targetPath);
-} else {
-    System.out.println("파일 변환 실패");
+    if (result) {
+        System.out.println("파일 변환 성공");
+    } else {
+        System.out.println("파일 변환 실패");
+    }
+} catch (Exception e) {
+    System.out.println("파일 변환 중 오류 발생");
 }
 ```
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

파일변환 문서가 관련소스와 예제로 싣는 `egovframework.com.utl.sim.service.EgovFileConverter` 가 현재 공통컴포넌트 소스에 없습니다. 같은 패키지의 `EgovPdfCnvr` 이 문서 개요와 같은 일(doc·xls·ppt 를 PDF 로 변환)을 문서에 적힌 것과 같은 스택(OpenOffice + JODConverter)으로 합니다.

| 문서 | 실제 소스 |
| --- | --- |
| `EgovFileConverter` | `EgovPdfCnvr` (`src/main/java/egovframework/com/utl/sim/service/EgovPdfCnvr.java`) |
| `convertFileToPdf(sourcePath, targetPath)` | `getPDF(targetPdf, request, response)` (같은 파일 66행) |
| `Globals.openoffice.home` · `Globals.openoffice.port` 를 등록 | 두 키가 소스에 없습니다. 임시 저장 경로로 `Globals.fileStorePath` 를 쓰고(54행), 접속 포트 8100 은 소스에 고정돼 있습니다(96행) |
| jodconverter `2.2.2` | `2.2.1`. 부모 POM `egovframe-web-config-parent` 5.0.0 이 `jodconverter.version` 으로 관리합니다 |

`getPDF` 는 요청에 첨부된 파일을 받아 변환하며 `throws Exception` 으로 선언돼 있습니다.

## 관련 이슈 (Related Issues)

- #721 에 `EgovSysInfo`·`EgovFtpTool`·`EgovFileConverter` 를 설명하는 문서 8건을 어떻게 처리할지 묻는 문의가 있습니다. 파일변환은 그 8건 중 하나입니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

같은 표의 JSP 행(`WEB-INF/jsp/egovframework/cmm/utl/EgovFileCnvr.jsp`)도 저장소에 없는 경로입니다. `WEB-INF/jsp/egovframework/cmm/` 으로 시작하는 표기는 이 문서를 포함해 51개 문서에 68건 있고, 공통컴포넌트 저장소의 JSP 747개 중 737개는 `WEB-INF/jsp/egovframework/com/` 아래에 있습니다. 이 행은 이번 PR 에서 고치지 않았습니다.
