### PR TITLE
docs: 달력·휴일관리 문서의 리소스 경로와 요청 URL 을 실제 값에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/calendar.md
+++ b/common-component/elementary-technology/calendar.md
@@ -34,23 +34,23 @@ menu:
 | Service            | `egovframework.com.sym.cal.service.EgovCalRestdeManageService.java`              | 달력, 휴일관리를 위한 서비스 인터페이스        |
 | ServiceImpl        | `egovframework.com.sym.cal.service.impl.EgovCalRestdeManageServiceImpl.java`     | 달력, 휴일관리를 위한 서비스구현 클래스   |
 | DAO                | `egovframework.com.sym.cal.service.impl.RestdeManageDAO.java`                    | 휴일 정보 관리를 위한 데이터처리 클래스        |
-| JS                 | `/webapp/js/egovframework/cmm/sym/cal/EgovCalPopup.js`                           | 일반달력, 행정달력 팝업 호출을 위한 JavaScript |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovAdministCalPopup.jsp`                | 행정달력 팝업을 위한 JSP 페이지                |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovAdministCalendar.jsp`                | 행정달력 팝업의 내용을 위한 JSP 페이지         |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovAdministDayCalendar.jsp`             | 행정달력 일간을위한 JSP 페이지                 |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovAdministMonthCalendar.jsp`           | 행정달력 월간을위한 JSP 페이지                 |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovAdministWeekCalendar.jsp`            | 행정달력 주간을위한 JSP 페이지                 |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovAdministYearCalendar.jsp`            | 행정달력 연간을위한 JSP 페이지                 |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovNormalCalPopup.jsp`                  | 일반달력 팝업을 위한 JSP 페이지                |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovNormalCalendar.jsp`                  | 일반달력 팝업의 내용을 위한 JSP 페이지         |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovNormalDayCalendar.jsp`               | 일반달력 일간을위한 JSP 페이지                 |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovNormalMonthCalendar.jsp`             | 일반달력 월간을위한 JSP 페이지                 |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovNormalWeekCalendar.jsp`              | 일반달력 주간을위한 JSP 페이지                 |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovNormalYearCalendar.jsp`              | 일반달력 연간을위한 JSP 페이지                 |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovRestdeDetail.jsp`                    | 휴일 상세보기를 위한 JSP 페이지                |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovRestdeList.jsp`                      | 휴일 목록을 위한 JSP 페이지                    |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovRestdeModify.jsp`                    | 휴일 수정을 위한 JSP 페이지                    |
-| JSP                | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovRestdeRegist.jsp`                    | 휴일 등록을 위한 JSP 페이지                    |
+| JS                 | `/webapp/js/egovframework/com/sym/cal/EgovCalPopup.js`                           | 일반달력, 행정달력 팝업 호출을 위한 JavaScript |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovAdministCalPopup.jsp`                | 행정달력 팝업을 위한 JSP 페이지                |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovAdministCalendar.jsp`                | 행정달력 팝업의 내용을 위한 JSP 페이지         |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovAdministDayCalendar.jsp`             | 행정달력 일간을위한 JSP 페이지                 |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovAdministMonthCalendar.jsp`           | 행정달력 월간을위한 JSP 페이지                 |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovAdministWeekCalendar.jsp`            | 행정달력 주간을위한 JSP 페이지                 |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovAdministYearCalendar.jsp`            | 행정달력 연간을위한 JSP 페이지                 |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovNormalCalPopup.jsp`                  | 일반달력 팝업을 위한 JSP 페이지                |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovNormalCalendar.jsp`                  | 일반달력 팝업의 내용을 위한 JSP 페이지         |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovNormalDayCalendar.jsp`               | 일반달력 일간을위한 JSP 페이지                 |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovNormalMonthCalendar.jsp`             | 일반달력 월간을위한 JSP 페이지                 |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovNormalWeekCalendar.jsp`              | 일반달력 주간을위한 JSP 페이지                 |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovNormalYearCalendar.jsp`              | 일반달력 연간을위한 JSP 페이지                 |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeDetail.jsp`                    | 휴일 상세보기를 위한 JSP 페이지                |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeList.jsp`                      | 휴일 목록을 위한 JSP 페이지                    |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeModify.jsp`                    | 휴일 수정을 위한 JSP 페이지                    |
+| JSP                | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeRegist.jsp`                    | 휴일 등록을 위한 JSP 페이지                    |
 | Query XML          | `resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_altibase.xml`   | 달력, 휴일관리를 위한 Altibase용 Query XML     |
 | Query XML          | `resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_cubrid.xml`     | 달력, 휴일관리를 위한 Cubrid용 Query XML       |
 | Query XML          | `resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_maria.xml`      | 달력, 휴일관리를 위한 MariaDB용 Query XML      |
@@ -115,7 +115,7 @@ INSERT INTO COMTECOPSEQ VALUES ('RESTDE_ID','0');
 
 <script
     type="text/javascript"
-    src="<c:url value='/js/egovframework/cmm/sym/cal/EgovCalPopup.js' />"
+    src="<c:url value='/js/egovframework/com/sym/cal/EgovCalPopup.js' />"
 ></script>
 ```
 
@@ -124,7 +124,7 @@ INSERT INTO COMTECOPSEQ VALUES ('RESTDE_ID','0');
 ```html
 <form
     name="Form1"
-    action="<c:url value='/sym/cmm/EgovNormalCalPopup.do'/>"
+    action="<c:url value='/sym/cal/EgovNormalCalPopup.do'/>"
     method="post"
 >
     <input
@@ -144,7 +144,7 @@ INSERT INTO COMTECOPSEQ VALUES ('RESTDE_ID','0');
         onClick="javascript:fn_egov_NormalCalendar(document.Form1, document.Form1.sDate, document.Form1.vDate);"
     />
     <img
-        src="<c:url value='/images/egovframework/cmm/sym/cal/bu_icon_carlendar.gif' />"
+        src="<c:url value='/images/egovframework/com/sym/cal/bu_icon_carlendar.gif' />"
         onClick="javascript:fn_egov_NormalCalendar(document.Form1, document.Form1.sDate, document.Form1.vDate);"
     />
 </form>
@@ -161,7 +161,7 @@ INSERT INTO COMTECOPSEQ VALUES ('RESTDE_ID','0');
 
 | URL                                    | Controller                      |
 | -------------------------------------- | ------------------------------- |
-| `/sym/cmm/EgovselectNormalCalendar.do` | `EgovCalRestdeManageController` |
+| `/sym/cal/EgovselectNormalCalendar.do` | `EgovCalRestdeManageController` |
 
 다음 소스코드 부분을
 
@@ -244,7 +244,7 @@ for(int i=0; i<42;i++) {
 
 <script
     type="text/javascript"
-    src="<c:url value='/js/egovframework/cmm/sym/cal/EgovCalPopup.js' />"
+    src="<c:url value='/js/egovframework/com/sym/cal/EgovCalPopup.js' />"
 ></script>
 ```
 
@@ -253,7 +253,7 @@ for(int i=0; i<42;i++) {
 ```html
 <form
     name="Form2"
-    action="<c:url value='/sym/cmm/EgovAdministCalPopup.do'/>"
+    action="<c:url value='/sym/cal/EgovAdministCalPopup.do'/>"
     method="post"
 >
     <input
@@ -273,7 +273,7 @@ for(int i=0; i<42;i++) {
         onClick="javascript:fn_egov_AdministCalendar(document.Form2, document.Form2.sDate, document.Form2.vDate);"
     />
     <img
-        src="<c:url value='/images/egovframework/cmm/sym/cal/bu_icon_carlendar.gif' />"
+        src="<c:url value='/images/egovframework/com/sym/cal/bu_icon_carlendar.gif' />"
         onClick="javascript:fn_egov_AdministCalendar(document.Form2, document.Form2.sDate, document.Form2.vDate);"
     />
 </form>

--- a/common-component/elementary-technology/holiday-management.md
+++ b/common-component/elementary-technology/holiday-management.md
@@ -31,8 +31,8 @@ menu:
 | DAO | `egovframework.com.sym.cal.service.impl.RestdeManageDAO.java` | 휴일 정보 관리를 위한 데이터처리 클래스 |
 | Model | `egovframework.com.sym.cal.service.Restde.java` | 휴일 정보 Model 클래스 |
 | VO | `egovframework.com.sym.cal.service.RestdeVO.java` | 달력, 휴일관리를 위한 VO 클래스 |
-| JS | `/js/egovframework/cmm/sym/cal/EgovCalPopup.js` | 일반달력·행정달력 팝업 호출 JavaScript |
-| JSP | `/WEB-INF/jsp/egovframework/cmm/sym/cal/EgovRestdeList.jsp` 외 | 휴일 목록/등록/수정/상세 및 일반·행정달력(팝업/일간/주간/월간/연간) JSP 페이지 일체 |
+| JS | `/js/egovframework/com/sym/cal/EgovCalPopup.js` | 일반달력·행정달력 팝업 호출 JavaScript |
+| JSP | `/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeList.jsp` 외 | 휴일 목록/등록/수정/상세 및 일반·행정달력(팝업/일간/주간/월간/연간) JSP 페이지 일체 |
 
 ### 관련테이블
 
@@ -78,9 +78,9 @@ INSERT INTO COMTECOPSEQ VALUES('RESTDE_ID','0');
 일반달력·행정달력 팝업 호출을 위하여 `EgovCalPopup.js`를 해당 페이지에 등록한다.
 
 ```html
-<script type="text/javascript" src="<c:url value='/js/egovframework/cmm/sym/cal/EgovCalPopup.js' />"></script>
+<script type="text/javascript" src="<c:url value='/js/egovframework/com/sym/cal/EgovCalPopup.js' />"></script>
 
-<form name="Form1" action="<c:url value='/sym/cmm/EgovNormalCalPopup.do'/>" method="post">
+<form name="Form1" action="<c:url value='/sym/cal/EgovNormalCalPopup.do'/>" method="post">
     <input type="hidden" name="sDate" value="" size="8" readonly
         onClick="javascript:fn_egov_NormalCalendar(document.Form1, document.Form1.sDate, document.Form1.vDate);" />
     <input type="text" name="vDate" value="" size="10" readonly


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

`calendar.md` 와 `holiday-management.md` 의 리소스 경로와 요청 URL 이 실제와 다릅니다. 두 파일에서 28곳을 고쳤습니다.

| 문서 | 실제 소스 |
| --- | --- |
| `egovframework/cmm/sym/cal/` (JSP·JavaScript·이미지, 24곳) | `egovframework/com/sym/cal/` |
| `/sym/cmm/*.do` (폼 액션과 URL 표, 4곳) | `/sym/cal/*.do` |

`EgovCalRestdeManageController` 는 메서드마다 `/sym/cal/` 로 매핑합니다. 공통컴포넌트에 `egovframework/cmm` 경로는 없고 JSP·JavaScript·이미지 모두 `egovframework/com` 아래에 있습니다. `egov-com-servlet.xml` 의 `mvc:resources` 는 `/js/**` 를 `/js/` 로 그대로 넘기므로 별칭도 없습니다.

표뿐 아니라 사용방법 절의 `<c:url>` 예제에도 있어서 예제의 `EgovCalPopup.js` 와 `bu_icon_carlendar.gif` 는 없는 경로를 가리키고 폼 액션은 매핑되지 않은 URL 로 갑니다. 소스의 `EgovRestdeRegist.jsp` 는 같은 스크립트를 `com/sym/cal` 로 부릅니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

`화면(URL)` 열의 `/cmm/sym/cal/...` 13곳은 손대지 않았습니다. 컨트롤러가 반환하는 값은 `egovframework/com/sym/cal/...` 이라 `cmm` 을 `com` 으로 바꾸는 것만으로는 맞지 않습니다.

같은 코드블록에 남아 있는 `html/egovframework/com/cmm/utl/htmlarea3.0/` 도 없는 경로입니다. 이번 변경과는 다른 부류이고 `webeditor_20.md` 에도 같은 표기가 있어 함께 두었습니다.
