### PR TITLE
docs: 공통컴포넌트 가이드의 실행환경 클래스 표기를 5.0 기준으로 정정

### DIFF
--- a/common-component/collaboration/blog-management.md
+++ b/common-component/collaboration/blog-management.md
@@ -76,7 +76,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('BLOG_ID', 1);
 #### ID Generation 환경 설정(context-idgn-bbs.xml)
 
 ```xml
-<bean name="egovBlogIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" 
+<bean name="egovBlogIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" 
     destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="blogIdStrategy" />
@@ -84,7 +84,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('BLOG_ID', 1);
     <property name="table"      value="COMTECOPSEQ"/>
     <property name="tableName"  value="BLOG_ID"/>
 </bean>
-<bean name="blogIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="blogIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix"   value="BLOG_" />
     <property name="cipers"   value="15" />
     <property name="fillChar" value="0" />

--- a/common-component/collaboration/board-guestbook.md
+++ b/common-component/collaboration/board-guestbook.md
@@ -73,14 +73,14 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('NTT_ID', 1);
 #### ID Generation 환경 설정(context-idgn-bbs.xml)
 
 ```xml
-<bean name="egovNttIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovNttIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="nttIdStrategy" />
     <property name="blockSize"  value="10"/>
     <property name="table"      value="COMTECOPSEQ"/>
     <property name="tableName"  value="NTT_ID"/>
 </bean>
-<bean name="nttIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="nttIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="cipers"   value="20" />
 </bean>
 ```

--- a/common-component/collaboration/board-integrated.md
+++ b/common-component/collaboration/board-integrated.md
@@ -78,14 +78,14 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('NTT_ID', 1);
 #### ID Generation 환경 설정(context-idgn-bbs.xml)
 
 ```xml
-<bean name="egovNttIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovNttIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="nttIdStrategy" />
     <property name="blockSize"  value="10"/>
     <property name="table"      value="COMTECOPSEQ"/>
     <property name="tableName"  value="NTT_ID"/>
 </bean>
-<bean name="nttIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="nttIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="cipers"   value="20" />
 </bean>
 ```

--- a/common-component/collaboration/comment-management.md
+++ b/common-component/collaboration/comment-management.md
@@ -84,14 +84,14 @@ INSERT INTO COMTECOPSEQ VALUES ('ANSWER_NO','0');
 #### ID Generation 환경설정(context-idgn-AnswerNo.xml)
 
 ```xml
-<bean name="egovAnswerNoGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovAnswerNoGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="answerNoStrategy" />
     <property name="blockSize"  value="10" />
     <property name="table"      value="COMTECOPSEQ" />
     <property name="tableName"  value="ANSWER_NO" />
 </bean>
-<bean name="answerNoStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="answerNoStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="cipers"     value="20" />
 </bean>
 ```

--- a/common-component/collaboration/community-creation.md
+++ b/common-component/collaboration/community-creation.md
@@ -75,14 +75,14 @@ INSERT INTO COMTECOPSEQ VALUES('CMMNTY_ID',1);
 #### ID Generation 환경설정(context-idgn-Cmmnty.xml)
 
 ```xml
-<bean name="egovCmmntyIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovCmmntyIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="cmmntyStrategy" />
     <property name="blockSize"  value="10"/>
     <property name="table"      value="COMTECOPSEQ"/>
     <property name="tableName"  value="CMMNTY_ID"/>
 </bean>
-<bean name="cmmntyStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="cmmntyStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix"   value="CMMNTY_" />
     <property name="cipers"   value="13" />
     <property name="fillChar" value="0" />

--- a/common-component/collaboration/department-schedule.md
+++ b/common-component/collaboration/department-schedule.md
@@ -79,14 +79,14 @@ INSERT INTO COMTECOPSEQ VALUES('SCHDUL_ID','1');
 #### ID Generation 환경설정(context-idgn-deptSchdulManage.xml)
 
 ```xml
-<bean name="deptSchdulManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="deptSchdulManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="DeptSchdulManageStrategy" />
     <property name="blockSize"  value="10"/>
     <property name="table"      value="COMTECOPSEQ"/>
     <property name="tableName"  value="SCHDUL_ID"/>
 </bean>
-<bean name="DeptSchdulManageStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="DeptSchdulManageStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix"   value="SCHDUL_" />
     <property name="cipers"   value="13" />
     <property name="fillChar" value="0" />

--- a/common-component/collaboration/journal-management.md
+++ b/common-component/collaboration/journal-management.md
@@ -72,14 +72,14 @@ INSERT INTO COMTECOPSEQ VALUES('DIARY_ID',1);
 #### ID Generation 환경설정(context-idgn-diaryManage.xml)
 
 ```xml
-<bean name="diaryManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="diaryManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="DiaryManageInfotrategy" />
     <property name="blockSize"  value="10"/>
     <property name="table"      value="COMTECOPSEQ"/>
     <property name="tableName"  value="DIARY_ID"/>
 </bean>
-<bean name="DiaryManageInfotrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="DiaryManageInfotrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix"   value="DIARY_" />
     <property name="cipers"   value="14" />
     <property name="fillChar" value="0" />

--- a/common-component/collaboration/schedule-management.md
+++ b/common-component/collaboration/schedule-management.md
@@ -76,14 +76,14 @@ INSERT INTO COMTECOPSEQ VALUES('SCHDUL_ID','1');
 #### ID Generation 환경설정(context-idgn-indvdlSchdulManage.xml)
 
 ```xml
-<bean name="indvdlSchdulManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="indvdlSchdulManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="IndvdlSchdulManageStrategy" />
     <property name="blockSize"  value="10"/>
     <property name="table"      value="COMTECOPSEQ"/>
     <property name="tableName"  value="SCHDUL_ID"/>
 </bean>
-<bean name="IndvdlSchdulManageStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="IndvdlSchdulManageStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix"   value="SCHDUL_" />
     <property name="cipers"   value="14" />
     <property name="fillChar" value="0" />

--- a/common-component/collaboration/sms-service.md
+++ b/common-component/collaboration/sms-service.md
@@ -102,14 +102,14 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('SMS_ID', 1);
 #### ID Generation 환경설정(context-idgn-Sms)
 
 ```xml
-<bean name="egovSmsIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovSmsIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="smsStrategy" />
     <property name="blockSize"  value="10"/>
     <property name="table"      value="COMTECOPSEQ"/>
     <property name="tableName"  value="SMS_ID"/>
 </bean>
-<bean name="smsStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="smsStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix"   value="SMS_" />
     <property name="cipers"   value="16" />
     <property name="fillChar" value="0" />

--- a/common-component/digital-asset-management/personal-knowledge-manage.md
+++ b/common-component/digital-asset-management/personal-knowledge-manage.md
@@ -81,14 +81,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 #### ID Generation 환경설정(context-idgn-DamManage.xml)
 
 ```xml
-<bean name="egovDamManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovDamManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="damManageStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="DAM_ID"/>
     </bean>
-    <bean name="damManageStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="damManageStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="DMID_" />
         <property name="cipers"     value="15" />
         <property name="fillChar"   value="0" />

--- a/common-component/elementary-technology/calendar.md
+++ b/common-component/elementary-technology/calendar.md
@@ -103,7 +103,7 @@ INSERT INTO COMTECOPSEQ VALUES ('RESTDE_ID','0');
 ### ID Generation 환경설정(context-idgn-RestDe.xml)
 
 ```xml
-<bean name="egovRestDeIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovRestDeIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="blockSize" value="10" />
     <property name="table" value="COMTECOPSEQ" />

--- a/common-component/elementary-technology/cmtmanage.md
+++ b/common-component/elementary-technology/cmtmanage.md
@@ -79,14 +79,14 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('WRKTM_ID', 1);
 #### ID Generation 환경설정(context-idgn-Cmt.xml)
 
 ```xml
-	<bean name="egovCmtManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService" destroy-method="destroy">
+	<bean name="egovCmtManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="cmtIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="WRKTM_ID"/>
     </bean>
-    <bean name="cmtIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="cmtIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="WRKTM_" />
         <property name="cipers"   value="13" />
         <property name="fillChar" value="0" />

--- a/common-component/elementary-technology/db-service-monitoring.md
+++ b/common-component/elementary-technology/db-service-monitoring.md
@@ -118,14 +118,14 @@ INSERT INTO COMTECOPSEQ VALUES ('DB_MNTRNG_LOG_ID', 0);
 ### ID Generation 환경설정 (`context-idgn-DbMntrngLog.xml`)
 
 ```xml
-<bean name="egovDbMntrngLogIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovDbMntrngLogIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="dbMntrngLogIdStrategy" />
     <property name="blockSize"  value="10" />
     <property name="table"      value="COMTECOPSEQ" />
     <property name="tableName"  value="DB_MNTRNG_LOG_ID" />
 </bean>
-<bean name="dbMntrngLogIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="dbMntrngLogIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix"     value="" />
     <property name="cipers"     value="20" />
     <property name="fillChar"   value="0" />

--- a/common-component/elementary-technology/easybatch.md
+++ b/common-component/elementary-technology/easybatch.md
@@ -51,15 +51,15 @@
   </step>
 </job>
  
-<bean id="defaultReader" class="egovframework.rte.bat.item.DefaultItemReader" scope="step">
+<bean id="defaultReader" class="org.egovframe.rte.bat.item.DefaultItemReader" scope="step">
   <property name="dataSource" ref="dataSource" />
 </bean>
  
-<bean id="defaultWriter" class="egovframework.rte.bat.item.DefaultItemWriter" scope="step">
+<bean id="defaultWriter" class="org.egovframe.rte.bat.item.DefaultItemWriter" scope="step">
   <property name="dataSource" ref="dataSource" />
 </bean>
  
-<bean id="itemProcessor" class="egovframework.rte.bat.sample.domain.trade.CustomerCreditIncreaseProcessor" />
+<bean id="itemProcessor" class="org.egovframe.rte.bat.sample.domain.trade.CustomerCreditIncreaseProcessor" />
 ```
 
  2. 실행한다.

--- a/common-component/elementary-technology/holiday-management.md
+++ b/common-component/elementary-technology/holiday-management.md
@@ -55,7 +55,7 @@ flowchart LR
 
 ```xml
 <bean name="egovRestDeIdGnrService"
-    class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+    class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
     destroy-method="destroy">
     <property name="dataSource" ref="dataSource" />
     <property name="blockSize" value="10"/>

--- a/common-component/elementary-technology/network-service-monitoring.md
+++ b/common-component/elementary-technology/network-service-monitoring.md
@@ -88,14 +88,14 @@ INSERT INTO COMTECOPSEQ VALUES ('NTWRKSVC_LOGID','0');
 `context-idgn-NtwrkSvcMntrngLog.xml`
 
 ```xml
-<bean name="egovNtwrkSvcMntrngLogIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovNtwrkSvcMntrngLogIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="ntwrkSvcMntrngLogIdStrategy" />
     <property name="blockSize"  value="10" />
     <property name="table"      value="COMTECOPSEQ" />
     <property name="tableName"  value="NTWRKSVC_LOGID" />
 </bean>
-<bean name="ntwrkSvcMntrngLogIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="ntwrkSvcMntrngLogIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix"     value="" />
     <property name="cipers"     value="20" />
     <property name="fillChar"   value="0" />

--- a/common-component/elementary-technology/proxy-service.md
+++ b/common-component/elementary-technology/proxy-service.md
@@ -100,28 +100,28 @@ INSERT INTO COMTECOPSEQ VALUES ('PROXYLOG_ID','0');
 
 ```xml
 <!-- 프록시서비스 ID -->
-<bean name="egovProxySvcIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovProxySvcIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="ProxySvcIdStrategy" />
     <property name="blockSize"  value="10" />
     <property name="table"      value="COMTECOPSEQ" />
     <property name="tableName"  value="PROXYSVC_ID" />
 </bean>
-<bean name="ProxySvcIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="ProxySvcIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix"     value="PXY_" />
     <property name="cipers"     value="16" />
     <property name="fillChar"   value="0" />
 </bean>
 
 <!-- 프록시Log ID -->
-<bean name="egovProxyLogIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovProxyLogIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="ProxyLogIdStrategy" />
     <property name="blockSize"  value="10" />
     <property name="table"      value="COMTECOPSEQ" />
     <property name="tableName"  value="PROXYLOG_ID" />
 </bean>
-<bean name="ProxyLogIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="ProxyLogIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix"     value="PLG_" />
     <property name="cipers"     value="16" />
     <property name="fillChar"   value="0" />

--- a/common-component/security/group-management.md
+++ b/common-component/security/group-management.md
@@ -97,14 +97,14 @@ flowchart LR
 #### ID Generation 환경설정(context-idgn-Group.xml)
 
 ```xml
-    <bean name="egovGroupIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovGroupIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="groupIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="GROUP_ID"/>
     </bean>
-    <bean name="groupIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="groupIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="GROUP_" />
         <property name="cipers"   value="14" />
         <property name="fillChar" value="0" />

--- a/common-component/security/role-management.md
+++ b/common-component/security/role-management.md
@@ -110,14 +110,14 @@ flowchart LR
 #### ID Generation 환경설정(context-idgn-Role.xml)
 
 ```xml
-    <bean name="egovRoleIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovRoleIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="roleIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="ROLE_ID"/>
     </bean>
-    <bean name="roleIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="roleIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="" />
         <property name="cipers"   value="6" />
         <property name="fillChar" value="0" />

--- a/common-component/statistics-reporting/data-use-statistics.md
+++ b/common-component/statistics-reporting/data-use-statistics.md
@@ -77,7 +77,7 @@ INSERT INTO COMTECOPSEQ VALUES('DUS_ID','0');
 
 ```xml
 <bean name="egovDtaUseStatsIdGnrService"
-    class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+    class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
     destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="dtaUseStatsIdStrategy" />
@@ -87,7 +87,7 @@ INSERT INTO COMTECOPSEQ VALUES('DUS_ID','0');
 </bean>
 
 <bean name="dtaUseStatsIdStrategy"
-    class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix" value="DUS_" />
     <property name="cipers" value="16" />
     <property name="fillChar" value="0" />

--- a/common-component/statistics-reporting/report-statistics.md
+++ b/common-component/statistics-reporting/report-statistics.md
@@ -77,7 +77,7 @@ INSERT INTO COMTECOPSEQ VALUES('RS_ID','0');
 
 ```xml
 <bean name="egovReprtStatsIdGnrService"
-    class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+    class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
     destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="reprtStatsIdStrategy" />
@@ -87,7 +87,7 @@ INSERT INTO COMTECOPSEQ VALUES('RS_ID','0');
 </bean>
 
 <bean name="reprtStatsIdStrategy"
-    class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix" value="RS_" />
     <property name="cipers" value="3" />
     <property name="fillChar" value="0" />

--- a/common-component/system-management/access-log-management.md
+++ b/common-component/system-management/access-log-management.md
@@ -78,14 +78,14 @@ CREATE TABLE COMTECOPSEQ(TABLE_NAME VARCHAR(20) NOT NULL,
 #### ID Generation 환경설정(context-idgn-LoginLog.xml)
 
 ```xml
-<bean name="egovLoginLogIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovLoginLogIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="loginLogStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="LOGINLOG_ID"/>
     </bean>
-    <bean name="loginLogStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="loginLogStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="LOGIN_" />
         <property name="cipers"   value="14" />
         <property name="fillChar" value="0" />

--- a/common-component/system-management/backup-management.md
+++ b/common-component/system-management/backup-management.md
@@ -132,28 +132,28 @@ flowchart LR
 
 ```xml
     <!--  백업작업 ID -->
-    <bean name="egovBackupOpertIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovBackupOpertIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="backupOpertIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="BACKUP_OPERT_ID"/>
     </bean>
-    <bean name="backupOpertIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="backupOpertIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="BACKUP_OPERT_" />
         <property name="cipers"     value="17" />
         <property name="fillChar"   value="0" />
     </bean>
  
     <!-- 백업결과 ID -->
-    <bean name="egovBackupResultIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovBackupResultIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="backupResultIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="BACKUP_RESULT_ID"/>
     </bean>
-    <bean name="backupResultIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="backupResultIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="BACKUP_RESULT_" />
         <property name="cipers"     value="17" />
         <property name="fillChar"   value="0" />

--- a/common-component/system-management/batch-job-management.md
+++ b/common-component/system-management/batch-job-management.md
@@ -79,14 +79,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 ### ID Generation 환경설정(context-idgn-BatchOpert.xml)
 
 ```xml
-<bean name="egovBatchOpertIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovBatchOpertIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="batchOpertIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="BATCH_OPERT_ID"/>
     </bean>
-    <bean name="batchOpertIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="batchOpertIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="BAT" />
         <property name="cipers"   value="17" />
         <property name="fillChar" value="0" />

--- a/common-component/system-management/batch-result-management.md
+++ b/common-component/system-management/batch-result-management.md
@@ -75,14 +75,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 ### ID Generation 환경설정(context-idgn-BatchResult.xml)
 
 ```xml
-<bean name="egovBatchResultIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovBatchResultIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="batchResultIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="BATCH_RESULT_ID"/>
     </bean>
-    <bean name="batchResultIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="batchResultIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="BRT" />
         <property name="cipers"     value="17" />
         <property name="fillChar"   value="0" />

--- a/common-component/system-management/error-application.md
+++ b/common-component/system-management/error-application.md
@@ -83,14 +83,14 @@ menu:
 #### ID Generation 환경설정(context-idgn-Trobl.xml)
 
 ```xml
-    <bean name="egovTroblIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovTroblIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="TroblIdStrategy" />
         <property name="blockSize"  value="10" />
         <property name="table"      value="COMTECOPSEQ" />
         <property name="tableName"  value="TROBL_ID" />
     </bean>
-    <bean name="TroblIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="TroblIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="TBM_" />
         <property name="cipers"     value="16" />
         <property name="fillChar"   value="0" />

--- a/common-component/system-management/legal-dong-code.md
+++ b/common-component/system-management/legal-dong-code.md
@@ -66,7 +66,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 ```xml
 <bean name="egovAdministCodeRecptnIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="blockSize" 	value="1"/>

--- a/common-component/system-management/log-management.md
+++ b/common-component/system-management/log-management.md
@@ -81,7 +81,7 @@ CREATE TABLE COMTECOPSEQ( TABLE_NAME VARCHAR(20) NOT NULL,
 
 ```xml
 <bean name="egovSysLogIdGnrService"
-    class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+    class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
     destroy-method="destroy">
     <property name="dataSource" ref="egov.dataSource" />
     <property name="strategy"   ref="sysLogStrategy" />
@@ -91,7 +91,7 @@ CREATE TABLE COMTECOPSEQ( TABLE_NAME VARCHAR(20) NOT NULL,
   </bean>
  
   <bean name="sysLogStrategy"
-    class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix" value="SYSLOG_" />
     <property name="cipers" value="13" />
     <property name="fillChar" value="0" />

--- a/common-component/system-management/network-management.md
+++ b/common-component/system-management/network-management.md
@@ -82,14 +82,14 @@ menu:
 #### ID Generation 환경설정(context-idgn-Ntwrk.xml)
 
 ```xml
-    <bean name="egovNtwrkIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovNtwrkIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="ntwrkIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="NTWRK_ID"/>
     </bean>
-    <bean name="ntwrkIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="ntwrkIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="NID_" />
         <property name="cipers"     value="16" />
         <property name="fillChar"   value="0" />

--- a/common-component/system-management/org-code.md
+++ b/common-component/system-management/org-code.md
@@ -69,7 +69,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 ```xml
 <bean name="egovInsttCodeRecptnIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="blockSize" 	value="1"/>

--- a/common-component/system-management/privacy-log-management.md
+++ b/common-component/system-management/privacy-log-management.md
@@ -100,7 +100,7 @@ return idGnrService;
 
 ```xml
 <bean name="egovPrivacyLogIdGnrService"
-    class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+    class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
     destroy-method="destroy">
     <property name="dataSource" ref="dataSource" />
     <property name="strategy"   ref="privacyLogStrategy" />
@@ -110,7 +110,7 @@ return idGnrService;
   </bean>
  
   <bean name="privacyLogStrategy"
-    class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix" value="PRVCY_" />
     <property name="cipers" value="14" />
     <property name="fillChar" value="0" />

--- a/common-component/system-management/schedule-processing.md
+++ b/common-component/system-management/schedule-processing.md
@@ -82,14 +82,14 @@ menu:
 #### ID Generation 환경설정(context-idgn-BatchOpert.xml)
 
 ```xml
-    <bean name="egovBatchSchdulIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovBatchSchdulIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="batchSchdulIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="BATCH_SCHDUL_ID"/>
     </bean>
-    <bean name="batchSchdulIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="batchSchdulIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="BSC" />
         <property name="cipers"     value="17" />
         <property name="fillChar"   value="0" />

--- a/common-component/system-management/send-receive-log-management.md
+++ b/common-component/system-management/send-receive-log-management.md
@@ -79,7 +79,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 ```xml
 <bean name="egovTrsmrcvLogIdGnrService"
-    class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+    class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
     destroy-method="destroy">
     <property name="dataSource" ref="dataSource" />
     <property name="strategy"   ref="trsmrcvLogStrategy" />
@@ -89,7 +89,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
   </bean>
  
   <bean name="trsmrcvLogStrategy"
-    class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
     <property name="prefix" value="TRSMRCV_" />
     <property name="cipers" value="12" />
     <property name="fillChar" value="0" />

--- a/common-component/system-management/server-info-management.md
+++ b/common-component/system-management/server-info-management.md
@@ -101,28 +101,28 @@ menu:
 
 ```xml
     <!-- 서버 ID -->
-    <bean name="egovServerIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovServerIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="ServerIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="SERVER_ID"/>
     </bean>
-    <bean name="ServerIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="ServerIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="SRV_" />
         <property name="cipers"     value="16" />
         <property name="fillChar"   value="0" />
     </bean> 
  
     <!-- 서버장비 ID -->
-    <bean name="egovServerEqpmnIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovServerEqpmnIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="ServerEqpmnIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="SEVEQ_ID"/>
     </bean>
-    <bean name="ServerEqpmnIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="ServerEqpmnIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="SVE_" />
         <property name="cipers"     value="16" />
         <property name="fillChar"   value="0" />

--- a/common-component/system-management/web-log-management.md
+++ b/common-component/system-management/web-log-management.md
@@ -78,14 +78,14 @@ CREATE TABLE COMTECOPSEQ(TABLE_NAME VARCHAR(20) NOT NULL,
 #### ID Generation 환경설정(context-idgn-WebLog.xml)
 
 ```xml
-<bean name="egovWebLogIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovWebLogIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="webLogStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="WEBLOG_ID"/>
     </bean>
-    <bean name="webLogStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="webLogStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="WEBLOG_" />
         <property name="cipers"   value="13" />
         <property name="fillChar" value="0" />

--- a/common-component/system-management/zipcode-management.md
+++ b/common-component/system-management/zipcode-management.md
@@ -91,13 +91,13 @@ flowchart LR
 #### context-excel.xml
 
 ```xml
-    <bean id="excelZipService"	class="egovframework.rte.fdl.excel.impl.EgovExcelServiceImpl">
+    <bean id="excelZipService"	class="org.egovframe.rte.fdl.excel.impl.EgovExcelServiceImpl">
        <property name="propertyPath" value="excelInfo.xml" />
        <property name="mapClass" value="egovframework.com.sym.ccm.zip.service.impl.EgovCcmExcelZipMapping" />
        <property name="sqlMapClient" ref="egov.sqlMapClient" />
     </bean>
  
-    <bean id="excelRdnmadZipService"	class="egovframework.rte.fdl.excel.impl.EgovExcelServiceImpl">
+    <bean id="excelRdnmadZipService"	class="org.egovframe.rte.fdl.excel.impl.EgovExcelServiceImpl">
         <property name="propertyPath" value="excelInfo.xml" />
         <property name="mapClass" value="egovframework.com.sym.ccm.zip.service.impl.EgovCcmExcelRdnmadZipMapping" />
         <property name="sqlMapClient" ref="egov.sqlMapClient" />

--- a/common-component/system-service-linkage/linkage-message-manage.md
+++ b/common-component/system-service-linkage/linkage-message-manage.md
@@ -78,28 +78,28 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 ```xml
 <!-- 연계메시지 -->
-    <bean name="egovCntcMessageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovCntcMessageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="egovCntcMessageIdMsgtrategy" />
         <property name="blockSize"  value="10" />
         <property name="table"      value="COMTECOPSEQ" />
         <property name="tableName"  value="CNTC_MESSAGE_ID" />
     </bean>
-    <bean name="egovCntcMessageIdMsgtrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="egovCntcMessageIdMsgtrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="MSG" />
         <property name="cipers"     value="17" />
         <property name="fillChar"   value="0" />
     </bean>
  
     <!-- 연계메시지항목 -->
-    <bean name="egovCntcMessageItemIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovCntcMessageItemIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="egovCntcMessageItemIdMsgtrategy" />
         <property name="blockSize"  value="10" />
         <property name="table"      value="COMTECOPSEQ" />
         <property name="tableName"  value="ITEM_ID" />
     </bean>
-    <bean name="egovCntcMessageItemIdMsgtrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="egovCntcMessageItemIdMsgtrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="ITM" />
         <property name="cipers"     value="17" />
         <property name="fillChar"   value="0" />

--- a/common-component/system-service-linkage/linkage-org-manage.md
+++ b/common-component/system-service-linkage/linkage-org-manage.md
@@ -83,42 +83,42 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 ```xml
 <!-- 연계기관 -->
-    <bean name="egovCntcInsttIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovCntcInsttIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="egovCntcInsttIdMsgtrategy" />
         <property name="blockSize"  value="10" />
         <property name="table"      value="COMTECOPSEQ" />
         <property name="tableName"  value="INSTT_ID" />
     </bean>
-    <bean name="egovCntcInsttIdMsgtrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="egovCntcInsttIdMsgtrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="INS" />
         <property name="cipers"     value="5" />
         <property name="fillChar"   value="0" />
     </bean>
  
     <!-- 연계시스템 -->
-    <bean name="egovCntcSystemIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovCntcSystemIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="egovCntcSystemIdMsgtrategy" />
         <property name="blockSize"  value="10" />
         <property name="table"      value="COMTECOPSEQ" />
         <property name="tableName"  value="SYS_ID" />
     </bean>
-    <bean name="egovCntcSystemIdMsgtrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="egovCntcSystemIdMsgtrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="SYS" />
         <property name="cipers"     value="5" />
         <property name="fillChar"   value="0" />
     </bean>
  
     <!-- 연계서비스 -->
-    <bean name="egovCntcServiceIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovCntcServiceIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="egovCntcServiceIdMsgtrategy" />
         <property name="blockSize"  value="10" />
         <property name="table"      value="COMTECOPSEQ" />
         <property name="tableName"  value="SVC_ID" />
     </bean>
-    <bean name="egovCntcServiceIdMsgtrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="egovCntcServiceIdMsgtrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="SVC" />
         <property name="cipers"     value="5" />
         <property name="fillChar"   value="0" />

--- a/common-component/system-service-linkage/system-linkage-manage.md
+++ b/common-component/system-service-linkage/system-linkage-manage.md
@@ -75,14 +75,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 #### ID Generation 환경설정(context-idgn-SystemCntc.xml)
 
 ```xml
-<bean name="egovSystemCntcIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovSystemCntcIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="egovSystemCntcIdMsgtrategy" />
         <property name="blockSize"  value="10" />
         <property name="table"      value="COMTECOPSEQ" />
         <property name="tableName"  value="CNTC_ID" />
     </bean>
-    <bean name="egovSystemCntcIdMsgtrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="egovSystemCntcIdMsgtrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="CNTC" />
         <property name="cipers"     value="4" />
         <property name="fillChar"   value="0" />

--- a/common-component/user-authentication/certificate-login.md
+++ b/common-component/user-authentication/certificate-login.md
@@ -55,13 +55,13 @@ menu:
 
 ### web.xml 설정
 
- CertProcessFilter 및 CertProcessRequestWrapper의 경우는 전자정부 표준프레임워크의 HTMLTagFilter(egovframework.rte.ptl.mvc.filter.HTMLTagFilter)를 사용할 경우 다음과 같이 web.xml에 같이 추가를 해주어야 한다. HTMLTagFilter는 request 파라미터들에 대하여 자동으로 tag를 변환하는데 인증서로그인 처리 부분은 이 부분이 제외되어야 하기 때문이다.
+ CertProcessFilter 및 CertProcessRequestWrapper의 경우는 전자정부 표준프레임워크의 HTMLTagFilter(org.egovframe.rte.ptl.mvc.filter.HTMLTagFilter)를 사용할 경우 다음과 같이 web.xml에 같이 추가를 해주어야 한다. HTMLTagFilter는 request 파라미터들에 대하여 자동으로 tag를 변환하는데 인증서로그인 처리 부분은 이 부분이 제외되어야 하기 때문이다.
 
 ```xml
     <filter>
         <filter-name>HTMLTagFilter</filter-name>
         <filter-class>
-            egovframework.rte.ptl.mvc.filter.HTMLTagFilter
+            org.egovframe.rte.ptl.mvc.filter.HTMLTagFilter
         </filter-class>
     </filter>
     <filter-mapping>

--- a/common-component/user-support/admin-terminology.md
+++ b/common-component/user-support/admin-terminology.md
@@ -80,7 +80,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 ```xml
 <bean name="egovAdministrationWordIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy" ref="administrationWordIdMsgtrategy" />
@@ -89,7 +89,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 		<property name="tableName"	value="ADMINIST_WORD_ID"/>
 	</bean>
 	<bean name="administrationWordIdMsgtrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="ADMINIST_" />
 		<property name="cipers" value="11" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/anniversary.md
+++ b/common-component/user-support/anniversary.md
@@ -82,14 +82,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 ### ID Generation 환경설정(context-idgn-AnnvrsryManage.xml)
 
 ```xml
-<bean name="egovAnnvrsryManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovAnnvrsryManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="annvrsryManageIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="ANN_ID"/>
     </bean>
-    <bean name="annvrsryManageIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="annvrsryManageIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="ANN_" />
         <property name="cipers"     value="16" />
         <property name="fillChar"   value="0" />

--- a/common-component/user-support/award-management.md
+++ b/common-component/user-support/award-management.md
@@ -85,14 +85,14 @@ menu:
 #### ID Generation 환경설정(context-idgn-RwardManage.xml)
 
 ```xml
-    <bean name="egovRwardManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovRwardManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="rwardManageIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="RWARD_ID"/>
     </bean>
-    <bean name="rwardManageIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="rwardManageIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="RWARD_" />
         <property name="cipers"     value="14" />
         <property name="fillChar"   value="0" />

--- a/common-component/user-support/banner-management.md
+++ b/common-component/user-support/banner-management.md
@@ -89,7 +89,7 @@ flowchart LR
 #### ID Generation 환경설정(context-idgn-Banner.xml)
 
 ```xml
-    <bean name="egovBannerIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovBannerIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="bannerIdStrategy" />
         <property name="blockSize"  value="10"/>
@@ -98,7 +98,7 @@ flowchart LR
     </bean>
  
     <bean name="bannerIdStrategy"
-        class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+        class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix" value="BANNER_" />
         <property name="cipers" value="13" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/company-member-management.md
+++ b/common-component/user-support/company-member-management.md
@@ -86,7 +86,7 @@ INSERT INTO COMTECOPSEQ VALUES('USRCNFRM_ID','1');
 
 ```xml
 <bean name="egovUsrCnfrmIdGnrService"
-      class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
+      class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
       destroy-method="destroy">
   <property name="dataSource" ref="egov.dataSource" />
   <property name="strategy" ref="usrCnfrmStrategy" />
@@ -96,7 +96,7 @@ INSERT INTO COMTECOPSEQ VALUES('USRCNFRM_ID','1');
 </bean>
 
 <bean name="usrCnfrmStrategy"
-      class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+      class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
   <property name="prefix" value="USRCNFRM_" />
   <property name="cipers" value="11" />
   <property name="fillChar" value="0" />

--- a/common-component/user-support/copyright-policy.md
+++ b/common-component/user-support/copyright-policy.md
@@ -74,14 +74,14 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('CPYRHT_ID', 1);
 #### ID Generation 환경설정(context-idgn-CpyrhtPrtcPolicy.xml)
 
 ```xml
-	<bean name="egovCpyrhtPrtcPolicyIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+	<bean name="egovCpyrhtPrtcPolicyIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="cpyrhtPrtcPolicyStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="CPYRHT_ID"/>
     </bean>
-    <bean name="cpyrhtPrtcPolicyStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="cpyrhtPrtcPolicyStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="CPYRHT_" />
         <property name="cipers"   value="13" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/counseling-management.md
+++ b/common-component/user-support/counseling-management.md
@@ -77,14 +77,14 @@ CREATE TABLE COMTECOPSEQ ( TABLE_NAME VARCHAR(20) NOT NULL,
 #### ID Generation 환경설정(context-idgn-CnsltManage.xml)
 
 ```xml
-<bean name="egovCnsltManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovCnsltManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="cnsltManageStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="CNSLT_ID"/>
     </bean>
-    <bean name="cnsltManageStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="cnsltManageStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="CNSLT_" />
         <property name="cipers"   value="14" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/event-application.md
+++ b/common-component/user-support/event-application.md
@@ -81,14 +81,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 ### ID Generation 환경설정(context-idgn-EventManage.xml)
 
 ```xml
-<bean name="egovEventManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovEventManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="eventManageEventIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="EVENT_ID"/>
     </bean>
-    <bean name="eventManageEventIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="eventManageEventIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="EVENT_" />
         <property name="cipers"   value="14" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/event-reception.md
+++ b/common-component/user-support/event-reception.md
@@ -82,14 +82,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 ### ID Generation 환경설정(context-idgn-EventAtdrn.xml)
 
 ```xml
-<bean name="egovEventAtdrnIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovEventAtdrnIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="eventAtdrnApplcntIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="APPLCNT_ID"/>
     </bean>
-    <bean name="eventAtdrnApplcntIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="eventAtdrnApplcntIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="APPLCNT_" />
         <property name="cipers"     value="12" />
         <property name="fillChar"   value="0" />

--- a/common-component/user-support/help.md
+++ b/common-component/user-support/help.md
@@ -72,7 +72,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 ```xml
 <bean name="egovHpcmManageIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy"   ref="hpcmManageStrategy" />
@@ -82,7 +82,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 	</bean>
  
 	<bean name="hpcmManageStrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="HPCM_" />
 		<property name="cipers" value="15" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/integrated-link.md
+++ b/common-component/user-support/integrated-link.md
@@ -84,7 +84,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('UNITY_LINK_ID', 1);
 
 ```xml
 <bean name="egovUnityLinkIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy" ref="unityLinkIdMsgtrategy" />
@@ -93,7 +93,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('UNITY_LINK_ID', 1);
 		<property name="tableName"	value="UNITY_LINK_ID"/>
 	</bean>
 	<bean name="unityLinkIdMsgtrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="ULINK_" />
 		<property name="cipers" value="14" />
 		<property name="fillChar" value="0" />
@@ -183,14 +183,14 @@ flowchart LR
 #### 비즈니스 규칙
 
  입력명 우측의 빨간* 표시는 반드시 입력해야할 항목을 표시한다.
- 저장처리 시 UNITY_LINK_ID 컬럼은 "egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"를 통하여
+ 저장처리 시 UNITY_LINK_ID 컬럼은 "org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"를 통하여
 
  Primary Key => ULINK_(20자리) : ULINK_(6자리) + 일련번호(14자리)로 자동생성 부여된다.
 
 ```xml
 <!-- IdGnrService... START-->			
 <bean name="egovUnityLinkIdGnrService"
-	class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+	class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 	destroy-method="destroy">
 	<property name="dataSource" ref="dataSource" />
 	<property name="strategy" ref="unityLinkIdMsgtrategy" />
@@ -199,7 +199,7 @@ flowchart LR
 	<property name="tableName"	value="UNITY_LINK_ID"/>
 </bean>
 <bean name="unityLinkIdMsgtrategy"
-	class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+	class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 	<property name="prefix" value="ULINK_" />
 	<property name="cipers" value="14" />
 	<property name="fillChar" value="0" />

--- a/common-component/user-support/internet-service-guide.md
+++ b/common-component/user-support/internet-service-guide.md
@@ -81,7 +81,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('ISG_ID', 1);
 #### ID Generation 환경설정(context-idgn-IntnetSvcGuidance.xml)
 
 ```xml
-<bean name="egovIntnetSvcGuidanceIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovIntnetSvcGuidanceIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="intnetSvcGuidanceIdStrategy" />
         <property name="blockSize"  value="10"/>
@@ -89,7 +89,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('ISG_ID', 1);
         <property name="tableName"  value="ISG_ID"/>
     </bean>
  
-    <bean name="intnetSvcGuidanceIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="intnetSvcGuidanceIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix" value="ISG_" />
         <property name="cipers" value="16" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/login-image.md
+++ b/common-component/user-support/login-image.md
@@ -79,7 +79,7 @@ menu:
 #### ID Generation 환경설정(context-idgn-LoginScrinImage.xml)
 
 ```xml
-    <bean name="egovLoginScrinImageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovLoginScrinImageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="loginScrinImageIdStrategy" />
         <property name="blockSize"  value="10"/>
@@ -88,7 +88,7 @@ menu:
     </bean>
  
     <bean name="loginScrinImageIdStrategy"
-        class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+        class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix" value="LSI_" />
         <property name="cipers" value="16" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/main-image.md
+++ b/common-component/user-support/main-image.md
@@ -84,7 +84,7 @@ menu:
 
 ```xml
     <bean name="egovMainImageIdGnrService"
-        class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
+        class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
         destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="mainImageIdStrategy" />
@@ -94,7 +94,7 @@ menu:
     </bean>
  
     <bean name="mainImageIdStrategy"
-        class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+        class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix" value="MSI_" />
         <property name="cipers" value="16" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/map-management.md
+++ b/common-component/user-support/map-management.md
@@ -69,14 +69,14 @@ menu:
 #### ID Generation 환경설정(context-idgn-RoughMap.xml)
 
 ```xml
-    <bean name="egovRoughMapIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovRoughMapIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="roumManageStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="ROUGHMAP_ID"/>
     </bean>
-    <bean name="roumManageStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="roumManageStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="ROUGHMAP_" />
         <property name="cipers"     value="11" />
         <property name="fillChar"   value="0" />

--- a/common-component/user-support/meeting-management.md
+++ b/common-component/user-support/meeting-management.md
@@ -77,14 +77,14 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('MTG_ID', 1);
 #### ID Generation 환경설정(context-idgn-Mgt.xml)
 
 ```xml
-<bean name="egovMgtIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovMgtIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="mgtMsgtrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="MTG_ID"/>
 </bean>
-<bean name="mgtMsgtrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+<bean name="mgtMsgtrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="MTG_" />
         <property name="cipers"   value="16" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/meeting-room-reservation.md
+++ b/common-component/user-support/meeting-room-reservation.md
@@ -83,14 +83,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 ### ID Generation 환경설정(context-idgn-MtgPlaceManage.xml)
 
 ```xml
-<bean name="egovMtgPlaceResveIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovMtgPlaceResveIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="mtgPlaceResveIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="RESVE_ID"/>
     </bean>
-    <bean name="mtgPlaceResveIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="mtgPlaceResveIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="RESVE_" />
         <property name="cipers"     value="14" />
         <property name="fillChar"   value="0" />

--- a/common-component/user-support/meeting-room.md
+++ b/common-component/user-support/meeting-room.md
@@ -80,14 +80,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 ### ID Generation 환경설정(context-idgn-MtgPlaceManage.xml)
 
 ```xml
-<bean name="egovMtgPlaceManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovMtgPlaceManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="mtgPlaceManageIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="MTG_PLACE_ID"/>
     </bean>
-    <bean name="mtgPlaceManageIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="mtgPlaceManageIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="MTGP_" />
         <property name="cipers"   value="15" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/mypage.md
+++ b/common-component/user-support/mypage.md
@@ -74,14 +74,14 @@ menu:
 #### ID Generation 환경설정(context-idgn-IndvdlPge.xml)
 
 ```xml
-    <bean name="egovIndvdlPgeIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovIndvdlPgeIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="cntntsIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="CNTNTS_ID"/>
     </bean>
-    <bean name="cntntsIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="cntntsIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="C" />
         <property name="cipers"   value="19" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/news-management.md
+++ b/common-component/user-support/news-management.md
@@ -70,7 +70,7 @@ menu:
 
 ```xml
 	<bean name="egovNewsManageIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy"   ref="newsManageStrategy" />
@@ -80,7 +80,7 @@ menu:
 	</bean>
  
 	<bean name="newsManageStrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="NEWS_" />
 		<property name="cipers" value="15" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/online-manual.md
+++ b/common-component/user-support/online-manual.md
@@ -87,7 +87,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 ```xml
 <bean name="egovOnlineMenualIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy" ref="onlineMenualMsgtrategy" />
@@ -96,7 +96,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 		<property name="tableName"	value="ONLINE_MUL_ID"/>
 	</bean>
 	<bean name="onlineMenualMsgtrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="OMUL_" />
 		<property name="cipers" value="15" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/popup-management.md
+++ b/common-component/user-support/popup-management.md
@@ -89,14 +89,14 @@ CREATE TABLE COMTECOPSEQ( TABLE_NAME VARCHAR(20) NOT NULL,
 #### ID Generation 환경설정(context-idgn-PopupManage.xml)
 
 ```xml
-<bean name="egovPopupManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovPopupManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
 		<property name="dataSource"     ref="egov.dataSource" />
 		<property name="strategy"       ref="egovPopupManageIdMsgtrategy" />
 		<property name="blockSize" 	value="10"/>
 		<property name="table"	   	value="COMTECOPSEQ"/>
 		<property name="tableName"	value="POPUP_ID"/>
 	</bean>
-	<bean name="egovPopupManageIdMsgtrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+	<bean name="egovPopupManageIdMsgtrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="POPUP_" />
 		<property name="cipers" value="14" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/privacy-policy.md
+++ b/common-component/user-support/privacy-policy.md
@@ -74,14 +74,14 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('INDVDL_INFO_ID', 1);
 #### ID Generation 환경설정(context-idgn-IndvdlInfoPolicy.xml)
 
 ```xml
-    <bean name="egovIndvdlInfoPolicyIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovIndvdlInfoPolicyIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="indvdlInfoPolicyIdMsgtrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="INDVDL_INFO_ID"/>
     </bean>
-    <bean name="indvdlInfoPolicyIdMsgtrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="indvdlInfoPolicyIdMsgtrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="INDVDL_" />
         <property name="cipers"   value="13" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/qna-management.md
+++ b/common-component/user-support/qna-management.md
@@ -89,7 +89,7 @@ flowchart LR
 
 ```xml
 	<bean name="egovQnaManageIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy"   ref="qnaManageStrategy" />
@@ -99,7 +99,7 @@ flowchart LR
 	</bean>
  
 	<bean name="qnaManageStrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="QA_" />
 		<property name="cipers" value="17" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/recommended-site.md
+++ b/common-component/user-support/recommended-site.md
@@ -72,14 +72,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 #### ID Generation 환경설정(context-idgn-RecomendSiteManage.xml)
 
 ```xml
-<bean name="egovRecomendSiteManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+<bean name="egovRecomendSiteManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="recomendSiteManageStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="RECOMEND_SITE_ID"/>
     </bean>
-    <bean name="recomendSiteManageStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="recomendSiteManageStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="RECOMEND_" />
         <property name="cipers"   value="11" />
         <property name="fillChar" value="0" />

--- a/common-component/user-support/site-management.md
+++ b/common-component/user-support/site-management.md
@@ -71,7 +71,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 ```xml
 <bean name="egovSiteManageIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy"   ref="siteManageStrategy" />
@@ -81,7 +81,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 	</bean>
  
 	<bean name="siteManageStrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="SITE_" />
 		<property name="cipers" value="15" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/staff-event.md
+++ b/common-component/user-support/staff-event.md
@@ -84,14 +84,14 @@ menu:
 #### ID Generation 환경설정(context-idgn-CtsnnManage.xml)
 
 ```xml
-    <bean name="egovCtsnnManageIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovCtsnnManageIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="ctsnnManageIdStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="CTSNN_ID"/>
     </bean>
-    <bean name="ctsnnManageIdStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="ctsnnManageIdStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"     value="CTSNN_" />
         <property name="cipers"     value="14" />
         <property name="fillChar"   value="0" />

--- a/common-component/user-support/survey-item.md
+++ b/common-component/user-support/survey-item.md
@@ -84,7 +84,7 @@ CREATE TABLE COMTECOPSEQ (
 
 ```xml
 <bean name="egovQustnrItemManageIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy" ref="QustnrItemManageInfotrategy" />
@@ -93,7 +93,7 @@ CREATE TABLE COMTECOPSEQ (
 		<property name="tableName"	value="QESTNR_QESITM_ID"/>
 	</bean>
 	<bean name="QustnrItemManageInfotrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="QESITM_" />
 		<property name="cipers" value="13" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/survey-management.md
+++ b/common-component/user-support/survey-management.md
@@ -106,7 +106,7 @@ CREATE TABLE COMTECOPSEQ (
 
 ```xml
 <bean name="egovQustnrManageIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy" ref="QustnrManageInfotrategy" />
@@ -115,7 +115,7 @@ CREATE TABLE COMTECOPSEQ (
 		<property name="tableName"	value="QUSTNRTMPLA_ID"/>
 	</bean>
 	<bean name="QustnrManageInfotrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="QMANAGE_" />
 		<property name="cipers" value="12" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/survey-question.md
+++ b/common-component/user-support/survey-question.md
@@ -85,7 +85,7 @@ CREATE TABLE COMTECOPSEQ (
 
 ```xml
 <bean name="egovQustnrQestnManageIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy" ref="QustnrQestnManageInfotrategy" />
@@ -94,7 +94,7 @@ CREATE TABLE COMTECOPSEQ (
 		<property name="tableName"	value="QUSTNRQESTN_ID"/>
 	</bean>
 	<bean name="QustnrQestnManageInfotrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="QQESTN_" />
 		<property name="cipers" value="13" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/survey-respondent.md
+++ b/common-component/user-support/survey-respondent.md
@@ -83,7 +83,7 @@ CREATE TABLE COMTECOPSEQ (
 
 ```xml
 <bean name="qustnrRespondManageIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy" ref="QustnrRespondManageInfotrategy" />
@@ -92,7 +92,7 @@ CREATE TABLE COMTECOPSEQ (
 		<property name="tableName"	value="QESTNR_RPD_ID"/>
 	</bean>
 	<bean name="QustnrRespondManageInfotrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="QRPD_" />
 		<property name="cipers" value="15" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/survey-template.md
+++ b/common-component/user-support/survey-template.md
@@ -91,7 +91,7 @@ CREATE TABLE COMTECOPSEQ (
 
 ```xml
 <bean name="egovQustnrTmplatManageIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy" ref="QustnrTmplatManageInfotrategy" />
@@ -100,7 +100,7 @@ CREATE TABLE COMTECOPSEQ (
 		<property name="tableName"	value="QUSTNRTMPLA_ID"/>
 	</bean>
 	<bean name="QustnrTmplatManageInfotrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="QTMPLA_" />
 		<property name="cipers" value="13" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/survey.md
+++ b/common-component/user-support/survey.md
@@ -84,7 +84,7 @@ CREATE TABLE COMTECOPSEQ (
 
 ```xml
 <bean name="qustnrRespondInfoIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy" ref="QustnrRespondInfotrategy" />
@@ -93,7 +93,7 @@ CREATE TABLE COMTECOPSEQ (
 		<property name="tableName"	value="QESRSPNS_ID"/>
 	</bean>
 	<bean name="QustnrRespondInfotrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="QRSPNS_" />
 		<property name="cipers" value="13" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/terms-management.md
+++ b/common-component/user-support/terms-management.md
@@ -72,7 +72,7 @@ menu:
 
 ```xml
 	<bean name="egovStplatManageIdGnrService"
-		class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrService"
+		class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
 		destroy-method="destroy">
 		<property name="dataSource" ref="egov.dataSource" />
 		<property name="strategy"   ref="stplatManageStrategy" />
@@ -82,7 +82,7 @@ menu:
 	</bean>
  
 	<bean name="stplatManageStrategy"
-		class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+		class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="STPLAT_" />
 		<property name="cipers" value="13" />
 		<property name="fillChar" value="0" />

--- a/common-component/user-support/user-manage.md
+++ b/common-component/user-support/user-manage.md
@@ -80,14 +80,14 @@ menu:
 #### ID Generation 환경설정(context-idgn-UsrCnfrm.xml)
 
 ```xml
-    <bean name="egovUsrCnfrmIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="egovUsrCnfrmIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="usrCnfrmStrategy" />
         <property name="blockSize"  value="10"/>
         <property name="table"      value="COMTECOPSEQ"/>
         <property name="tableName"  value="USRCNFRM_ID"/>
     </bean>
-    <bean name="usrCnfrmStrategy" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+    <bean name="usrCnfrmStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
         <property name="prefix"   value="USRCNFRM_" />
         <property name="cipers"   value="11" />
         <property name="fillChar" value="0" />


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

공통컴포넌트 가이드가 실행환경 4.0 이전의 클래스 표기를 그대로 쓰고 있습니다. 접두어가 `egovframework.rte` 인데 실행환경 5.0.0 저장소에는 그 접두어로 시작하는 패키지 선언이 하나도 없습니다. 아래는 실행환경 저장소(`eGovFramework/egovframe-runtime`)에서 돌린 것입니다.

```
$ git log --oneline -1 origin/main
cc2b332 Merge pull request #379 from itcen-entec-2026/codex/fix-cmmn-service-logging-locale

$ git grep -lE '^package org\.egovframe\.rte' origin/main -- '*.java' | wc -l
     838

$ git grep -lE '^package egovframework\.rte' origin/main -- '*.java' | wc -l
       0

$ git show origin/main:pom.xml | grep -m1 -n "<version>"
7:    <version>5.0.0</version>
```

**파일 단위로 완결되게 고쳤습니다.** 옛 표기가 남아 있는 공통컴포넌트 문서 76개 중 75개에서, 그 안의 실행환경 클래스 참조 162줄을 5.0 기준으로 맞췄습니다. 손댄 문서 안에서 옛 표기와 새 표기가 섞이는 곳은 없습니다.

대부분은 접두어만 바뀌지만 클래스가 바뀐 것도 있습니다. 문서 23개가 빈을 `class="...fdl.idgnr.impl.EgovTableIdGnrService"` 로 적는데, 이 클래스는 v4.3.0-Final 까지 `@deprecated Use the EgovTableIdGnrServiceImpl class.` 로 남아 있다가 5.0 에서 제거됐습니다.

```
$ git ls-tree -r --name-only v4.3.0-Final | grep 'idgnr.*EgovTableIdGnrService\.java$'
Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/EgovTableIdGnrService.java

$ git show v4.3.0-Final:Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/EgovTableIdGnrService.java | grep -n 'deprecated'
51: * @deprecated Use the EgovTableIdGnrServiceImpl class.

$ git ls-tree -r --name-only v5.0.1-Final | grep -c 'idgnr.*EgovTableIdGnrService\.java$'
0
```

빈의 `class` 속성은 인스턴스로 만들 구현 클래스를 적는 자리입니다. 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 실제 ID 생성 설정은 117곳 전부 `EgovTableIdGnrServiceImpl` 을 씁니다.

```
$ git grep -ohE 'class="[^"]*EgovTableIdGnrService[^"]*"' origin/main -- '*.xml' | sort | uniq -c
 117 class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl"
```

## 남겨둔 것

`encrypt_decrypt.md` 하나를 통째로 남겼습니다. 이 문서의 옛 표기 네 줄은 jar 파일명과 `<groupId>`·`<artifactId>`·`${egovframework.rte.version}` 이라, 패키지 표기가 아니라 Maven 좌표입니다. 접두어만 바꿔서는 맞는 값이 되지 않습니다 — 5.0 의 crypto 모듈은 groupId `org.egovframe.rte` 에 artifactId `egovframe-rte-fdl-crypto` 이고 같은 저장소의 `crypto-simplification.md` 가 이미 그 형태로 적고 있습니다. 갱신이 필요한 건 맞지만 이 PR 이 다루는 종류가 아니어서 남겼습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
