### PR TITLE
docs: 연계메시지관리 가이드 QueryID 오탈자 수정

### DIFF
--- a/common-component/system-service-linkage/linkage-message-manage.md
+++ b/common-component/system-service-linkage/linkage-message-manage.md
@@ -146,7 +146,7 @@ flowchart TD
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /ssi/syi/ims/getCntcMessageList.do | selectCntcMessageList | "CntcMessageDAO.selectCntcMessageList", |
+| 목록조회 | /ssi/syi/ims/getCntcMessageList.do | selectCntcMessageList | "CntcMessageDAO.selectCntcMessageList" |
 |  |  |  | "CntcMessageDAO.selectCntcMessageListTotCnt" |
 
  페이지당 검색 범위를 변경하고자 하는 경우


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/system-service-linkage/linkage-message-manage.md`의 "연계메시지 목록조회" 표 QueryID 셀에 남아있던 불필요한 쉼표(`,`) 오탈자를 수정했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/system-service-linkage/linkage-message-manage.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/system-service-linkage` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw