### PR TITLE
docs: QueryID 표 셀에 목록 구분자가 남은 7곳 정정

### DIFF
--- a/common-component/collaboration/sms-service.md
+++ b/common-component/collaboration/sms-service.md
@@ -190,7 +190,7 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /cop/sms/selectSmsList.do | selectSmsList | "SmsDAO" | "selectSmsInfs", |
+| 목록조회 | /cop/sms/selectSmsList.do | selectSmsList | "SmsDAO" | "selectSmsInfs" |
 | | | | "SmsDAO" | "selectSmsInfsCnt" |
 
 문자메시지 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 페이지당 검색 범위를 변경하고자 하는 경우 context-properties.xml 파일의 pageUnit, pageSize를 변경한다.(단 해당 설정은 전체 공통서비스 기능에 영향을 미친다.)

--- a/common-component/system-management/send-receive-log-management.md
+++ b/common-component/system-management/send-receive-log-management.md
@@ -179,7 +179,7 @@ trsmrcvLogService.logInsertTrsmrcvLogSummary();
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /sym/log/tlg/SelectTrsmrcvLogList.do | selectTrsmrcvLogInf | "TrsmrcvLogDAO.selectTrsmrcvLogInf", |
+| 목록조회 | /sym/log/tlg/SelectTrsmrcvLogList.do | selectTrsmrcvLogInf | "TrsmrcvLogDAO.selectTrsmrcvLogInf" |
 |  |  |  | "TrsmrcvLogDAO.selectTrsmrcvLogInfCnt" |
 
  ![image](./images/sym-trsmrcv-egovtrsmrcvloglist.png)

--- a/common-component/system-management/shortcut-menu.md
+++ b/common-component/system-management/shortcut-menu.md
@@ -82,7 +82,7 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /sym/mnu/bmm/selectBkmkMenuManageList.do | selectBkmkMenuManageList | "BkmkMenuManageDAO.selectBkmkMenuManageList", |
+| 목록조회 | /sym/mnu/bmm/selectBkmkMenuManageList.do | selectBkmkMenuManageList | "BkmkMenuManageDAO.selectBkmkMenuManageList" |
 |  |  |  | "BkmkMenuManageDAO.selectBkmkMenuManageListCnt" |
 
  검색조건은 메뉴명에 대해서 수행된다. 페이지당 검색 범위를 변경하고자 하는 경우
@@ -129,7 +129,7 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 미리보기 | /sym/mnu/bmm/previewBkmkInf.do | previewBkmkInf | "BkmkMenuManageDAO.selectBkmkMenuManageList", |
+| 미리보기 | /sym/mnu/bmm/previewBkmkInf.do | previewBkmkInf | "BkmkMenuManageDAO.selectBkmkMenuManageList" |
 |  |  |  | "BkmkMenuManageDAO.selectBkmkMenuManageListCnt" |
 
  ![image](./images/sym-shortcut-bkmkpreview.jpg)
@@ -148,7 +148,7 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회팝업 | /sym/mnu/bmm/selectMenuList.do | selectMenuList | "BkmkMenuManageDAO.selectBkmkMenuList", |
+| 조회팝업 | /sym/mnu/bmm/selectMenuList.do | selectMenuList | "BkmkMenuManageDAO.selectBkmkMenuList" |
 |  |  |  | "BkmkMenuManageDAO.selectBkmkMenuListCnt" |
 
  ![image](./images/sym-shortcut-bkmkmenu.jpg)

--- a/common-component/system-management/system-history-management.md
+++ b/common-component/system-management/system-history-management.md
@@ -88,7 +88,7 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /sym/log/slg/SelectSysHistoryList.do | selectSysHistoryList | "SysHistoryDAO.selectSysHistoryList", |
+| 목록조회 | /sym/log/slg/SelectSysHistoryList.do | selectSysHistoryList | "SysHistoryDAO.selectSysHistoryList" |
 |  |  |  | "SysHistoryDAO.selectSysHistoryListCnt" |
 
  ![image](./images/sym-syshist-egovsyshistlist.jpg)

--- a/common-component/user-support/copyright-policy.md
+++ b/common-component/user-support/copyright-policy.md
@@ -112,7 +112,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('CPYRHT_ID', 1);
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /uss/sam/cpy/CpyrhtPrtcPolicyListInqire.do | selectCpyrhtPrtcPolicyList | "CpyrhtPrtcPolicyDAO" | "selectCpyrhtPrtcPolicyList", |
+| 목록조회 | /uss/sam/cpy/CpyrhtPrtcPolicyListInqire.do | selectCpyrhtPrtcPolicyList | "CpyrhtPrtcPolicyDAO" | "selectCpyrhtPrtcPolicyList" |
 |  |  | selectCpyrhtPrtcPolicyListTotCnt | "CpyrhtPrtcPolicyDAO" | "selectCpyrhtPrtcPolicyListTotCnt" |
 
  저작권보호정책 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

공통컴포넌트 가이드의 QueryID 표에서 셀 값이 `"selectSmsInfs",` 처럼 쉼표로 끝나는 곳이 있습니다. 이 표들은 QueryID 를 한 행에 하나씩 나눠 적는 형식이라 바로 다음 행이 `"selectSmsInfsCnt"` 를 따로 담고 있고 앞 행에 남은 쉼표는 목록 구분자가 셀 안으로 들어간 것입니다.

한 문서만의 표기는 아니고 저장소 전체에서 아래 일곱 곳입니다.

```
$ git grep -nE '\|[[:space:]]*"[A-Za-z][A-Za-z0-9_.\]*",[[:space:]]*\|' origin/main -- '*.md'
origin/main:common-component/collaboration/sms-service.md:193:| 목록조회 | /cop/sms/selectSmsList.do | selectSmsList | "SmsDAO" | "selectSmsInfs", |
origin/main:common-component/system-management/send-receive-log-management.md:182:| 목록조회 | /sym/log/tlg/SelectTrsmrcvLogList.do | selectTrsmrcvLogInf | "TrsmrcvLogDAO.selectTrsmrcvLogInf", |
origin/main:common-component/system-management/shortcut-menu.md:85:| 목록조회 | /sym/mnu/bmm/selectBkmkMenuManageList.do | selectBkmkMenuManageList | "BkmkMenuManageDAO.selectBkmkMenuManageList", |
origin/main:common-component/system-management/shortcut-menu.md:132:| 미리보기 | /sym/mnu/bmm/previewBkmkInf.do | previewBkmkInf | "BkmkMenuManageDAO.selectBkmkMenuManageList", |
origin/main:common-component/system-management/shortcut-menu.md:151:| 조회팝업 | /sym/mnu/bmm/selectMenuList.do | selectMenuList | "BkmkMenuManageDAO.selectBkmkMenuList", |
origin/main:common-component/system-management/system-history-management.md:91:| 목록조회 | /sym/log/slg/SelectSysHistoryList.do | selectSysHistoryList | "SysHistoryDAO.selectSysHistoryList", |
origin/main:common-component/user-support/copyright-policy.md:115:| 목록조회 | /uss/sam/cpy/CpyrhtPrtcPolicyListInqire.do | selectCpyrhtPrtcPolicyList | "CpyrhtPrtcPolicyDAO" | "selectCpyrhtPrtcPolicyList", |
```

일곱 곳을 한 번에 정정했습니다. 표에 적힌 12개 id 는 공통컴포넌트 매퍼에 그대로 등록돼 있고 매퍼 쪽 id 중 쉼표가 들어간 것은 한 건도 없습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
