### PR TITLE
docs: 메뉴생성관리 가이드 QueryID 오탈자 수정

### DIFF
--- a/common-component/system-management/menu-creation.md
+++ b/common-component/system-management/menu-creation.md
@@ -94,7 +94,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/mnu/mcm/EgovMenuCreatManageSelect.do | selectMenuCreatManagList | "menuManageDAO.selectMenuCreatManageList\_D", |
+| 조회 | /sym/mnu/mcm/EgovMenuCreatManageSelect.do | selectMenuCreatManagList | "menuManageDAO.selectMenuCreatManageList\_D" |
 |  |  |  | "menuManageDAO.selectMenuCreatManageTotCnt\_S" |
 
  ![image](./images/sym-menucreat-egovmenucreatmanage.jpg)
@@ -136,7 +136,7 @@ flowchart LR
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
 | 조회 | /sym/mnu/mcm/EgovMenuCreatSiteMapSelect.do | selectMenuCreatSiteMap | "menuManageDAO.selectMenuCreatSiteMapList\_D" |
-| 등록 | /sym/mnu/mcm/EgovMenuCreatSiteMapInsert.do | selectMenuCreatSiteMapInsert | "menuManageDAO.selectMenuCreatSiteMapList\_D", |
+| 등록 | /sym/mnu/mcm/EgovMenuCreatSiteMapInsert.do | selectMenuCreatSiteMapInsert | "menuManageDAO.selectMenuCreatSiteMapList\_D" |
 |  |  |  | "menuManageDAO.insertSiteMap\_S" |
 
  webapp의 절대path를 지정해야 한다. 변경대상 소스(/sym/mnu/mcm/EgovMenuCreatSiteMap.jsp)에서 수정해야한다.


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/system-management/menu-creation.md`의 "메뉴생성관리 목록조회"와 "사이트맵 생성 등록" 표 QueryID 셀에 각각 남아있던 불필요한 쉼표(`,`) 오탈자 2건을 수정했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/system-management/menu-creation.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/system-management` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw