### PR TITLE
docs: 커뮤니티회원관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/collaboration/community-member.md
+++ b/common-component/collaboration/community-member.md
@@ -25,6 +25,16 @@ menu:
 
 - 패키지 간 참조 관계 : [게시판, 커뮤니티, 블로그 Package Dependency](../intro/package-reference.md)
 
+```mermaid
+flowchart LR
+    L[커뮤니티 사용자관리 목록조회] -->|탈퇴처리| X([탈퇴])
+    L -->|운영진등록| O([운영진 등록])
+    L -->|재가입| R([재가입])
+    X --> L
+    O --> L
+    R --> L
+```
+
 ### 관련소스
 
 #### 커뮤니티 사용자관리 및 승인관리
@@ -77,7 +87,7 @@ N/A
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /cop/cmy/selectCommuUserList.do | selectCommuUserList | "CommuManage.selectCommuUserList", |
+| 목록조회 | /cop/cmy/selectCommuUserList.do | selectCommuUserList | "CommuManage.selectCommuUserList" |
 | | | | "CommuManage.selectCommuUserListCnt" |
 
 페이지 당 검색 범위를 변경하고자 하는 경우 context-properties.xml 파일의 pageUnit, pageSize를 변경한다.(단 해당 설정은 전체 공통서비스 기능에 영향을 미친다.)


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/collaboration/community-member.md`의 "커뮤니티 사용자관리 목록조회" 표 QueryID 셀에 남아있던 불필요한 쉼표(`,`) 오탈자를 수정했습니다.
- 목록조회에서 탈퇴처리/운영진등록/재가입 이벤트로 이어지는 흐름을 시각화한 Mermaid 플로우차트를 추가했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/collaboration/community-member.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/collaboration` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw