### PR TITLE
docs: 자료이용현황통계 가이드 QueryID 오탈자 수정

### DIFF
--- a/common-component/statistics-reporting/data-use-statistics.md
+++ b/common-component/statistics-reporting/data-use-statistics.md
@@ -126,7 +126,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 대상목록 조회 | /sts/dst/selectDtaUseStatsList.do | selectDtaUseStatsList | "dtaUseStatsDAO.selectDtaUseStatsList", |
+| 대상목록 조회 | /sts/dst/selectDtaUseStatsList.do | selectDtaUseStatsList | "dtaUseStatsDAO.selectDtaUseStatsList" |
 |  |  |  | "dtaUseStatsDAO.selectDtaUseStatsListTotCnt" |
 | 전체카운트 조회 | /sts/dst/selectDtaUseStatsList.do | selectDtaUseStatsList | "dtaUseStatsDAO.selectDtaUseStatsListBarTotCnt" |
 | 그래프 조회 | /sts/dst/selectDtaUseStatsList.do | selectDtaUseStatsList | "dtaUseStatsDAO.selectDtaUseStatsBarList" |


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/statistics-reporting/data-use-statistics.md`의 "대상목록 조회" 표 QueryID 셀에 남아있던 불필요한 쉼표(`,`) 오탈자를 수정했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/statistics-reporting/data-use-statistics.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/statistics-reporting` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw