### PR TITLE
docs: 커뮤니티사용관리 가이드 표 오탈자 수정

### DIFF
--- a/common-component/collaboration/community-use.md
+++ b/common-component/collaboration/community-use.md
@@ -119,7 +119,7 @@ N/A
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /cop/bbs/selectBBSMasterInfs.do | selectBBSMasterInfs | "BBSMaster.selectBBSMasterList", |
+| 목록조회 | /cop/bbs/selectBBSMasterInfs.do | selectBBSMasterInfs | "BBSMaster.selectBBSMasterList" |
 | | | | "BBSMaster.selectBBSMasterListTotCnt" |
 
 게시판관리 목록은 기본적인 페이징 처리가 되며 다음과 같은 정보를 제공한다.


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/collaboration/community-use.md`의 "커뮤니티 게시판관리 목록조회" 표에서 첫 번째 QueryID 셀에 불필요한 쉼표(`,`)가 남아 있던 오탈자를 수정하여, 다른 문서와 동일한 2행(QueryID + TotCnt) 표기 규칙에 맞췄습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/collaboration/community-use.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/collaboration` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw