### PR TITLE
docs: 로그인 시간관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/security/login_session_management.md
+++ b/common-component/security/login_session_management.md
@@ -22,6 +22,16 @@
 
  세션에 객체 정보 저장, 취득, 제거의 기능을 가지며 HttpServletRequest 객체의 HttpSession 정보를 사용하여 처리된다.
 
+```mermaid
+flowchart LR
+    L[로그인] --> F[SessionTimeoutCookieFilter]
+    F -->|쿠키 기록| S([egovLatestServerTime, egovExpireSessionTime])
+    S --> D[남은 로그인 시간 표시]
+    D -->|시간연장 요청| R[refreshSessionTimeout]
+    R --> S
+    D -->|만료| E([세션 만료])
+```
+
 ### 관련소스
 
 | 유형 | 대상소스 | 설명 | 비고 |
@@ -84,8 +94,7 @@ public class EgovWebApplicationInitializer implements WebApplicationInitializer 
 
 #### 비즈니스 규칙
 
- 회원가입시 또는 비밀번호 변경시 비밀번호 수정날짜가 관리된다.  
-비밀번호 수정날짜에서 특정한 시일이 경과하면 비밀번호 만료에 대한 안내 팝업을 출력하여 비밀번호 변경을 유도한다.
+ 사용자가 화면에서 **시간연장**을 요청하면 서버는 세션 타임아웃 쿠키(egovLatestServerTime, egovExpireSessionTime)를 최신 시간으로 갱신하여 로그인 세션의 만료 시간을 연장한다.
 
 #### 관련코드
 


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/security/login_session_management.md`의 "로그인 시간관리 시간연장" 비즈니스 규칙이 비밀번호 만료 관련 문서(`pw_expiration_management.md`)의 문장이 그대로 복사되어 실제 기능(세션 시간연장)과 무관한 내용으로 기재되어 있던 것을 발견하여, 세션 타임아웃 쿠키 갱신 흐름에 맞는 설명으로 수정했습니다.
- 로그인 → 필터 쿠키 기록 → 남은시간 표시 → 시간연장/만료로 이어지는 흐름을 시각화한 Mermaid 플로우차트를 추가했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/security/login_session_management.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/security` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw