### PR TITLE
docs: 접속로그관리 문서 가독성 개선 및 오탈자 수정

### DIFF
--- a/common-component/system-management/access-log-management.md
+++ b/common-component/system-management/access-log-management.md
@@ -15,34 +15,34 @@ menu:
 
 ## 개요
 
- 접속로그관리는 사용자가 시스템 로그인/아웃한 로그를 검색, 조회하는 기능을 제공한다.
+ 접속로그관리는 사용자가 시스템 로그인 및 로그아웃 기록을 검색하고 조회하는 기능을 제공한다.
 
 ## 설명
 
- 접속로그관리는 로그인 패키지(egovframework-certlogin-x.x.x.zip) 설치 후에 사용이 가능하다.
- (단독 설치 후 실행 시 에러발생)
- 접속로그관리는 로그인로그의 등록, 조회, 목록의 기능을 수반한다.
+ 접속로그관리는 로그인 패키지(egovframework-certlogin-x.x.x.zip) 설치 후에 사용할 수 있다.
+ 단독 치 후 실행할 경우 오류가 발생한다.
+ 접속로그관리는 로그인로그의 등록, 조회, 목록의 기능을 제공한다.
 
- ① 접속로그등록 : 로그인로그정보를 등록한다. - AOP 기능을 이용
- ② 접속로그조회 : 로그인로그정보의 상세내용을 조회한다.
- ③ 접속로그목록 : 로그인로그정보의 목록을 검색, 조회한다.
+ 1. 접속로그 등록 : 로그인 로그 정보를 등록한다. - AOP 기능을 이용
+ 2. 접속로그 조회 : 로그인 로그 정보의 상세 내용을 조회한다.
+ 3. 접속로그 목록 : 로그인 로그 정보의 목록을 검색, 조회한다.
 
 ### 패키지 참조 관계
 
  접속로그관리 패키지는 요소기술의 공통(cmm) 패키지에 대해서만 직접적인 함수적 참조 관계를 가진다.
  패키지 간 참조 관계 : [시스템관리 Package Dependency](../intro/package-reference.md#시스템관리)
 
-### 관련소스
+### 관련 소스
 
 | 유형 | 대상소스명 | 비고 |
 | --- | --- | --- |
 | Controller | egovframework.com.sym.log.clg.web.EgovLoginLogController.java | 접속로그 관리를 위한 컨트롤러 클래스 |
-| Service | egovframework.com.sym.log.clg.service.EgovLoginLogService.java | 접속로그 관리를 위한  서비스 인터페이스 |
+| Service | egovframework.com.sym.log.clg.service.EgovLoginLogService.java | 접속로그 관리를 위한 서비스 인터페이스 |
 | ServiceImpl | egovframework.com.sym.log.clg.service.impl.EgovLoginLogServiceImpl.java | 접속로그 관리를 위한 서비스 구현 클래스 |
 | Model | egovframework.com.sym.log.clg.service.LoginLog.java | 접속로그 관리를 위한 VO 클래스 |
-| DAO | egovframework.com.sym.log.clg.service.impl.LoginLogDAO.java | 접속로그 관리를 위한 데이터처리 클래스 |
+| DAO | egovframework.com.sym.log.clg.service.impl.LoginLogDAO.java | 접속로그 관리를 위한 데이터 처리 클래스 |
 | Aspect | egovframework.com.sym.log.clg.service.EgovLoginLogAspect.java | 접속로그 등록을 위한 Aspect 클래스 |
-| JSP | /WEB-INF/jsp/egovframework/com/sym/log/clg/EgovLoginLogList.jsp | 접속로그 목록을 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/sym/log/clg/EgovLoginLogList.jsp | 접속로그 목록을 위한 JSP 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/sym/log/clg/EgovLoginLogDetail.jsp | 접속로그 상세조회를 위한 jsp페이지 |
 | Query XML | resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog\_SQL\_altibase.xml | 접속로그 관리를 위한 Altibase용 Query XML |
 | Query XML | resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog\_SQL\_cubrid.xml | 접속로그 관리를 위한 Cubrid용 Query XML |
@@ -59,13 +59,13 @@ menu:
 
 ### 클래스 다이어그램
 
- ![image](./images/sym-conectlog-접속로그관리_클래스다이어그램.jpg)
+ ![접속로그관리 클래스 다이어그램](./images/sym-conectlog-접속로그관리_클래스다이어그램.jpg)
 
 ### ID Generation
 
 #### ID Generation 관련 DDL 및 DML
 
- ID Generation Service를 활용하기 위해서 Sequence 저장테이블인 COMTECOPSEQ에 LOGINLOG_ID 항목을 추가한다.
+ ID Generation Service를 활용하기 위해서 Sequence 저장 테이블인 COMTECOPSEQ에 LOGINLOG_ID 항목을 추가한다.
 
 ```sql
 CREATE TABLE COMTECOPSEQ(TABLE_NAME VARCHAR(20) NOT NULL,
@@ -96,7 +96,7 @@ CREATE TABLE COMTECOPSEQ(TABLE_NAME VARCHAR(20) NOT NULL,
 
 | 테이블명 | 테이블명(영문) | 비고 |
 | --- | --- | --- |
-| 접속로그 | COMTNLOGINLOG | 로그인로그 정보를 관리한다. |
+| 접속로그 | COMTNLOGINLOG | 로그인 로그 정보를 관리한다. |
 
 ### AOP
 
@@ -115,8 +115,7 @@ CREATE TABLE COMTECOPSEQ(TABLE_NAME VARCHAR(20) NOT NULL,
 	</aop:config>
 ```
 
- 접속로그 등록 기능구현을 위하여 AOP를 설정한다.
- 접속로그 등록 기능구현을 위하여 EgovLoginLogAspect 클래스를 생성한다.
+ 접속로그 등록 기능을 구현하기 위해 AOP를 설정하고 EgovLoginLogAspect 클래스를 생성한다.
 
 ```java
 package egovframework.com.sym.log.clg.service;
@@ -149,7 +148,7 @@ loginLog.setLoginId(uniqId);
 loginLog.setLoginIp(ip);
 loginLog.setLoginMthd("I"); // 로그인:I, 로그아웃:O
 loginLog.setErrOccrrAt("N");
-loginLog.setErrorCode(");
+loginLog.setErrorCode("");
 loginLogService.logInsertLoginLog(loginLog);
 }
 /**
@@ -182,21 +181,21 @@ loginLogService.logInsertLoginLog(loginLog);
 ```
 
 
-## 관련기능
+## 관련 기능
 
- 접속로그관리는 접속로그 목록조회, 접속로그 상세조회 기능으로 구분된다.
+ 접속로그관리는 접속로그 목록 조회, 접속로그 상세 조회 기능으로 구분된다.
 
-### 접속로그 목록조회
+### 접속 로그 목록 조회
 
 #### 비즈니스 규칙
 
- 로그인로그 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 검색조건은 발생일자와 로그유형에 대해서 수행된다.
+ 로그인 로그 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 검색 조건은 발생 일자와 로그 유형에 대해서 수행된다.
 
-#### 관련코드
+#### 관련 코드
 
  N/A
 
-#### 관련화면 및 수행매뉴얼
+#### 관련 화면 및 수행매뉴얼
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
@@ -205,27 +204,27 @@ loginLogService.logInsertLoginLog(loginLog);
 
  ![image](./images/sym-conectlog-목록.jpg)
 
- 로그인로그 상세조회 기능을 수행하기 위해서는 상세보기 버튼을 클릭한다.
+ 로그인 로그 상세 조회 기능을 수행하기 위해서는 상세보기 버튼을 클릭한다.
 
-### 접속로그 상세조회
+### 접속 로그 상세 조회
 
 #### 비즈니스 규칙
 
- 로그인로그 상세조회는 팝업창으로 구성되며, 닫기 버튼을 클릭하면 창을 닫는다.
+ 로그인 로그 상세 조회는 팝업창으로 구성되며, 닫기 버튼을 클릭하면 창을 닫는다.
 
-#### 관련코드
+#### 관련 코드
 
  N/A
 
 #### 관련화면 및 수행매뉴얼
 
-| Action | URL | Controller method | SQL Namespace | SQL QueryID |
+| Action | URL | Controller Method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /sym/log/clg/SelectLoginLogDetail.do | selectLoginLog | "LoginLog" | "selectLoginLog" |
+| 상세 조회 | /sym/log/clg/SelectLoginLogDetail.do | selectLoginLog | "LoginLog" | "selectLoginLog" |
 
  ![image](./images/sym-conectlog-상세.jpg)
 
-## 참고자료
+## 참고 자료
 
  실행환경 참조 : [AOP](/egovframe-runtime/foundation-layer-core/aop.md)
  실행환경 참조 : [ID Generation](/egovframe-runtime/foundation-layer/id-generation.md)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [x] 기존 문서 보완 (docs/update)
- [ ] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

접속로그관리 문서의 가독성을 개선하고 일부 오탈자 및 띄어쓰기를 수정했습니다.

- 문서 내 어색한 표현 및 문장 구조 개선
- 용어 및 띄어쓰기 정리
- 중복된 설명을 하나의 문장으로 정리
- 관련 소스 및 기능 설명의 표기 방식 개선



## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->



## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [ ] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->


