### PR TITLE
docs: 보고서통계 가이드 QueryID 오탈자 수정

### DIFF
--- a/common-component/statistics-reporting/report-statistics.md
+++ b/common-component/statistics-reporting/report-statistics.md
@@ -126,7 +126,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sts/rst/selectReprtStatsList.do | selectReprtStatsList | "reprtStatsDAO.selectReprtStatsList", |
+| 조회 | /sts/rst/selectReprtStatsList.do | selectReprtStatsList | "reprtStatsDAO.selectReprtStatsList" |
 |  |  |  | "reprtStatsDAO.selectReprtStatsListTotCnt" |
 
  ![image](./images/sts-보고서통계_목록조회.png)


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/statistics-reporting/report-statistics.md`의 "조회" 표 QueryID 셀에 남아있던 불필요한 쉼표(`,`) 오탈자를 수정했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/statistics-reporting/report-statistics.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/statistics-reporting` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw