### PR TITLE
docs: 사용자부재관리 가이드 QueryID 오탈자 수정

### DIFF
--- a/common-component/user-support/user-absence.md
+++ b/common-component/user-support/user-absence.md
@@ -96,7 +96,7 @@ flowchart LR
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /uss/ion/uas/selectUserAbsnceList.do | selectUserAbsnceList | "userAbsnceDAO" | "selectUserAbsnceList", |
+| 목록조회 | /uss/ion/uas/selectUserAbsnceList.do | selectUserAbsnceList | "userAbsnceDAO" | "selectUserAbsnceList" |
 |  |  |  | "userAbsnceDAO" | "selectUserAbsnceListTotCnt" |
 
  ![image](./images/uss-absnt-사용자부재관리_목록.jpg)


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/user-support/user-absence.md`의 "사용자부재 목록조회" 표 QueryID 셀에 남아있던 불필요한 쉼표(`,`) 오탈자를 수정했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/user-support/user-absence.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/user-support` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw