### PR TITLE
docs: 약도관리 가이드 QueryID 오탈자 수정

### DIFF
--- a/common-component/user-support/map-management.md
+++ b/common-component/user-support/map-management.md
@@ -128,7 +128,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /com/uss/ion/rmm/selectRoughMapList.do | selectRoughMapList | "RoughMapDAO.selectRoughMapList", |
+| 목록조회 | /com/uss/ion/rmm/selectRoughMapList.do | selectRoughMapList | "RoughMapDAO.selectRoughMapList" |
 |  |  |  | "RoughMapDAO.selectRoughMapListTotCnt" |
 
  약도목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/user-support/map-management.md`의 "약도목록조회" 표 QueryID 셀에 남아있던 불필요한 쉼표(`,`) 오탈자를 수정했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/user-support/map-management.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/user-support` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw