### PR TITLE
docs: RSS태그관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/user-support/rss-tag.md
+++ b/common-component/user-support/rss-tag.md
@@ -18,6 +18,17 @@ RSS태그관리는 게시판 등 콘텐츠를 RSS로 제공하기 위한 RSS 태
 
 ## 설명
 
+```mermaid
+flowchart LR
+    L[RSS태그관리 목록조회] -->|등록| R[RSS태그관리 등록]
+    L -->|상세조회| D[RSS태그관리 상세조회]
+    R --> L
+    D -->|수정| U[RSS태그관리 수정]
+    U --> L
+    D -->|삭제| L
+    L -->|RSS 피드 생성| F([RSS 피드])
+```
+
 ### 관련소스
 
 | 유형 | 대상소스명 | 비고 |
@@ -49,11 +60,11 @@ RSS태그관리는 게시판 등 콘텐츠를 RSS로 제공하기 위한 RSS 태
 | `selectRssTagManageTableList()` | `List<?>` | 목록을 조회한다 |
 | `selectRssTagManageTableColumnList(Map<?, ?>)` | `List<?>` | JDBC 테이블 컬럼 목록을 조회한다. |
 | `selectRssTagManageList(RssManage)` | `List<?>` | RSS태그관리 목록을 조회한다. |
-| `selectRssTagManageListCnt(RssManage)` | `int` | RSS태그관리를(을) 목록 전체 건수를(을) 조회한다. |
-| `selectRssTagManageDetail(RssManage)` | `RssManage` | RSS태그관리를(을) 상세조회 한다. |
-| `insertRssTagManage(RssManage)` | `void` | RSS태그관리를(을) 등록한다. |
-| `updateRssTagManage(RssManage)` | `void` | RSS태그관리를(을) 수정한다. |
-| `deleteRssTagManage(RssManage)` | `void` | RSS태그관리를(을) 삭제한다. |
+| `selectRssTagManageListCnt(RssManage)` | `int` | RSS태그관리 목록의 전체 건수를 조회한다. |
+| `selectRssTagManageDetail(RssManage)` | `RssManage` | RSS태그관리를 상세조회 한다. |
+| `insertRssTagManage(RssManage)` | `void` | RSS태그관리를 등록한다. |
+| `updateRssTagManage(RssManage)` | `void` | RSS태그관리를 수정한다. |
+| `deleteRssTagManage(RssManage)` | `void` | RSS태그관리를 삭제한다. |
 
 ## 참고자료
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)
- [ ] 신규 문서 추가 (docs/new)
- [x] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)
공통컴포넌트 사용자지원 부문의 RSS태그관리 가이드 문서에 화면 전환 흐름을 시각화하고 미해결 템플릿 표기를 정정했습니다.

1. **화면 전환 흐름 시각화**: '설명' 항목에 Mermaid.js 기반 flowchart 다이어그램을 추가하여 RSS태그관리 목록조회/등록/수정/상세조회(삭제)와 RSS 피드 생성으로 이어지는 흐름을 직관적으로 표현
2. **문장 오류 정정**: '주요 메서드' 표에서 조사 선택이 해결되지 않은 템플릿 표기(`를(을)`)가 5곳 남아있던 것을, 해당 명사(받침 없음)에 맞는 조사 "를"로 정정. "목록 전체 건수를(을) 조회한다."는 어색한 이중 조사 문장도 "목록의 전체 건수를 조회한다."로 자연스럽게 정비
3. **정합성 검증**: scripts/docs_lint.py를 실행하여 Frontmatter 보존 및 검사(0 findings) 통과 확인

## 관련 이슈 (Related Issues)
해당 사항 없음

## 변경 영역 (Affected Areas)
- [ ] 개발환경 (egovframe-development/)
- [ ] 실행환경 (egovframe-runtime/)
- [x] 공통컴포넌트 (common-component/)
- [ ] 기타 (README, 설정 파일 등)

## 체크리스트 (Checklist)
- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 title, url, menu, weight 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)
2026 전자정부 표준프레임워크 컨트리뷰션 (대학생 부문) 출품작입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw