### PR TITLE
docs: 백업관리·게시물통계 문서의 요청 URL 을 실제 매핑에 맞춰 정정

### DIFF
--- a/common-component/statistics-reporting/post-statistics.md
+++ b/common-component/statistics-reporting/post-statistics.md
@@ -145,8 +145,8 @@ public class EgovBbsStatsScheduling {
 | 게시물 생성글수 통계검색 | /sts/bst/selectBbsStats.do | selectBbsStats | "BbsStatsDAO.selectBbsCretCntStats" |
 | 게시물 총조회수 통계검색 | /sts/bst/selectBbsStats.do | selectBbsStats | "BbsStatsDAO.selectBbsTotCntStats" |
 | 게시물 평균조회수 통계검색 | /sts/bst/selectBbsStats.do | selectBbsStats | "BbsStatsDAO.selectBbsAvgCntStats" |
-| 게시물 최고조회 게시물 정보검색 | /bst/sts/selectBbsStats.do | selectBbsStats | "BbsStatsDAO.selectBbsMaxCntStats" |
-| 게시물 최소조회 게시물 정보검색 | /bst/sts/selectBbsStats.do | selectBbsStats | "BbsStatsDAO.selectBbsMinCntStats" |
+| 게시물 최고조회 게시물 정보검색 | /sts/bst/selectBbsStats.do | selectBbsStats | "BbsStatsDAO.selectBbsMaxCntStats" |
+| 게시물 최소조회 게시물 정보검색 | /sts/bst/selectBbsStats.do | selectBbsStats | "BbsStatsDAO.selectBbsMinCntStats" |
 | 게시물 최고게시자 정보검색 | /sts/bst/selectBbsStats.do | selectBbsStats | "BbsStatsDAO.selectBbsMaxUserStats" |
 
  ![image](./images/sts-stats1.png)

--- a/common-component/system-management/backup-management.md
+++ b/common-component/system-management/backup-management.md
@@ -153,8 +153,8 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/bat/selectBackupOpertList.do | selectBackupOpertList | "BackupOpertDAO.selectBackupOpertList" |
-| 조회 | /sym/bat/selectBackupOpertList.do | selectBackupOpertList | "BackupOpertDAO.selectBackupOpertListCnt" |
+| 조회 | /sym/sym/bak/getBackupOpertList.do | selectBackupOpertList | "BackupOpertDAO.selectBackupOpertList" |
+| 조회 | /sym/sym/bak/getBackupOpertList.do | selectBackupOpertList | "BackupOpertDAO.selectBackupOpertListCnt" |
 
  백업작업 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
  검색조건은 백업작업명,백업원본디렉토리에 대해서 수행된다.
@@ -168,7 +168,7 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 등록 | /sym/bat/addBackupOpert.do | insertBackupOpert | "BackupOpertDAO.insertBackupOpert" |
+| 등록 | /sym/sym/bak/addBackupOpert.do | insertBackupOpert | "BackupOpertDAO.insertBackupOpert" |
 
  백업작업의 속성정보를 입력한 뒤 등록한다.
 
@@ -181,7 +181,7 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /sym/bat/updateBackupOpert | updateBackupOpert | "BackupOpertDAO.updateBackupOpert" |
+| 수정 | /sym/sym/bak/updateBackupOpert.do | updateBackupOpert | "BackupOpertDAO.updateBackupOpert" |
 
  백업작업의 속성정보를 변경한 후 저장한다.
 
@@ -194,8 +194,8 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /sym/bat/getBackupOpert.do | selectBackupOpert | "BackupOpertDAO.selectBackupOpert" |
-| 삭제 | /sym/bat/deleteBackupOpert.do | deleteBackupOpert | "BackupOpertDAO.deleteBackupOpert" |
+| 상세조회 | /sym/sym/bak/getBackupOpert.do | selectBackupOpert | "BackupOpertDAO.selectBackupOpert" |
+| 삭제 | /sym/sym/bak/deleteBackupOpert.do | deleteBackupOpert | "BackupOpertDAO.deleteBackupOpert" |
 
  백업작업의 속성정보를 조회한다.
 
@@ -209,8 +209,8 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/bat/selectBackupResultList.do | selectBackupResultList | "BackupResultDAO.selectBackupResultList" |
-| 조회 | /sym/bat/selectBackupResultList.do | selectBackupResultList | "BackupResultDAO.selectBackupResultListCnt" |
+| 조회 | /sym/sym/bak/getBackupResultList.do | selectBackupResultList | "BackupResultDAO.selectBackupResultList" |
+| 조회 | /sym/sym/bak/getBackupResultList.do | selectBackupResultList | "BackupResultDAO.selectBackupResultListCnt" |
 
  백업결과 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
  검색조건은 백업작업명,백업작업ID에 대해서 수행된다.
@@ -225,8 +225,8 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /sym/bat/getBackupResult.do | selectBackupResult | "BackupResultDAO.selectBackupResult" |
-| 삭제 | /sym/bat/deleteBackupResult.do | deleteBackupResult | "BackupResultDAO.deleteBackupResult" |
+| 상세조회 | /sym/sym/bak/getBackupResult.do | selectBackupResult | "BackupResultDAO.selectBackupResult" |
+| 삭제 | /sym/sym/bak/deleteBackupResult.do | deleteBackupResult | "BackupResultDAO.deleteBackupResult" |
 
  백업결과의 속성정보를 조회한다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

`backup-management.md`와 `post-statistics.md`의 URL 열이 실제 `@RequestMapping`과 다릅니다.

`backup-management.md`는 표에 `/sym/bat/` 접두사를 쓰고 있는데, 그건 배치 모듈(`EgovBatchOpertController`의 `addBatchOpert.do` 등)의 경로입니다. 백업 기능은 `EgovBackupOpertController`가 매핑한 `/sym/sym/bak/` 아래에 있습니다. 접두사를 여기 맞췄습니다.

목록조회 표 네 줄은 URL 자리에 Controller method 이름이 그대로 들어가 있었습니다. 실제 매핑은 `getBackupOpertList.do`·`getBackupResultList.do`이고 `selectBackupOpertList`·`selectBackupResultList`는 그 메서드 이름입니다. 같은 표의 Controller method 열은 원래도 맞는 값이라 그대로 두었습니다.

수정 한 줄(`updateBackupOpert`)은 `.do`가 빠져 있어 함께 붙였습니다.

`post-statistics.md`는 같은 표 안에서 `selectBbsStats.do`를 `/sts/bst/`와 `/bst/sts/` 두 가지로 적고 있습니다. 실제 매핑인 `/sts/bst/`로 통일했습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

고친 두 문서의 URL 9개는 모두 실제 `@RequestMapping`과 대조해 확인했습니다.
