### PR TITLE
docs: 사용자 통계 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/statistics-reporting/user-statistics.md
+++ b/common-component/statistics-reporting/user-statistics.md
@@ -53,7 +53,7 @@
 | Query XML | resources/egovframework/mapper/com/sts/ust/EgovUserStats\_SQL\_tibero.xml | 사용자 통계를 위한 Tibero용 Query XML |
 | Query XML | resources/egovframework/mapper/com/sts/ust/EgovUserStats\_SQL\_altibase.xml | 사용자 통계를 위한 Altibase용 Query XML |
 | Query XML | resources/egovframework/mapper/com/sts/ust/EgovUserStats\_SQL\_maria.xml | 사용자 통계를 위한 Maria용 Query XML |
-| Query XML | resources/egovframework/mapper/com/sts/ust/EgovUserStats\_SQL\_postgres.xml | 사용자 통계를 위한 PostgresSQL용 Query XML |
+| Query XML | resources/egovframework/mapper/com/sts/ust/EgovUserStats\_SQL\_postgres.xml | 사용자 통계를 위한 PostgreSQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/sts/ust/EgovUserStats\_SQL\_goldilocks.xml | 사용자 통계를 위한 Goldilocks용 Query XML |
 | Message properties | resources/egovframework/message/com/sts/ust/message\_ko.properties | 사용자 통계 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/sts/ust/message\_en.properties | 사용자 통계 Message properties(영문) |
@@ -142,7 +142,7 @@ public class EgovUserStatsScheduling {
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 사용자 통계검색 | /sts/ust/selectUserStats.do | selectUserStats | "UserStatsDAO.selectUserStats", |
+| 사용자 통계검색 | /sts/ust/selectUserStats.do | selectUserStats | "UserStatsDAO.selectUserStats" |
 
  ![image](./images/sts-stats2.png)
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)
- [ ] 신규 문서 추가 (docs/new)
- [x] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)
공통컴포넌트 통계/리포팅 부문의 사용자 통계 가이드 문서에서 오탈자와 표 오류를 정정했습니다.

1. **오탈자 정정**: '관련소스' 표에서 "PostgresSQL용 Query XML"로 되어 있던 것을 "PostgreSQL용 Query XML"로 정정
2. **표 오류 정정**: '사용자 통계' 표의 QueryID 값 끝에 후속 행 없이 불필요한 쉼표(`,`)가 남아있던 것을 제거
3. **정합성 검증**: scripts/docs_lint.py를 실행하여 Frontmatter 보존 및 검사(0 findings) 통과 확인

## 관련 이슈 (Related Issues)
해당 사항 없음

## 변경 영역 (Affected Areas)
- [ ] 개발환경 (egovframe-development/)
- [ ] 실행환경 (egovframe-runtime/)
- [x] 공통컴포넌트 (common-component/)
- [ ] 기타 (README, 설정 파일 등)

## 체크리스트 (Checklist)
- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 title, url, menu, weight 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)
2026 전자정부 표준프레임워크 컨트리뷰션 (대학생 부문) 출품작입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw