### PR TITLE
docs: 일정관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/collaboration/schedule-management.md
+++ b/common-component/collaboration/schedule-management.md
@@ -53,7 +53,7 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_goldilocks.xml | 일정관리를 위한 Goldilocks용 Query XML |
 | Message properties | resources/egovframework/message/com/cop/smt/sim/message_ko.properties | 마이페이지 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/cop/smt/sim/message_en.properties | 마이페이지 Message properties(영문) |
-| Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-diaryManage.xml | 일정관리 Id생성 Idgen XML |
+| Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-indvdlSchdulManage.xml | 일정관리 Id생성 Idgen XML |
 
 ### 클래스 다이어그램
 
@@ -73,18 +73,18 @@ CREATE TABLE COMTECOPSEQ (TABLE_NAME VARCHAR(20) NOT NULL,
 INSERT INTO COMTECOPSEQ VALUES('SCHDUL_ID','1');
 ```
 
-#### ID Generation 환경설정(context-idgn-diaryManage.xml)
+#### ID Generation 환경설정(context-idgn-indvdlSchdulManage.xml)
 
 ```xml
-<bean name="diaryManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="indvdlSchdulManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
-    <property name="strategy"   ref="DiaryManageInfotrategy" />
+    <property name="strategy"   ref="IndvdlSchdulManageStrategy" />
     <property name="blockSize"  value="10"/>
     <property name="table"      value="COMTECOPSEQ"/>
-    <property name="tableName"  value="DIARY_ID"/>
+    <property name="tableName"  value="SCHDUL_ID"/>
 </bean>
-<bean name="DiaryManageInfotrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
-    <property name="prefix"   value="DIARY_" />
+<bean name="IndvdlSchdulManageStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <property name="prefix"   value="SCHDUL_" />
     <property name="cipers"   value="14" />
     <property name="fillChar" value="0" />
 </bean>
@@ -94,11 +94,23 @@ INSERT INTO COMTECOPSEQ VALUES('SCHDUL_ID','1');
 
 | 테이블명 | 테이블명(영문) | 비고 |
 | --- | --- | --- |
-| 일정관리 | COMTNMTGINFO | 일정을 관리한다. |
+| 일정관리 | COMTNSCHDULINFO | 일정을 관리한다. |
 
 ## 관련기능
 
 일정관리 기능은 일정관리 월별목록, 일정관리 주간별목록, 일정관리 일별목록, 일정관리 상세조회, 일정관리 등록, 일정관리 수정 기능으로 구성되어 있다.
+
+```mermaid
+flowchart LR
+    M[일정관리 월별목록] -->|일정클릭| D[일정관리 상세조회]
+    W[일정관리 주간별목록] -->|일정클릭| D
+    Y[일정관리 일별목록] -->|일정클릭| D
+    M -->|날짜클릭| R[일정관리 등록]
+    R --> M
+    D -->|수정| U[일정관리 수정]
+    U --> M
+    D -->|삭제| M
+```
 
 ### 일정관리 월별목록
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)
- [ ] 신규 문서 추가 (docs/new)
- [x] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)
공통컴포넌트 협업지원 부문의 일정관리 가이드 문서에 화면 전환 흐름을 시각화하고, 다른 문서에서 잘못 복사된 ID Generation/테이블 정보를 정정했습니다.

1. **화면 전환 흐름 시각화**: '관련기능' 항목에 Mermaid.js 기반 flowchart 다이어그램을 추가하여 월별/주간별/일별목록 → 상세조회 → 수정/삭제, 날짜클릭 → 등록으로 이어지는 흐름을 직관적으로 표현
2. **ID Generation 오류 정정**: 본문 DDL/INSERT문은 이미 이 문서의 실제 ID(`SCHDUL_ID`)를 올바르게 사용 중이었으나, Idgen 환경설정 블록 전체(Bean 이름, Strategy, tableName, prefix, Idgen XML 파일 경로)가 `journal-management.md`(일지관리)의 `DIARY_ID` 설정을 그대로 복사해 온 상태였음을 교차 확인 후, 자매 문서 `department-schedule.md`의 명명 규칙(`deptSchdulManageIdGnrService`, `tableName=SCHDUL_ID`, `prefix=SCHDUL_`)에 맞춰 이 문서의 클래스 접두어(`IndvdlSchdulManage`)를 반영한 값으로 정정
3. **관련테이블 오류 정정**: 테이블 영문명이 이 기능(개인일정관리)과 무관한 `COMTNMTGINFO`(회의정보관리·부서일정관리에서 사용하는 값)로 되어 있던 것을, 직접 연관된 자매 패키지 `all-schedule.md`(전체일정)가 사용하는 `COMTNSCHDULINFO`로 정정
4. **정합성 검증**: scripts/docs_lint.py를 실행하여 Frontmatter 보존 및 검사(0 findings) 통과 확인

## 관련 이슈 (Related Issues)
해당 사항 없음

## 변경 영역 (Affected Areas)
- [ ] 개발환경 (egovframe-development/)
- [ ] 실행환경 (egovframe-runtime/)
- [x] 공통컴포넌트 (common-component/)
- [ ] 기타 (README, 설정 파일 등)

## 체크리스트 (Checklist)
- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 title, url, menu, weight 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)
2026 전자정부 표준프레임워크 컨트리뷰션 (대학생 부문) 출품작입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw