### PR TITLE
docs: 지식맵(조직별) 관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/digital-asset-management/org-knowledge-map-management.md
+++ b/common-component/digital-asset-management/org-knowledge-map-management.md
@@ -41,14 +41,14 @@ menu:
 | JSP | /WEB-INF/jsp/egovframework/com/dam/map/tea/EgovComDamMapTeamRegist.jsp | 지식맵(조직별) 등록을 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/dam/map/tea/EgovComDamMapTeamModify.jsp | 지식맵(조직별) 수정을 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/dam/map/tea/EgovComDamMapTeamDetail.jsp | 등록된 지식맵(조직별)을 조회하기 위한 jsp페이지 |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_altibase.xml | 지식맵(조직별) 관리를 위한 Altibase용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_cubrid.xml | 지식맵(조직별) 관리를 위한 Cubrid용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_maria.xml | 지식맵(조직별) 관리를 위한 MariaDB용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_mysql.xml | 지식맵(조직별) 관리를 위한 MySQL용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_oracle.xml | 지식맵(조직별) 관리를 위한 Oracle용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_postgres.xml | 지식맵(조직별) 관리를 위한 PostgreSQL용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_tibero.xml | 지식맵(조직별) 관리를 위한 Tibero용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_goldilocks.xml | 지식맵(조직별) 관리를 위한 Goldilocks용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_altibase.xml | 지식맵(조직별) 관리를 위한 Altibase용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_cubrid.xml | 지식맵(조직별) 관리를 위한 Cubrid용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_maria.xml | 지식맵(조직별) 관리를 위한 MariaDB용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_mysql.xml | 지식맵(조직별) 관리를 위한 MySQL용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_oracle.xml | 지식맵(조직별) 관리를 위한 Oracle용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_postgres.xml | 지식맵(조직별) 관리를 위한 PostgreSQL용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_tibero.xml | 지식맵(조직별) 관리를 위한 Tibero용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_goldilocks.xml | 지식맵(조직별) 관리를 위한 Goldilocks용 Query XML |
 | Message properties | resources/egovframework/message/com/dam/map/tea/message\_en.properties | 지식맵(조직별) 관리를 위한 Message properties(영문) |
 | Message properties | resources/egovframework/message/com/dam/map/tea/message\_ko.properties | 지식맵(조직별) 관리를 위한 Message properties(한글) |
 
@@ -63,6 +63,16 @@ menu:
 | 지식맵(조직별) | COMTNDAMMAPTEAM | 지식맵(조직별)정보를 관리하기 위한 속성정보를 정의하고, 관리한다. |
 
 ## 관련화면 및 수행매뉴얼
+
+```mermaid
+flowchart LR
+    L[지식맵(조직별) 목록조회] -->|등록| R[지식맵(조직별) 등록]
+    L -->|조직명 클릭| D[지식맵(조직별) 상세조회]
+    R -->|저장| L
+    D -->|수정| U[지식맵(조직별) 수정]
+    U -->|저장| L
+    D -->|삭제| L
+```
 
 ### 지식맵(조직별) 목록조회
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)
- [ ] 신규 문서 추가 (docs/new)
- [x] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)
공통컴포넌트 디지털자산관리 부문의 지식맵(조직별) 관리 가이드 문서에 화면 전환 흐름을 시각화하고 소스 경로 오류를 정정했습니다.

1. **화면 전환 흐름 시각화**: '관련화면 및 수행매뉴얼' 항목에 Mermaid.js 기반 flowchart 다이어그램을 추가하여 지식맵(조직별) 목록조회/등록/수정/상세조회(삭제) 화면 간 전환 관계를 직관적으로 표현
2. **표 오류 정정**:
   - 8개 DB(Altibase/Cubrid/MariaDB/MySQL/Oracle/PostgreSQL/Tibero/Goldilocks)용 Query XML 파일명이 모두 `EgovDamMapTeamMapTeam_SQL_*.xml`로 `MapTeam`이 중복 기재되어 있던 것을 `EgovDamMapTeam_SQL_*.xml`로 정정
   - 자매 문서(지식맵(유형별) 관리)의 Query XML 파일명에도 동일 오류가 `EgovDamMapTeamMapMaterial_SQL_*.xml` 형태로 전파되어 있음을 확인, 해당 오류가 본 문서에서 유래했음을 교차 검증
3. **정합성 검증**: scripts/docs_lint.py를 실행하여 Frontmatter 보존 및 검사(0 findings) 통과 확인

## 관련 이슈 (Related Issues)
해당 사항 없음

## 변경 영역 (Affected Areas)
- [ ] 개발환경 (egovframe-development/)
- [ ] 실행환경 (egovframe-runtime/)
- [x] 공통컴포넌트 (common-component/)
- [ ] 기타 (README, 설정 파일 등)

## 체크리스트 (Checklist)
- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 title, url, menu, weight 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)
2026 전자정부 표준프레임워크 컨트리뷰션 (대학생 부문) 출품작입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw