### PR TITLE
docs: 배너관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/user-support/banner-management.md
+++ b/common-component/user-support/banner-management.md
@@ -29,6 +29,15 @@ menu:
   ⑤ 배너조회 : 등록된 배너는 이미지 단위로 배너표현 위치에 보여진다.
 ```
 
+```mermaid
+flowchart LR
+    L[배너 목록조회] -->|등록| R[배너 등록]
+    L -->|목록 선택| U[배너 수정]
+    U -->|삭제| L
+    R --> L
+    U -->|저장| L
+```
+
 ### 패키지 참조 관계
 
  배너관리 패키지는 요소기술의 공통 패키지(cmm)에 대해서만 직접적인 함수적 참조 관계를 가진다.
@@ -121,7 +130,7 @@ menu:
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /uss/ion/bnr/selectBannerList.do | selectBannerList | "bannerDAO" | "selectBannerList", |
+| 목록조회 | /uss/ion/bnr/selectBannerList.do | selectBannerList | "bannerDAO" | "selectBannerList" |
 |  |  |  | "bannerDAO" | "selectBannerListTotCnt" |
 
  ![image](./images/uss-banner-배너_목록.jpg)


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/user-support/banner-management.md`의 "배너 목록조회" 표 QueryID 셀에 남아있던 불필요한 쉼표(`,`) 오탈자를 수정했습니다.
- 배너 목록조회 → 등록/수정(삭제 포함)으로 이어지는 흐름을 시각화한 Mermaid 플로우차트를 추가했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/user-support/banner-management.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/user-support` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw