### PR TITLE
docs: 백업관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/system-management/backup-management.md
+++ b/common-component/system-management/backup-management.md
@@ -37,6 +37,19 @@ menu:
   ⑤ 백업결과조회 : 등록된 백업결과정보를 조회한다.
 ```
 
+```mermaid
+flowchart LR
+    L[백업작업 목록조회] -->|등록| R[백업작업 등록]
+    L -->|목록클릭| D[백업작업 상세조회]
+    R --> L
+    D -->|수정| U[백업작업 수정]
+    U --> L
+    D -->|삭제| L
+    D -.배치 실행.-> RL[백업결과 목록조회]
+    RL --> RD[백업결과 상세조회]
+    RD -->|삭제| RL
+```
+
 ### 관련소스
 
 | 유형 | 대상소스명 | 비고 |
@@ -63,8 +76,8 @@ menu:
 | QUERY XML | resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert\_SQL\_altibase.xml | 백업작업관리 Altibase용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert\_SQL\_cubrid.xml | 백업작업관리 Cubrid용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert\_SQL\_maria.xml | 백업작업관리 Maria용 QUERY XML |
-| QUERY XML | resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert\_SQL\_postgres.xml | 백업작업관리 Goldilocks용 QUERY XML |
-| QUERY XML | resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert\_SQL\_goldilocks.xml | 백업작업관리 Postgres용 QUERY XML |
+| QUERY XML | resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert\_SQL\_postgres.xml | 백업작업관리 Postgres용 QUERY XML |
+| QUERY XML | resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert\_SQL\_goldilocks.xml | 백업작업관리 Goldilocks용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult\_SQL\_mysql.xml | 백업결과관리 MySQL용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult\_SQL\_oracle.xml | 백업결과관리 Oracle용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult\_SQL\_tibero.xml | 백업결과관리 Tibero용 QUERY XML |
@@ -94,7 +107,7 @@ menu:
 
 #### ID Generation
 
- ID Generation Service를 활용하기 위해서 Sequence 저장테이블인  COMTECOPSEQ에 BACKUP_OPERT_ID, BACKUP_RESULT_ID 항목을 추가한다.
+ ID Generation Service를 활용하기 위해서 Sequence 저장테이블인 COMTECOPSEQ에 BACKUP_OPERT_ID, BACKUP_RESULT_ID 항목을 추가한다.
 
 ```sql
   INSERT INTO COMTECOPSEQ VALUES('BACKUP_OPERT_ID','0');
@@ -103,7 +116,7 @@ menu:
 
 #### ID Generation 관련 DDL 및 DML
 
- ID Generation Service를 활용하기 위해서 Sequence 저장테이블인  COMTECOPSEQ에 BACKUP_OPERT_ID, BACKUP_RESULT_ID 항목을 추가해야 한다.
+ ID Generation Service를 활용하기 위해서 Sequence 저장테이블인 COMTECOPSEQ에 BACKUP_OPERT_ID, BACKUP_RESULT_ID 항목을 추가해야 한다.
 
 ```sql
     CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL, 
@@ -115,33 +128,33 @@ menu:
     INSERT INTO COMTECOPSEQ VALUES('BACKUP_RESULT_ID','0');
 ```
 
-#### ID Generation 환경설정(context-idgn-BatchOpert.xml)
+#### ID Generation 환경설정(context-idgn-BackupOpert.xml)
 
 ```xml
-    <!--  배치작업 ID -->
-    <bean name="egovBatchOpertIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <!--  백업작업 ID -->
+    <bean name="egovBackupOpertIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
-        <property name="strategy"   ref="batchOpertIdStrategy" />
+        <property name="strategy"   ref="backupOpertIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
-        <property name="tableName"  value="BATCH_OPERT_ID"/>
+        <property name="tableName"  value="BACKUP_OPERT_ID"/>
     </bean>
-    <bean name="batchOpertIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
-        <property name="prefix"     value="BAT" />
+    <bean name="backupOpertIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+        <property name="prefix"     value="BACKUP_OPERT_" />
         <property name="cipers"     value="17" />
         <property name="fillChar"   value="0" />
     </bean>
  
-    <!-- 배치스케줄 ID -->
-    <bean name="egovBatchSchdulIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <!-- 백업결과 ID -->
+    <bean name="egovBackupResultIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
-        <property name="strategy"   ref="batchSchdulIdStrategy" />
+        <property name="strategy"   ref="backupResultIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
-        <property name="tableName"  value="BATCH_SCHDUL_ID"/>
+        <property name="tableName"  value="BACKUP_RESULT_ID"/>
     </bean>
-    <bean name="batchSchdulIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
-        <property name="prefix"     value="BSC" />
+    <bean name="backupResultIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+        <property name="prefix"     value="BACKUP_RESULT_" />
         <property name="cipers"     value="17" />
         <property name="fillChar"   value="0" />
     </bean>


### PR DESCRIPTION
## 변경 유형 (Type of Change)
- [ ] 신규 문서 추가 (docs/new)
- [x] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)
공통컴포넌트 시스템관리 부문의 백업관리 가이드 문서에 처리 흐름을 시각화하고, 다른 문서에서 잘못 복사된 ID Generation/표 오류를 정정했습니다.

1. **처리 흐름 시각화**: '설명' 항목에 Mermaid.js 기반 flowchart 다이어그램을 추가하여 백업작업 목록조회/등록/수정/상세조회(삭제)와 배치 실행 이후의 백업결과 목록조회/상세조회(삭제) 흐름을 함께 표현
2. **ID Generation 오류 정정**: 본문 DDL/INSERT문 및 '관련소스' Idgen XML 경로(`context-idgn-BackupOpert.xml`)는 이미 이 문서의 실제 ID(`BACKUP_OPERT_ID`, `BACKUP_RESULT_ID`)를 올바르게 사용 중이었으나, Idgen 환경설정 XML 블록 전체(제목의 파일명, Bean 이름, Strategy, tableName, prefix, 주석)가 `batch-job-management.md`(배치작업관리, `BATCH_OPERT_ID`)와 `schedule-processing.md`(스케줄처리, `BATCH_SCHDUL_ID`)에서 그대로 복사되어 온 상태였음을 교차 확인 후, 이 문서 자신의 도메인(백업작업/백업결과)에 맞는 값으로 정정
3. **표 오류 정정**: '관련소스' 표에서 `EgovBackupOpert_SQL_postgres.xml`을 "Goldilocks용", `EgovBackupOpert_SQL_goldilocks.xml`을 "Postgres용"으로 설명이 서로 뒤바뀌어 있던 것을 파일명과 일치하도록 정정
4. **서식 오류 정정**: ID Generation 설명 문장 2곳의 중복 공백 제거
5. **정합성 검증**: scripts/docs_lint.py를 실행하여 Frontmatter 보존 및 검사(0 findings) 통과 확인

## 관련 이슈 (Related Issues)
해당 사항 없음

## 변경 영역 (Affected Areas)
- [ ] 개발환경 (egovframe-development/)
- [ ] 실행환경 (egovframe-runtime/)
- [x] 공통컴포넌트 (common-component/)
- [ ] 기타 (README, 설정 파일 등)

## 체크리스트 (Checklist)
- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 title, url, menu, weight 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)
2026 전자정부 표준프레임워크 컨트리뷰션 (대학생 부문) 출품작입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw