### PR TITLE
docs: 프로그램관리 가이드 잔여 QueryID 오탈자 수정

### DIFF
--- a/common-component/system-management/program-management.md
+++ b/common-component/system-management/program-management.md
@@ -239,7 +239,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/prm/EgovProgramChangeRequstSelect.do | selectProgrmChangeRequstList | "progrmManageDAO.selectProgrmChangeRequstList\_D", |
+| 조회 | /sym/prm/EgovProgramChangeRequstSelect.do | selectProgrmChangeRequstList | "progrmManageDAO.selectProgrmChangeRequstList\_D" |
 |  |  |  | "progrmManageDAO.selectProgrmChangeRequstListTotCnt\_S" |
 
  프로그램 변경요청 은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
@@ -334,7 +334,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/prm/EgovProgramChangeRequstProcessListSelect.do | selectProgrmChangeRequstProcessList | "progrmManageDAO.selectChangeRequstProcessList\_D", |
+| 조회 | /sym/prm/EgovProgramChangeRequstProcessListSelect.do | selectProgrmChangeRequstProcessList | "progrmManageDAO.selectChangeRequstProcessList\_D" |
 |  |  |  | "progrmManageDAO.selectChangeRequstProcessListTotCnt\_S" |
 
  프로그램 변경요청 처리 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
@@ -390,7 +390,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/prm/EgovProgramChgHstListSelect.do | selectProgrmChgHstList | "progrmManageDAO.selectProgrmChangeRequstList\_D", |
+| 조회 | /sym/prm/EgovProgramChgHstListSelect.do | selectProgrmChgHstList | "progrmManageDAO.selectProgrmChangeRequstList\_D" |
 |  |  |  | "progrmManageDAO.selectProgrmChangeRequstListTotCnt\_S" |
 
  ![image](./images/sym-program-egovprogramchghst.jpg)


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/system-management/program-management.md`의 "프로그램 변경요청 조회", "프로그램 변경요청 처리 조회", "프로그램 변경이력 조회" 3개 표에 남아있던 QueryID 셀의 불필요한 쉼표(`,`) 오탈자를 수정했습니다. (이전 PR에서 목록조회 표 1건만 수정되고 나머지 3건이 누락되어 있었습니다.)

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/system-management/program-management.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/system-management` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw