### PR TITLE
docs: 템플릿관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/collaboration/template-management.md
+++ b/common-component/collaboration/template-management.md
@@ -23,6 +23,14 @@ menu:
 
 추가적으로 템플릿 등록, 삭제 등의 템플릿 관리 기능은 게시판 관리 또는 사용 기능과 분리되어 제공된다.
 
+```mermaid
+flowchart LR
+    L[템플릿 목록조회] -->|등록| R[템플릿 등록]
+    L -->|템플릿명 클릭| U[템플릿 수정]
+    R --> L
+    U --> L
+```
+
 ### 패키지 참조 관계
 
 디자인템플릿 패키지는 요소기술의 공통 패키지(cmm)에 대해서만 직접적인 함수적 참조 관계를 가진다. 하지만, 컴포넌트 배포 시 오류 없이 실행되기 위하여 패키지 간의 참조관계에 따라 시스템(sim), 포맷/계산/변환, 협업의 공통기능(com), 게시판, 달력 패키지와 함께 배포 파일을 구성한다.
@@ -117,7 +125,7 @@ N/A
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /cop/tpl/selectTemplateInfs.do | selectTemplateInfs | "TemplateManageDAO.selectTemplateInfs", |
+| 목록조회 | /cop/tpl/selectTemplateInfs.do | selectTemplateInfs | "TemplateManageDAO.selectTemplateInfs" |
 | | | | "TemplateManageDAO.selectTemplateInfsCnt" |
 | 팝업 목록조회 | /cop/tpl/selectTemplateInfsPop.do | selectTemplateInfsPop | "TemplateManageDAO.selectTemplateInfs" |
 


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/collaboration/template-management.md`의 "템플릿 목록조회" 표 QueryID 셀에 남아있던 불필요한 쉼표(`,`) 오탈자를 수정했습니다.
- 템플릿 목록조회 → 등록/수정으로 이어지는 흐름을 시각화한 Mermaid 플로우차트를 추가했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/collaboration/template-management.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/collaboration` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw