### PR TITLE
docs: 설문응답자관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/user-support/survey-respondent.md
+++ b/common-component/user-support/survey-respondent.md
@@ -19,6 +19,16 @@ menu:
 
 ## 설명
 
+```mermaid
+flowchart LR
+    L[응답자정보 목록조회] -->|등록| R[응답자정보 등록]
+    L -->|목록 클릭| D[응답자정보 상세조회]
+    D -->|수정| U[응답자정보 수정]
+    D -->|삭제| L
+    R --> L
+    U --> L
+```
+
 ### 패키지 참조 관계
 
  설문응답자관리 패키지는 요소기술의 공통 패키지(cmm)에 대해서만 직접적인 함수적 참조 관계를 가진다. 하지만, 컴포넌트 배포 시 오류 없이 실행되기 위하여 패키지 간의 참조관계에 따라 설문조사, 설문관리, 설문템플릿관리, 설문질문관리, 설문항목관리, 달력 패키지와 함께 배포 파일을 구성한다.
@@ -102,8 +112,8 @@ CREATE TABLE COMTECOPSEQ (
 
 | 코드분류 | 코드분류명 | 코드ID | 코드명 |
 | --- | --- | --- | --- |
-| COM014 | 성별코드 | M | 기능설명 |
-| COM014 | 성별코드 | F | 절차설명 |
+| COM014 | 성별코드 | M | 남 |
+| COM014 | 성별코드 | F | 여 |
 | COM034 | 작업유형코드 | 1 | 학생 |
 | COM034 | 작업유형코드 | 2 | 대학생 |
 | COM034 | 작업유형코드 | 3 | 군인 |
@@ -128,7 +138,7 @@ CREATE TABLE COMTECOPSEQ (
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /uss/olp/qrm/EgovQustnrRespondManageList.do | egovQustnrRespondManageList | "QustnrRespondManage.selectQustnrRespondManage", |
+| 목록조회 | /uss/olp/qrm/EgovQustnrRespondManageList.do | egovQustnrRespondManageList | "QustnrRespondManage.selectQustnrRespondManage" |
 |  |  |  | "QustnrRespondManage.selectQustnrRespondManageCnt" |
 
  응답자정보 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/user-support/survey-respondent.md`의 성별코드(COM014) 코드명이 M="기능설명", F="절차설명"으로 잘못 기재되어 있던 것을(성별과 무관한 문서 템플릿 문구), 표준 성별 표기인 M="남", F="여"로 정정했습니다.
- "응답자정보 목록조회" 표 QueryID 셀에 남아있던 불필요한 쉼표(`,`) 오탈자를 수정했습니다.
- 응답자정보 목록조회 → 등록/상세조회 → 수정/삭제로 이어지는 흐름을 시각화한 Mermaid 플로우차트를 추가했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/user-support/survey-respondent.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/user-support` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw