### PR TITLE
docs: 트리메뉴·인쇄 문서를 실제 소스에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/print.md
+++ b/common-component/elementary-technology/print.md
@@ -84,7 +84,7 @@ function printOption(type1, type2) {
 | Service | `egovframework.com.utl.pao.service.EgovPrntngOutpt.java` | 테스트용 인터페이스 | |
 | ServiceImpl | `egovframework.com.utl.pao.service.impl.EgovPrntngOutptImpl.java` | 테스트용 구현체 | |
 | DAO | `egovframework.com.utl.pao.service.impl.PrntngOutptDAO.java` | 테스트용 데이터 처리 | |
-| JSP | `/WEB-INF/jsp/egovframework/cmm/utl/EgovErncslOutpt.jsp` | 테스트 페이지 | |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/pao/EgovErncslOutpt.jsp` | 테스트 페이지 | |
 
 #### 전자관인출력 사용 방법
 

--- a/common-component/elementary-technology/tree-menu.md
+++ b/common-component/elementary-technology/tree-menu.md
@@ -27,7 +27,7 @@ menu:
 | 유형 | 대상소스명 | 설명 | 비고 |
 | --- | --- | --- | --- |
 | Service | `egovframework.com.utl.sim.service.EgovMenuGov.java` | 메인메뉴 요소기술 클래스 | 메뉴파일 생성 |
-| JS | `/js/egovframework/cmm/utl/EgovMenuGov.js` | 트리생성 JavaScript | |
+| JS | `/js/egovframework/com/cmm/utl/EgovMenuGov.js` | 트리생성 JavaScript | |
 | JSP | `WEB-INF/jsp/egovframework/cmm/EgovTreeMenu.jsp` | 테스트 페이지 | 직접 생성 (사용방법 참고) |
 
 ### 클래스 및 메소드 설명
@@ -37,12 +37,15 @@ menu:
 <!-- markdownlint-disable MD013 -->
 | 결과값 | 메소드명 | 설명 | 내용 |
 | --- | --- | --- | --- |
-| Vector | `parsFileByMenuChar(String parFile, String parChar, int parField)` | 메뉴테이블형태 파싱 | 입력된 데이터를 구분자와 필드 수를 기준으로 메뉴 필드 형태로 분리한다. |
+| Vector | `parsFileByMenuChar(String basePath, String parFile, String parChar, int parField)` | 메뉴테이블형태 파싱 | 입력된 데이터를 구분자와 필드 수를 기준으로 메뉴 필드 형태로 분리한다. |
 <!-- markdownlint-restore -->
 
 #### 파라미터 정의 (Input)
 
+- `basePath`: 파일 접근을 허용할 기준 경로(String). 비우면 `Globals.fileStorePath` 를 사용한다
 - `parFile`: 메뉴 변환 파일의 절대 경로(String) (예: `/user/com/test/file1.dat`)
+- `parChar`: 구분자(String)
+- `parField`: 필드 수(int)
 
 ### 사용 방법
 
@@ -51,7 +54,7 @@ menu:
 ```jsp
 <%
 import egovframework.com.utl.sim.service.EgovMenuGov;
-Vector result1 = EgovMenuGov.parsFileByMenuChar(parFile, parChar, parField);
+Vector result1 = EgovMenuGov.parsFileByMenuChar(basePath, parFile, parChar, parField);
 %>
 
 <div class="tree">


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

`tree-menu.md` 와 `print.md` 에 리소스 경로 두 곳과 메서드 시그니처 한 곳이 실제와 다르게 적혀 있습니다.

| 문서 | 실제 위치 |
| --- | --- |
| `/js/egovframework/cmm/utl/EgovMenuGov.js` | `/js/egovframework/com/cmm/utl/EgovMenuGov.js` |
| `/WEB-INF/jsp/egovframework/cmm/utl/EgovErncslOutpt.jsp` | `/WEB-INF/jsp/egovframework/com/utl/pao/EgovErncslOutpt.jsp` |

`EgovErncslOutpt.jsp` 는 파일 위치뿐 아니라 코드로도 확정됩니다. `EgovPrntngOutptController` 가 뷰 이름을 `egovframework/com/utl/pao/EgovErncslOutpt` 로 지정하고, `egov-com-servlet.xml` 의 뷰 리졸버가 `/WEB-INF/jsp/` 와 `.jsp` 를 붙입니다. 같은 표의 Controller·VO·Service 행도 이미 `com.utl.pao` 를 가리킵니다.

공통컴포넌트에 `egovframework/cmm` 경로는 없습니다.

`tree-menu.md` 의 `parsFileByMenuChar` 는 인자가 네 개인데 문서는 세 개만 적고 있습니다. 누락된 `basePath` 를 메소드 표와 예제에 반영하고, 파라미터 정의에는 `parChar`·`parField` 설명도 소스 주석대로 채웠습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

저장소에 남아 있는 다른 `egovframework/cmm/...` 표기는 손대지 않았습니다. 그쪽은 대상 파일이 공통컴포넌트에 없어 정정할 경로를 세울 수 없습니다. `tree-menu.md` 의 `EgovTreeMenu.jsp` 는 비고가 "직접 생성"이고, `print.md` 의 `EgovPrint.jsp`·`EgovPrintStatus.jsp` 도 같은 경우로 보입니다. 이번에는 배포되는 산출물을 가리키는 경로만 고쳤습니다.
