### PR TITLE
docs: 기관코드 가이드 오탈자 수정

### DIFF
--- a/common-component/system-management/org-code.md
+++ b/common-component/system-management/org-code.md
@@ -44,7 +44,7 @@ menu:
 | QUERY XML | resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn\_SQL\_maria.xml | 기관코드 MariaDB용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn\_SQL\_postgres.xml | 기관코드 PostgreSQL용 QUERY XML |
 | QUERY XML | resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn\_SQL\_goldilocks.xml | 기관코드 Goldilocks용 QUERY XML |
-| Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-InsttCodeRecptn.xml | 행정코드 Id생성 Idgen XML |
+| Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-InsttCodeRecptn.xml | 기관코드 Id생성 Idgen XML |
 | Message properties | resources/egovframework/message/com/sym/ccm/icr/message\_ko.properties | 기관코드를 위한 Message properties(한글) |
 | Message properties | resources/egovframework/message/com/sym/ccm/icr/message\_en.properties | 기관코드를 위한 Message properties(영문) |
 


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/system-management/org-code.md`의 관련소스 표에서 Idgen XML 설명이 "행정코드 Id생성 Idgen XML"로 잘못 기재되어 있던 것을(다른 문서에서 복사된 값), 문서 전체가 다루는 실제 대상인 "기관코드 Id생성 Idgen XML"로 정정했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/system-management/org-code.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/system-management` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw