### PR TITLE
docs: 온라인POLL관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/user-support/online-poll.md
+++ b/common-component/user-support/online-poll.md
@@ -18,6 +18,12 @@ menu:
 
 ## 설명
 
+```mermaid
+flowchart LR
+    M[관리자: POLL 등록/항목관리] --> P[사용자: POLL 참여/응답]
+    P --> R[결과 집계·조회]
+```
+
 ### 관련소스
 
 | 유형 | 대상소스명 | 비고 |
@@ -57,26 +63,26 @@ menu:
 | 메서드 | 반환형 | 설명 |
 | --- | --- | --- |
 | `selectOnlinePollManageList(ComDefaultVO)` | `List<EgovMap>` | 목록을 조회한다 |
-| `selectOnlinePollManageDetail(OnlinePollManage)` | `OnlinePollManage` | 온라인POLL관리를(을) 상세조회 한다. |
-| `selectOnlinePollManageListCnt(ComDefaultVO)` | `int` | 온라인POLL관리를(을) 목록 전체 건수를(을) 조회한다. |
-| `insertOnlinePollManage(OnlinePollManage)` | `void` | 온라인POLL관리를(을) 등록한다. |
-| `updateOnlinePollManage(OnlinePollManage)` | `void` | 온라인POLL관리를(을) 수정한다. |
-| `deleteOnlinePollManage(OnlinePollManage)` | `void` | 온라인POLL관리를(을) 삭제한다. |
-| `selectOnlinePollManageStatistics(OnlinePollManage)` | `List<?>` | 온라인POLL관리를(을) 통계를 조회 한다. |
-| `selectOnlinePollItemList(OnlinePollItem)` | `List<EgovMap>` | 온라인POLL항목를(을) 조회한다. |
-| `insertOnlinePollItem(OnlinePollItem)` | `void` | 온라인POLL항목를(을) 등록한다. |
-| `updateOnlinePollItem(OnlinePollItem)` | `void` | 온라인POLL항목를(을) 수정한다. |
-| `deleteOnlinePollItem(OnlinePollItem)` | `void` | 온라인POLL항목를(을) 삭제한다. |
+| `selectOnlinePollManageDetail(OnlinePollManage)` | `OnlinePollManage` | 온라인POLL관리를 상세조회 한다. |
+| `selectOnlinePollManageListCnt(ComDefaultVO)` | `int` | 온라인POLL관리 목록의 전체 건수를 조회한다. |
+| `insertOnlinePollManage(OnlinePollManage)` | `void` | 온라인POLL관리를 등록한다. |
+| `updateOnlinePollManage(OnlinePollManage)` | `void` | 온라인POLL관리를 수정한다. |
+| `deleteOnlinePollManage(OnlinePollManage)` | `void` | 온라인POLL관리를 삭제한다. |
+| `selectOnlinePollManageStatistics(OnlinePollManage)` | `List<?>` | 온라인POLL관리의 통계를 조회한다. |
+| `selectOnlinePollItemList(OnlinePollItem)` | `List<EgovMap>` | 온라인POLL항목을 조회한다. |
+| `insertOnlinePollItem(OnlinePollItem)` | `void` | 온라인POLL항목을 등록한다. |
+| `updateOnlinePollItem(OnlinePollItem)` | `void` | 온라인POLL항목을 수정한다. |
+| `deleteOnlinePollItem(OnlinePollItem)` | `void` | 온라인POLL항목을 삭제한다. |
 
 ### 주요 메서드 (EgovOnlinePollPartcptnService (참여))
 
 | 메서드 | 반환형 | 설명 |
 | --- | --- | --- |
 | `selectOnlinePollManageList(ComDefaultVO)` | `List<EgovMap>` | 목록을 조회한다 |
-| `selectOnlinePollManageListCnt(ComDefaultVO)` | `int` | 온라인POLL관리를(을) 목록 전체 건수를(을) 조회한다. |
-| `selectOnlinePollManageDetail(OnlinePollPartcptn)` | `List<EgovMap>` | 온라인POLL관리를(을) 상세조회 한다. |
-| `selectOnlinePollItemDetail(OnlinePollPartcptn)` | `List<EgovMap>` | 온라인POLL항목를(을) 상세조회 한다. |
-| `insertOnlinePollResult(OnlinePollPartcptn)` | `void` | 온라인POLL참여를(을) 등록한다. |
+| `selectOnlinePollManageListCnt(ComDefaultVO)` | `int` | 온라인POLL관리 목록의 전체 건수를 조회한다. |
+| `selectOnlinePollManageDetail(OnlinePollPartcptn)` | `List<EgovMap>` | 온라인POLL관리를 상세조회 한다. |
+| `selectOnlinePollItemDetail(OnlinePollPartcptn)` | `List<EgovMap>` | 온라인POLL항목을 상세조회 한다. |
+| `insertOnlinePollResult(OnlinePollPartcptn)` | `void` | 온라인POLL참여를 등록한다. |
 | `selectOnlinePollManageStatistics(OnlinePollPartcptn)` | `List<EgovMap>` | 온라인POLL참여 통계를 조회한다. |
 | `selectOnlinePollResult(OnlinePollPartcptn)` | `int` | 온라인POLL참여 여부를 조회한다. |
 
@@ -85,7 +91,7 @@ menu:
 | 메서드 | 반환형 | 설명 |
 | --- | --- | --- |
 | `selectOnlinePollResultList(OnlinePollResult)` | `List<?>` | 목록을 조회한다 |
-| `deleteOnlinePollResult(OnlinePollResult)` | `void` | 온라인POLL결과를(을) 삭제 한다. |
+| `deleteOnlinePollResult(OnlinePollResult)` | `void` | 온라인POLL결과를 삭제 한다. |
 
 ## 참고자료
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)
- [ ] 신규 문서 추가 (docs/new)
- [x] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)
공통컴포넌트 사용자지원 부문의 온라인POLL관리 가이드 문서에 관리·참여·결과 처리 흐름을 시각화하고 미해결 템플릿 표기를 대량 정정했습니다.

1. **처리 흐름 시각화**: '설명' 항목에 Mermaid.js 기반 flowchart 다이어그램을 추가하여 개요에 명시된 "관리자의 POLL 등록/항목관리 → 사용자 참여/응답 → 결과 집계·조회" 흐름을 직관적으로 표현
2. **문장 오류 대량 정정**: '주요 메서드' 3개 표(관리/참여/결과)에서 조사 선택이 해결되지 않은 템플릿 표기(`를(을)`)가 16곳 남아있던 것을, 각 명사의 받침 유무에 맞는 올바른 조사(관리→를, 항목→을, 참여→를, 결과→를)로 정정. 아울러 "목록 전체 건수를(을) 조회한다.", "통계를(을) 조회 한다."처럼 어색한 이중 조사 문장 2건도 자연스러운 문장으로 정비
3. **정합성 검증**: scripts/docs_lint.py를 실행하여 Frontmatter 보존 및 검사(0 findings) 통과 확인

## 관련 이슈 (Related Issues)
해당 사항 없음

## 변경 영역 (Affected Areas)
- [ ] 개발환경 (egovframe-development/)
- [ ] 실행환경 (egovframe-runtime/)
- [x] 공통컴포넌트 (common-component/)
- [ ] 기타 (README, 설정 파일 등)

## 체크리스트 (Checklist)
- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 title, url, menu, weight 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)
2026 전자정부 표준프레임워크 컨트리뷰션 (대학생 부문) 출품작입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw