### PR TITLE
docs: 약도관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/user-support/map-management.md
+++ b/common-component/user-support/map-management.md
@@ -30,15 +30,15 @@ menu:
 | ServiceImpl | egovframework.com.uss.ion.rmm.service.impl.EgovRoughMapServiceImpl.java | 약도관리를 위한 서비스 구현 클래스 |
 | VO | egovframework.com.uss.ion.rmm.service.RoughMapVO.java | 약도관리를 위한 VO 클래스 |
 | VO | egovframework.com.uss.ion.rmm.service.RoughMapDefaultVO.java | 약도관리를 위한 SearchVO 클래스 |
-| DAO | egovframework.com.uss.ion.rmm.service.impl.EgovRoughMapDAO.java | 약도관리를 위한 데이터처리 클래스 |
+| DAO | egovframework.com.uss.ion.rmm.service.impl.RoughMapDAO.java | 약도관리를 위한 데이터처리 클래스 |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/ion/rmm/EgovRoughMapList.jsp | 약도관리를 위한 목록조회 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/ion/rmm/EgovRoughMapDetail.jsp | 약도관리를 위한 상세조회 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/ion/rmm/EgovRoughMapRegist.jsp | 약도관리를 위한 등록 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/uss/ion/rmm/EgovRoughMapUpdt.jsp | 약도관리를 위한 수정 페이지 |
 | XML | resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap\_SQL\_altibase.xml | 약도관리 QUERY Altibase XML |
-| XML | resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap\_SQL\_cubrid.xml | 약도관리 QUERY Cubrid XML XML |
-| XML | resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap\_SQL\_maria.xml | 약도관리 QUERY MariaDB XML XML |
-| XML | resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap\_SQL\_mysql.xml | 약도관리 QUERY MySQL XML XML |
+| XML | resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap\_SQL\_cubrid.xml | 약도관리 QUERY Cubrid XML |
+| XML | resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap\_SQL\_maria.xml | 약도관리 QUERY MariaDB XML |
+| XML | resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap\_SQL\_mysql.xml | 약도관리 QUERY MySQL XML |
 | XML | resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap\_SQL\_oracle.xml | 약도관리 QUERY Oracle XML |
 | XML | resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap\_SQL\_postgres.xml | 약도관리 QUERY PostgreSQL XML |
 | XML | resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap\_SQL\_tibero.xml | 약도관리 QUERY Tibero XML |
@@ -104,6 +104,16 @@ roughMap.appkey = 발급키입력
 
  약도관리기능은 크게 약도목록조회, 약도상세조회, 약도등록, 약도수정 기능으로 구성되어 있다.
 
+```mermaid
+flowchart LR
+    L[약도목록조회] -->|등록| R[약도등록]
+    L -->|목록클릭| D[약도상세조회]
+    R -->|저장| L
+    D -->|수정| U[약도수정]
+    U -->|저장| L
+    D -->|삭제| L
+```
+
 ### 약도목록조회
 
 #### 비즈니스 규칙
@@ -118,8 +128,8 @@ roughMap.appkey = 발급키입력
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /com/uss/ion/rmm/selectRoughMapList.do | selectRoughMapList | "EgovRoughMapDAO.selectRoughMapList", |
-|  |  |  | "EgovRoughMapDAO.selectRoughMapListTotCnt" |
+| 목록조회 | /com/uss/ion/rmm/selectRoughMapList.do | selectRoughMapList | "RoughMapDAO.selectRoughMapList", |
+|  |  |  | "RoughMapDAO.selectRoughMapListTotCnt" |
 
  약도목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
  검색조건은 약도제목, 약도주소에 대해서 수행된다.
@@ -154,7 +164,7 @@ roughMap.appkey = 발급키입력
  ![image](./images/uss-map-약도관리상세.jpg)
 
  길찾기 : 약도에 표시된 위치로 목적지로 하는 다음길찾기 화면으로 이동한다.
- 크게보기 : 약도에 표신된 위치를 기준으로 하는 다음지도 화면으로 이동한다.
+ 크게보기 : 약도에 표시된 위치를 기준으로 하는 다음지도 화면으로 이동한다.
  수정: 수정버튼 클릭 시 약도를 수정할 수 있는 화면으로 이동한다.
  삭제: 삭제버튼 클릭 시 삭제여부를 확인하는 메시지를 보여주고 삭제처리를 할 수 있다.
  목록: 약도목록조회 화면으로 이동한다.


### PR DESCRIPTION
## 변경 유형 (Type of Change)
- [ ] 신규 문서 추가 (docs/new)
- [x] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)
공통컴포넌트 사용자지원 부문의 약도관리 가이드 문서에 화면 전환 흐름을 시각화하고 DAO 표기 및 오탈자 오류를 정정했습니다.

1. **화면 전환 흐름 시각화**: '관련기능' 항목에 Mermaid.js 기반 flowchart 다이어그램을 추가하여 약도목록조회/등록/상세조회(삭제)/수정 화면 간 전환 관계를 직관적으로 표현
2. **DAO 클래스명 표기 정정**:
   - '관련소스' 표와 '약도목록조회' QueryID에서 DAO 클래스명이 `EgovRoughMapDAO`로 표기되어 있던 것을, 같은 문서의 나머지 5개 QueryID(상세조회/삭제/등록/수정)가 공통으로 사용하는 `RoughMapDAO`(Egov 접두사 없음)로 통일 — 공통컴포넌트 전반의 DAO 클래스 명명 관례(Controller/Service와 달리 DAO는 Egov 접두사를 붙이지 않음)와도 일치
3. **표 오류 정정**: Cubrid/MariaDB/MySQL용 Query XML 비고란에 "XML XML"로 단어가 중복 기재되어 있던 것을 정정
4. **오탈자 정정**: "약도에 표신된 위치를" → "약도에 표시된 위치를"
5. **정합성 검증**: scripts/docs_lint.py를 실행하여 Frontmatter 보존 및 검사(0 findings) 통과 확인

## 관련 이슈 (Related Issues)
해당 사항 없음

## 변경 영역 (Affected Areas)
- [ ] 개발환경 (egovframe-development/)
- [ ] 실행환경 (egovframe-runtime/)
- [x] 공통컴포넌트 (common-component/)
- [ ] 기타 (README, 설정 파일 등)

## 체크리스트 (Checklist)
- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 title, url, menu, weight 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)
2026 전자정부 표준프레임워크 컨트리뷰션 (대학생 부문) 출품작입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw