### PR TITLE
docs: 공통상세코드 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/system-management/common-detail-code.md
+++ b/common-component/system-management/common-detail-code.md
@@ -19,6 +19,17 @@ menu:
 
 ## 설명
 
+```mermaid
+flowchart LR
+    L[공통상세코드 목록조회] -->|등록| R[공통상세코드 등록]
+    L -->|목록클릭| D[공통상세코드 상세조회]
+    D -->|수정| U[공통상세코드 수정]
+    D -->|삭제| X[공통상세코드 삭제]
+    R --> L
+    U --> L
+    X --> L
+```
+
 ### 패키지 참조 관계
 
  공통상세코드관리 패키지는 요소기술의 공통 패키지(cmm)와 공통코드 패키지에 대해서만 직접적인 함수적 참조 관계를 가진다. 하지만, 컴포넌트 배포 시 오류 없이 실행되기 위하여 패키지 간의 참조관계에 따라 공통분류코드관리 패키지와 함께 배포 파일을 구성한다.
@@ -37,14 +48,14 @@ menu:
 | JSP | /WEB-INF/jsp/egovframework/com/sym/ccm/cde/EgovCcmCmmnDetailCodeList.jsp | 공통상세코드 목록을 위한 JSP 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/sym/ccm/cde/EgovCcmCmmnDetailCodeUpdt.jsp | 공통상세코드 수정을 위한 JSP 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/sym/ccm/cde/EgovCcmCmmnDetailCodeRegist.jsp | 공통상세코드 등록을 위한 JSP 페이지 |
-| Query XML | resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage\_SQL\_altibase.xml | 공통상세코드 관리를 위한 Altibase용 Query XML |
-| Query XML | resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage\_SQL\_cubrid.xml | 공통상세코드 관리를 위한 Cubrid용 Query XML |
-| Query XML | resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage\_SQL\_maria.xml | 공통상세코드 관리를 위한 MariaDB용 Query XML |
-| Query XML | resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage\_SQL\_mysql.xml | 공통상세코드 관리를 위한 MySQL용 Query XML |
-| Query XML | resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage\_SQL\_oracle.xml | 공통상세코드 관리를 위한 Oracle용 Query XML |
-| Query XML | resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage\_SQL\_postgres.xml | 공통상세코드 관리를 위한 PostgreSQL용 Query XML |
-| Query XML | resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage\_SQL\_tibero.xml | 공통상세코드 관리를 위한 Tibero용 Query XML |
-| Query XML | resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage\_SQL\_goldilocks.xml | 공통상세코드 관리를 위한 Goldilocks용 Query XML |
+| Query XML | resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage\_SQL\_altibase.xml | 공통상세코드 관리를 위한 Altibase용 Query XML |
+| Query XML | resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage\_SQL\_cubrid.xml | 공통상세코드 관리를 위한 Cubrid용 Query XML |
+| Query XML | resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage\_SQL\_maria.xml | 공통상세코드 관리를 위한 MariaDB용 Query XML |
+| Query XML | resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage\_SQL\_mysql.xml | 공통상세코드 관리를 위한 MySQL용 Query XML |
+| Query XML | resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage\_SQL\_oracle.xml | 공통상세코드 관리를 위한 Oracle용 Query XML |
+| Query XML | resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage\_SQL\_postgres.xml | 공통상세코드 관리를 위한 PostgreSQL용 Query XML |
+| Query XML | resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage\_SQL\_tibero.xml | 공통상세코드 관리를 위한 Tibero용 Query XML |
+| Query XML | resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage\_SQL\_goldilocks.xml | 공통상세코드 관리를 위한 Goldilocks용 Query XML |
 | Message properties | resources/egovframework/message/com/sym/ccm/cde/message\_ko.properties | 공통상세코드를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/sym/ccm/cde/message\_en.properties | 공통상세코드를 위한 Message properties(영문) |
 


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/system-management/common-detail-code.md`의 관련소스 표에서 Query XML 8개 행이 다른 패키지(공통분류코드, `ccm/ccc/EgovCmmnClCodeManage`)의 파일 경로로 교차 오염되어 있던 것을, 같은 문서 내 Controller/Service/JSP/Message properties 행과 QueryID Namespace(`CmmnDetailCodeManage`)가 일관되게 사용하는 `ccm/cde/EgovCmmnDetailCodeManage` 패턴으로 정정했습니다.
- 공통상세코드 목록조회 → 등록/상세조회 → 수정/삭제로 이어지는 흐름을 시각화한 Mermaid 플로우차트를 추가했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/system-management/common-detail-code.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/system-management` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw