### PR TITLE
docs: 실행환경 가이드의 클래스 표기를 5.0 기준으로 정정

### DIFF
--- a/egovframe-runtime/batch-layer/batch-core-item_writer.md
+++ b/egovframe-runtime/batch-layer/batch-core-item_writer.md
@@ -364,13 +364,13 @@ NDX 파일목록 중 잘못된 파일명이 존재할 경우 에러를 발생한
 Index Reader을 통해 읽어드린 파일을 NDX파일 설정에 따라 동적으로 새로운 파일을 생성한다.
 
 ```xml
-<bean id="fileIndex-delimitedItemWriter" class="egovframework.rte.bat.core.item.file.EgovIndexFileWriter" scope="step">
+<bean id="fileIndex-delimitedItemWriter" class="org.egovframe.rte.bat.core.item.file.EgovIndexFileWriter" scope="step">
 	<property name="indexResource" value="file:./src/main/resources/egovframework/batch/data/inputs/csvData_NDX(+1)" />
 	<property name="lineAggregator">
 		<bean class="org.springframework.batch.item.file.transform.DelimitedLineAggregator">
 			<property name="delimiter" value="," />
 			<property name="fieldExtractor">
-				<bean class="egovframework.rte.bat.core.item.file.transform.EgovFieldExtractor">
+				<bean class="org.egovframe.rte.bat.core.item.file.transform.EgovFieldExtractor">
 					<property name="names" value="name,credit" />
 				</bean>
 			</property>
@@ -400,7 +400,7 @@ Index Reader을 통해 읽어드린 파일을 NDX파일 설정에 따라 동적�
 
 #### EgovMyBatisBatchItemWriter 설정항목 설정
 ```xml
-<bean id="mybatisJobStep.mybatisItemWriter" class="egovframework.rte.bat.item.database.EgovMyBatisBatchItemWriter">
+<bean id="mybatisJobStep.mybatisItemWriter" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter">
 	<property name="resourceVariable" ref="resourceVariable" />
 	<property name="jobVariable" ref="jobVariable" />
 	<property name="stepVariable" ref="stepVariable" />

--- a/egovframe-runtime/batch-layer/batch-core-job_variable.md
+++ b/egovframe-runtime/batch-layer/batch-core-job_variable.md
@@ -25,7 +25,7 @@ menu:
 배치실행환경에서 제공하는 EgovJobVariableListener 사용하여 사용자 정의 변수를 설정한다.
 
 ```xml
-<bean id="egovJobVariableListener" class="egovframework.rte.bat.support.EgovJobVariableListener">
+<bean id="egovJobVariableListener" class="org.egovframe.rte.bat.support.EgovJobVariableListener">
 <property name="pros">
 <props>
 	<prop key="JobVariableKey1">JobVariableValue1</prop>

--- a/egovframe-runtime/batch-layer/batch-core-resource_variable.md
+++ b/egovframe-runtime/batch-layer/batch-core-resource_variable.md
@@ -22,7 +22,7 @@ menu:
 배치실행환경에서 제공하는 EgovResourceVariable 사용하여 사용자 정의 리소스를 설정한다.
 
 ```xml
-<bean id="egovResourceVariable" class="egovframework.rte.bat.support.EgovResourceVariable">
+<bean id="egovResourceVariable" class="org.egovframe.rte.bat.support.EgovResourceVariable">
 	<property name="pros">
 	<props>
 		<prop key="input.resource">file:./src/main/resources/egovframework/batch/data/inputs/csvData.csv</prop>
@@ -40,14 +40,14 @@ Setp에서 ItemReader, ItemWriter 사용시 사용자 정의 리소스 변수를
 	class="org.springframework.batch.item.file.FlatFileItemReader" scope="step">
 	<property name="resource" value="#{egovResourceVariable.getVariable('input.resource')}" />
 	<property name="lineMapper">
-		<bean class="egovframework.rte.bat.core.item.file.mapping.EgovDefaultLineMapper">
+		<bean class="org.egovframe.rte.bat.core.item.file.mapping.EgovDefaultLineMapper">
 			<property name="lineTokenizer">
-				<bean class="egovframework.rte.bat.core.item.file.transform.EgovDelimitedLineTokenizer">
+				<bean class="org.egovframe.rte.bat.core.item.file.transform.EgovDelimitedLineTokenizer">
 					<property name="delimiter" value="," />
 				</bean>
 			</property>
 			<property name="objectMapper">
-				<bean class="egovframework.rte.bat.core.item.file.mapping.EgovObjectMapper">
+				<bean class="org.egovframe.rte.bat.core.item.file.mapping.EgovObjectMapper">
 					<property name="type"
 						value="egovframework.example.bat.domain.trade.CustomerCredit" />
 					<property name="names" value="name,credit" />
@@ -64,7 +64,7 @@ Setp에서 ItemReader, ItemWriter 사용시 사용자 정의 리소스 변수를
 		<bean class="org.springframework.batch.item.file.transform.DelimitedLineAggregator">
 			<property name="delimiter" value="," />
 			<property name="fieldExtractor">
-				<bean class="egovframework.rte.bat.core.item.file.transform.EgovFieldExtractor">
+				<bean class="org.egovframe.rte.bat.core.item.file.transform.EgovFieldExtractor">
 					<property name="names" value="name,credit" />
 				</bean>
 			</property>

--- a/egovframe-runtime/batch-layer/batch-core-step_variable.md
+++ b/egovframe-runtime/batch-layer/batch-core-step_variable.md
@@ -25,7 +25,7 @@ menu:
 배치실행환경에서 제공하는 EgovJobVariableListener 사용하여 사용자 정의 변수를 설정한다.
 
 ```xml
-<bean id="egovStepVariableListener" class="egovframework.rte.bat.support.EgovStepVariableListener">
+<bean id="egovStepVariableListener" class="org.egovframe.rte.bat.support.EgovStepVariableListener">
 <property name="pros">
 <props>
 	<prop key="StepVariableKey1">StepVariableValue1</prop>

--- a/egovframe-runtime/batch-layer/batch-execution-remote_job_launcher.md
+++ b/egovframe-runtime/batch-layer/batch-execution-remote_job_launcher.md
@@ -88,7 +88,7 @@ package egovframework.example.bat.remote;
  
 import java.util.ArrayList;
 ...
-import egovframework.rte.bat.core.launch.support.EgovBatchRunner;
+import org.egovframe.rte.bat.core.launch.support.EgovBatchRunner;
  
 public class RemoteJobLauncherImpl implements RemoteJobLauncher {
  

--- a/egovframe-runtime/business-logic-layer/exception-handling.md
+++ b/egovframe-runtime/business-logic-layer/exception-handling.md
@@ -74,7 +74,7 @@ ExceptionTransfer의 property로 존재하는 exceptionHandlerService는 다수�
 		</aop:aspect>
 	</aop:config>
  
-	<bean id="exceptionTransfer" class="egovframework.rte.fdl.cmmn.aspect.ExceptionTransfer">
+	<bean id="exceptionTransfer" class="org.egovframe.rte.fdl.cmmn.aspect.ExceptionTransfer">
 		<property name="exceptionHandlerService">
 			<list>
 				<ref bean="defaultExceptionHandleManager" />
@@ -83,7 +83,7 @@ ExceptionTransfer의 property로 존재하는 exceptionHandlerService는 다수�
 	</bean>
  
 	<bean id="defaultExceptionHandleManager"
-		class="egovframework.rte.fdl.cmmn.exception.manager.DefaultExceptionHandleManager">
+		class="org.egovframe.rte.fdl.cmmn.exception.manager.DefaultExceptionHandleManager">
 		<property name="patterns">
 			<list>
 				<value>**service.*Impl</value>
@@ -97,7 +97,7 @@ ExceptionTransfer의 property로 존재하는 exceptionHandlerService는 다수�
 	</bean>
  
 	<bean id="egovHandler"
-		class="egovframework.rte.fdl.cmmn.exception.handler.EgovServiceExceptionHandler" />
+		class="org.egovframe.rte.fdl.exception.handler.EgovServiceExceptionHandler" />
 ...
 ```
 defaultExceptionHandleManager는 setPatterns(), setHandlers() 메소드를 가지고 있다. 상단과 같이 등록된 pattern 정보를 이용하여 Exception 발생 클래스와의 비교하여 ture인 경우 handlers에 등록된 handler를 실행한다.<br/>
@@ -175,7 +175,7 @@ CustomizableHandler의 등록을 해보도록 하겠다.<br/>
 여기서 주의해야 하는 부분은 patterns에 sample 패키지에 있는 Helloworld 클래스를 지정해주어야 한다는 것이다.
 
 ```xml
-	<bean id="exceptionTransfer" class="egovframework.rte.fdl.cmmn.aspect.ExceptionTransfer">
+	<bean id="exceptionTransfer" class="org.egovframe.rte.fdl.cmmn.aspect.ExceptionTransfer">
 		<property name="exceptionHandlerService">
 			<list>
 				<ref bean="customizableExceptionHandleManager" />
@@ -184,7 +184,7 @@ CustomizableHandler의 등록을 해보도록 하겠다.<br/>
 	</bean>
  
 	<bean id="customizableExceptionHandleManager"
-		class="egovframework.rte.fdl.cmmn.exception.manager.DefaultExceptionHandleManager">
+		class="org.egovframe.rte.fdl.cmmn.exception.manager.DefaultExceptionHandleManager">
 		<property name="patterns">
 			<list>
 				<value>**sample.Helloworld</value>
@@ -218,7 +218,7 @@ leaveaTrace·TraceHandler 관련 Bean 정의는 [The IoC Container](https://docs
 
 ```xml
 ...
-	<bean id="leaveaTrace" class="egovframework.rte.fdl.cmmn.trace.LeaveaTrace">
+	<bean id="leaveaTrace" class="org.egovframe.rte.fdl.cmmn.trace.LeaveaTrace">
 		<property name="traceHandlerServices">
 			<list>
 				<ref bean="traceHandlerService" />
@@ -226,7 +226,7 @@ leaveaTrace·TraceHandler 관련 Bean 정의는 [The IoC Container](https://docs
 		</property>
 	</bean>
  
-	<bean id="traceHandlerService" 	class="egovframework.rte.fdl.cmmn.trace.manager.DefaultTraceHandleManager">
+	<bean id="traceHandlerService" 	class="org.egovframe.rte.fdl.cmmn.trace.manager.DefaultTraceHandleManager">
 		<property name="patterns">
 			<list>
 				<value>*</value>
@@ -242,7 +242,7 @@ leaveaTrace·TraceHandler 관련 Bean 정의는 [The IoC Container](https://docs
 	<bean id="antPathMatcher" class="org.springframework.util.AntPathMatcher" />
  
 	<bean id="defaultTraceHandler"
-		class="egovframework.rte.fdl.cmmn.trace.handler.DefaultTraceHandler" />
+		class="org.egovframe.rte.fdl.cmmn.trace.handler.DefaultTraceHandler" />
 ...
 ```
 
@@ -251,7 +251,7 @@ leaveaTrace·TraceHandler 관련 Bean 정의는 [The IoC Container](https://docs
 ##### Interface TraceHandler를 아래와 같이 implements 한다.
 
 ```java
-package egovframework.rte.fdl.cmmn.trace.handler;
+package org.egovframe.rte.fdl.cmmn.trace.handler;
  
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/egovframe-runtime/foundation-layer/crypto-encryption-decryption.md
+++ b/egovframe-runtime/foundation-layer/crypto-encryption-decryption.md
@@ -201,7 +201,7 @@ crypto.hashed.password=gdyYs/IZqY86VcWhT8emCYfqY1ahw2vtLG+/FzNqtrQ=
 ```
 
 - crypto.password.algorithm : 패스워드 인코더에 사용될 hash function 알고리즘 (default : SHA-256)
-- crypto.hashed.password : 패스워드에 대한 hash value (egovframework.rte.fdl.cryptography.EgovPasswordEncoder의 main 메소드에 의해 해당 값을 얻어 기록한다.)
+- crypto.hashed.password : 패스워드에 대한 hash value (org.egovframe.rte.fdl.crypto.EgovPasswordEncoder의 main 메소드에 의해 해당 값을 얻어 기록한다.)
 
 그리고 이를 사용하기 위해 다음과 같이 property-placeholder 설정이 필요하다.
 
@@ -214,22 +214,22 @@ location="classpath*:/META-INF/spring/crypto_config.properties,classpath*:/META-
 ※ 위 property 파일과 이를 사용하기 위한 property-placeholder를 사용하지 않고 아래의 xml 설정에 직접 기록하여도 된다.
 
 ```xml
-<bean id="passwordEncoder" class="egovframework.rte.fdl.cryptography.EgovPasswordEncoder">
+<bean id="passwordEncoder" class="org.egovframe.rte.fdl.crypto.EgovPasswordEncoder">
   <property name="algorithm" value="${crypto.password.algorithm}" /><!-- default : SHA-256 -->
   <property name="hashedPassword" value="${crypto.hashed.password}" />
 </bean>
  
-<bean id="ARIACryptoService" class="egovframework.rte.fdl.cryptography.impl.EgovARIACryptoServiceImpl">
+<bean id="ARIACryptoService" class="org.egovframe.rte.fdl.crypto.impl.EgovARIACryptoServiceImpl">
   <property name="passwordEncoder" ref="passwordEncoder" />
   <property name="blockSize" value="1025" /><!-- default : 1024 -->
 </bean>
  
-<bean id="digestService" class="egovframework.rte.fdl.cryptography.impl.EgovDigestServiceImpl">
+<bean id="digestService" class="org.egovframe.rte.fdl.crypto.impl.EgovDigestServiceImpl">
   <property name="algorithm" value="SHA-256" /><!-- default : SHA-256 -->
   <property name="plainDigest" value="false" /><!-- default : false -->
 </bean>
  
-<bean id="generalCryptoService" class="egovframework.rte.fdl.cryptography.impl.EgovGeneralCryptoServiceImpl">
+<bean id="generalCryptoService" class="org.egovframe.rte.fdl.crypto.impl.EgovGeneralCryptoServiceImpl">
   <property name="passwordEncoder" ref="passwordEncoder" />
   <property name="algorithm" value="PBEWithSHA1AndDESede" /><!-- default : PBEWithSHA1AndDESede -->
   <property name="blockSize" value="1024" /><!-- default : 1024 -->

--- a/egovframe-runtime/foundation-layer/excel.md
+++ b/egovframe-runtime/foundation-layer/excel.md
@@ -273,11 +273,11 @@ ${persons.name}	${persons.id}	${persons.mon}	${persons.tue}	${persons.wed}	${per
 #### Configuration
 
 ```xml
-<bean id="categoryExcelView" class="egovframework.rte.fdl.excel.download.CategoryExcelView" />
+<bean id="categoryExcelView" class="org.egovframe.rte.fdl.excel.download.CategoryExcelView" />
  
 <!--
 XSSF 형태의 다운로드의 경우 다음의 View를 등록하여 사용한다.
-<bean id="CategoryPOIExcelView" class="egovframework.rte.fdl.excel.download.CategoryPOIExcelView" />
+<bean id="CategoryPOIExcelView" class="org.egovframe.rte.fdl.excel.download.CategoryPOIExcelView" />
 -->
  
 <bean class="org.springframework.web.servlet.view.BeanNameViewResolver">
@@ -544,21 +544,21 @@ public class CategoryPOIExcelView extends AbstractPOIExcelView {
 #### Configuration
 
 ```xml
-<bean id="excelService"	class="egovframework.rte.fdl.excel.impl.EgovExcelServiceImpl">
-	<property name="mapClass" value="egovframework.rte.fdl.excel.upload.EgovExcelTestMapping" />
+<bean id="excelService"	class="org.egovframe.rte.fdl.excel.impl.EgovExcelServiceImpl">
+	<property name="mapClass" value="org.egovframe.rte.fdl.excel.upload.EgovExcelTestMapping" />
 	<property name="sqlSessionTemplate" ref="sqlSessionTemplate" />
 </bean>
  
-<bean id="excelBigService" class="egovframework.rte.fdl.excel.impl.EgovExcelServiceImpl">
-	<property name="mapClass" value="egovframework.rte.fdl.excel.upload.EgovExcelTestMapping" />
+<bean id="excelBigService" class="org.egovframe.rte.fdl.excel.impl.EgovExcelServiceImpl">
+	<property name="mapClass" value="org.egovframe.rte.fdl.excel.upload.EgovExcelTestMapping" />
 	<property name="mapBeanName" value="mappingBean" />
 	<property name="sqlMapClient" ref="sqlMapClient" />
 </bean>
  
-<bean id="mappingBean" class="egovframework.rte.fdl.excel.upload.EgovExcelBigTestMapping" />
+<bean id="mappingBean" class="org.egovframe.rte.fdl.excel.upload.EgovExcelBigTestMapping" />
 ```
 
-- class : egovframework.rte.fdl.excel.impl.EgovExcelServiceImpl
+- class : org.egovframe.rte.fdl.excel.impl.EgovExcelServiceImpl
 - propertyPath : xml형식의 엑셀 형식정보 위치
 - mapClass : 개발자가 작성한 VO와 Query의 mapping을 위한 클래스
 - mapBeanName : Excel Cell과 VO를 mapping 구현 Bean name (mapClass보다 우선함)
@@ -639,7 +639,7 @@ public class EgovExcelTestMapping extends EgovExcelMapping {
 
 ```xml
 <sqlMap namespace="EmpBatchInsert">
-	<typeAlias alias="empVO" type="egovframework.rte.fdl.excel.vo.EmpVO" />
+	<typeAlias alias="empVO" type="org.egovframe.rte.fdl.excel.vo.EmpVO" />
 	<insert id="insertEmpUsingBatch" parameterClass="empVO">
 		<![CDATA[
 			insert into EMP (

--- a/egovframe-runtime/foundation-layer/logging-log4j2-configuration_file.md
+++ b/egovframe-runtime/foundation-layer/logging-log4j2-configuration_file.md
@@ -328,7 +328,7 @@ Connection 객체를 제공하기 위한 JNDI DataSource 혹은 Connection Facto
  <JDBC name="db" tableName="db_log">
   <!-- DB Connection을 제공해줄 클래스와 메서드명 정의 -->
   <!-- JDBCAppender가 EgovConnectionFactory.getDatabaseConnection() 메서드를 호출 -->
-  <ConnectionFactory class="egovframework.rte.fdl.logging.db.EgovConnectionFactory" method="getDatabaseConnection" />
+  <ConnectionFactory class="org.egovframe.rte.fdl.logging.db.EgovConnectionFactory" method="getDatabaseConnection" />
    <!-- log event가 insert될 컬럼 설정, insert될 값은 PatternLayout의 pattern 사용 -->
    <Column name="eventDate" isEventTimestamp="true" />
    <Column name="level" pattern="%p" />
@@ -341,7 +341,7 @@ Connection 객체를 제공하기 위한 JNDI DataSource 혹은 Connection Facto
 표준프레임워크에서는 Connection Factory 역할을 하는 EgovConnectionFactory를 제공하고 있으며, 어플리케이션에서 설정한 dataSource 빈을 주입받아 싱글톤을 생성한다. 이를 위해 다음과 같이 빈정의를 추가해야한다.
 
 ```xml
- <bean id="egovConnectionFactory" class="egovframework.rte.fdl.logging.db.EgovConnectionFactory">
+ <bean id="egovConnectionFactory" class="org.egovframe.rte.fdl.logging.db.EgovConnectionFactory">
   <property name="dataSource" ref="dataSource" />
  </bean>
 ```

--- a/egovframe-runtime/foundation-layer/property-service.md
+++ b/egovframe-runtime/foundation-layer/property-service.md
@@ -22,7 +22,7 @@ Property Service 는 시스템의 설치 환경에 관련된 정보나, 잦은 �
 ### Configuration
 
 ```xml
-<bean name="propertyService" class="egovframework.rte.fdl.property.impl.EgovPropertyServiceImpl" 
+<bean name="propertyService" class="org.egovframe.rte.fdl.property.impl.EgovPropertyServiceImpl" 
         destroy-method="destroy">
     <property name="properties">
         <map>
@@ -84,7 +84,7 @@ public void testPropertiesService() throws Exception {
 #### Configuration
 
 ```xml
-<bean name="propertyService" class="egovframework.rte.fdl.property.impl.EgovPropertyServiceImpl" 
+<bean name="propertyService" class="org.egovframe.rte.fdl.property.impl.EgovPropertyServiceImpl" 
         destroy-method="destroy">
     <property name="extFileName">
         <set>

--- a/egovframe-runtime/foundation-layer/property-source.md
+++ b/egovframe-runtime/foundation-layer/property-source.md
@@ -122,7 +122,7 @@ commit;
 		<jdbc:script location="classpath:db/dml.sql" />
 	</jdbc:embedded-database>
  
-	<bean id="dbPropertySource" class="egovframework.rte.fdl.property.db.DbPropertySource">
+	<bean id="dbPropertySource" class="org.egovframe.rte.fdl.property.db.DbPropertySource">
 		<constructor-arg value="dbPropertySource"/>
 		<constructor-arg ref="dataSource"/>
 		<constructor-arg value="SELECT PKEY, PVALUE FROM PROPERTY"/>
@@ -137,7 +137,7 @@ WAS 기동 시에 DB값을 가져오도록 web.xml에 추가설정이 필요하�
 ```xml
 <context-param>
     <param-name>contextInitializerClasses</param-name>
-    <param-value>egovframework.rte.fdl.property.db.initializer.DBPropertySourceInitializer</param-value>
+    <param-value>org.egovframe.rte.fdl.property.db.initializer.DBPropertySourceInitializer</param-value>
 </context-param>
 <context-param>
     <param-name>propertySourceConfigLocation</param-name>

--- a/egovframe-runtime/foundation-layer/server-security-authentication.md
+++ b/egovframe-runtime/foundation-layer/server-security-authentication.md
@@ -75,12 +75,12 @@ UserDetailsService 인터페이스 내 loadUserByUsername 메소드의 리턴된
 </authentication-manager>
  
  
-<beans:bean id="jdbcUserService" class="egovframework.rte.fdl.security.userdetails.jdbc.EgovJdbcUserDetailsManager" >
+<beans:bean id="jdbcUserService" class="org.egovframe.rte.fdl.security.userdetails.jdbc.EgovJdbcUserDetailsManager" >
 	<beans:property name="usersByUsernameQuery" value="SELECT USER_ID,PASSWORD,ENABLED,USER_NAME,BIRTH_DAY,SSN FROM USERS WHERE USER_ID = ?"/>
 	<beans:property name="authoritiesByUsernameQuery" value="SELECT USER_ID,AUTHORITY FROM AUTHORITIES WHERE USER_ID = ?"/>
 	<beans:property name="roleHierarchy" ref="roleHierarchy"/>
 	<beans:property name="dataSource" ref="dataSource"/>
-	<beans:property name="mapClass" value="egovframework.rte.fdl.security.userdetails.EgovUserDetailsMapping"/>
+	<beans:property name="mapClass" value="org.egovframe.rte.fdl.security.userdetails.EgovUserDetailsMapping"/>
 </beans:bean>
 ```
 
@@ -188,16 +188,16 @@ CAS 인증
  변경후(사용)
 
 ```xml
-<beans:bean id="jdbcUserService" class="egovframework.rte.fdl.security.userdetails.jdbc.EgovJdbcUserDetailsManager" >
+<beans:bean id="jdbcUserService" class="org.egovframe.rte.fdl.security.userdetails.jdbc.EgovJdbcUserDetailsManager" >
 	<beans:property name="usersByUsernameQuery" value="SELECT USER_ID,PASSWORD,ENABLED,USER_NAME,BIRTH_DAY,SSN FROM USERS WHERE USER_ID = ?"/>
 	<beans:property name="authoritiesByUsernameQuery" value="SELECT USER_ID,AUTHORITY FROM AUTHORITIES WHERE USER_ID = ?"/>
 	<beans:property name="roleHierarchy" ref="roleHierarchy"/>
 	<beans:property name="dataSource" ref="dataSource"/>
-	<beans:property name="mapClass" value="egovframework.rte.fdl.security.userdetails.EgovUserDetailsMapping"/>
+	<beans:property name="mapClass" value="org.egovframe.rte.fdl.security.userdetails.EgovUserDetailsMapping"/>
 </beans:bean>
 ```
 
-- class : egovframework.rte.fdl.security.userdetails.jdbc.EgovJdbcUserDetailsManager
+- class : org.egovframe.rte.fdl.security.userdetails.jdbc.EgovJdbcUserDetailsManager
 - usersByUsernameQuery : 사용자 인증을 위해 사용자 테이블에서 사용자정보를 조회한다.
 - authoritiesByUsernameQuery : 사용자 인증을 위해 사용자권한 테이블에서 사용자권한정보를 조회한다.
 - roleHierarchy : 역할의 계층적 관리를 위해 계층 역할을 설정한다.
@@ -289,7 +289,7 @@ public class EgovUserDetailsMapping extends EgovUsersByUsernameMapping {
 ##### 세션 가져오기
 
 ```java
-import egovframework.rte.fdl.security.userdetails.util.EgovUserDetailsHelper;
+import org.egovframe.rte.fdl.security.userdetails.util.EgovUserDetailsHelper;
   .
   .
   .

--- a/egovframe-runtime/foundation-layer/server-security-authorization.md
+++ b/egovframe-runtime/foundation-layer/server-security-authorization.md
@@ -34,22 +34,22 @@ Server Security에서는 Filter Security Interceptor에 의해 처리되며, DB�
 </beans:bean>
 ...
  
-<beans:bean id="databaseSecurityMetadataSource" class="egovframework.rte.fdl.security.intercept.EgovReloadableFilterInvocationSecurityMetadataSource">
+<beans:bean id="databaseSecurityMetadataSource" class="org.egovframe.rte.fdl.security.bean.EgovReloadableFilterInvocationSecurityMetadataSource">
 	<beans:constructor-arg ref="requestMap" />	
 	<beans:property name="securedObjectService" ref="securedObjectService"/>
 </beans:bean>
  
 <!--  url  -->
-<beans:bean id="requestMap" 	class="egovframework.rte.fdl.security.intercept.UrlResourcesMapFactoryBean" init-method="init">
+<beans:bean id="requestMap" 	class="org.egovframe.rte.fdl.security.bean.UrlResourcesMapFactoryBean" init-method="init">
 	<beans:property name="securedObjectService" ref="securedObjectService"/>
 </beans:bean>
  
-<beans:bean id="securedObjectService" class="egovframework.rte.fdl.security.securedobject.impl.SecuredObjectServiceImpl">
+<beans:bean id="securedObjectService" class="org.egovframe.rte.fdl.security.secureobject.impl.SecuredObjectServiceImpl">
 	<beans:property name="securedObjectDAO" ref="securedObjectDAO"/>
 	<beans:property name="requestMatcherType" value="regex"/>	<!--  default : ant -->
 </beans:bean>
  
-<beans:bean id="securedObjectDAO" class="egovframework.rte.fdl.security.securedobject.impl.SecuredObjectDAO" >
+<beans:bean id="securedObjectDAO" class="org.egovframe.rte.fdl.security.secureobject.impl.SecuredObjectDAO" >
 	<beans:property name="dataSource" ref="dataSource"/>
 </beans:bean>
 ```
@@ -103,7 +103,7 @@ FilterSecurityInterceptor는 <Acronym title="Hyper Text Transfer Protocol">HTTP<
 DB 기반으로 현재 시점의 url 보호자원-권한의 맵핑 정보를 Runtime 에 동적으로 변경 반영하기 위한 Spring Security 의 FilterInvocationSecurityMetadataSource 확장 클래스이다.
 
 ```xml
-<beans:bean id="databaseSecurityMetadataSource" class="egovframework.rte.fdl.security.intercept.EgovReloadableFilterInvocationSecurityMetadataSource">
+<beans:bean id="databaseSecurityMetadataSource" class="org.egovframe.rte.fdl.security.bean.EgovReloadableFilterInvocationSecurityMetadataSource">
 	<beans:constructor-arg ref="requestMap" />	
 	<beans:property name="securedObjectService" ref="securedObjectService"/>
 </beans:bean>
@@ -114,7 +114,7 @@ DB 기반의 보호자원 맵핑 정보를 얻어 이를 참조하는 빈의 초
 securedObjectService의 getRolesAndUrl()를 호출하여 DB에서 역할과 url의 매핑정보를 얻어온다.
 
 ```xml
-<beans:bean id="requestMap" class="egovframework.rte.fdl.security.intercept.UrlResourcesMapFactoryBean" init-method="init">
+<beans:bean id="requestMap" class="org.egovframe.rte.fdl.security.bean.UrlResourcesMapFactoryBean" init-method="init">
 	<beans:property name="securedObjectService" ref="securedObjectService"/>
 </beans:bean>
 ```
@@ -173,7 +173,7 @@ DB 기반의 보호자원 맵핑 정보를 얻어 이를 참조하는 빈의 초
 resourceType을 method로 설정하여 securedObjectService의 getRolesAndMethod()를 호출하여 DB에서 역할과 메소드의 매핑정보를 얻어온다.
 
 ```xml
-<beans:bean id="methodMap" class="egovframework.rte.fdl.security.intercept.MethodResourcesMapFactoryBean" init-method="init">
+<beans:bean id="methodMap" class="org.egovframe.rte.fdl.security.bean.MethodResourcesMapFactoryBean" init-method="init">
 	<beans:property name="securedObjectService" ref="securedObjectService"/>
 	<beans:property name="resourceType" value="method"/>
 </beans:bean>
@@ -181,7 +181,7 @@ resourceType을 method로 설정하여 securedObjectService의 getRolesAndMethod
 
 #### pointcut
 DB 기반의 보호자원 맵핑 정보를 얻어 이를 참조하는 빈의 초기화 데이터로 제공한다.
-resourceType을 pointcut으로 설정하여 securedObjectService의 getRolesAndPointcut()를 호출하여 DB에서 역할과 Pointcut의 매핑정보를 얻어온다. ex: execution(* egovframework.rte.security..service.\*Service.insert*(..))
+resourceType을 pointcut으로 설정하여 securedObjectService의 getRolesAndPointcut()를 호출하여 DB에서 역할과 Pointcut의 매핑정보를 얻어온다. ex: execution(* org.egovframe.rte.security..service.\*Service.insert*(..))
 
 ```xml
 <beans:bean id="protectPointcutPostProcessor" class="org.springframework.security.config.method.ProtectPointcutPostProcessor">
@@ -189,7 +189,7 @@ resourceType을 pointcut으로 설정하여 securedObjectService의 getRolesAndP
 	<beans:property name="pointcutMap" ref="pointcutMap"/>
 </beans:bean>
  
-<beans:bean id="pointcutMap" class="egovframework.rte.fdl.security.intercept.MethodResourcesMapFactoryBean" init-method="init">
+<beans:bean id="pointcutMap" class="org.egovframe.rte.fdl.security.bean.MethodResourcesMapFactoryBean" init-method="init">
 	<beans:property name="securedObjectService" ref="securedObjectService"/>
 	<beans:property name="resourceType" value="pointcut"/>
 </beans:bean>
@@ -222,19 +222,19 @@ resourceType을 pointcut으로 설정하여 securedObjectService의 getRolesAndP
 ```
  
 ```xml
-<beans:bean id="hierarchyStrings" class="egovframework.rte.fdl.security.userdetails.hierarchicalroles.HierarchyStringsFactoryBean" init-method="init">
+<beans:bean id="hierarchyStrings" class="org.egovframe.rte.fdl.security.userdetails.hierarchicalroles.HierarchyStringsFactoryBean" init-method="init">
 	<beans:property name="securedObjectService" ref="securedObjectService"/>
 </beans:bean>
-	<beans:bean id="jdbcUserService" class="egovframework.rte.fdl.security.userdetails.jdbc.EgovJdbcUserDetailsManager" >
+	<beans:bean id="jdbcUserService" class="org.egovframe.rte.fdl.security.userdetails.jdbc.EgovJdbcUserDetailsManager" >
 		<beans:property name="usersByUsernameQuery" value="SELECT USER_ID,PASSWORD,ENABLED,USER_NAME,BIRTH_DAY,SSN FROM USERS WHERE USER_ID = ?"/>
 		<beans:property name="authoritiesByUsernameQuery" value="SELECT USER_ID,AUTHORITY FROM AUTHORITIES WHERE USER_ID = ?"/>
 		<beans:property name="roleHierarchy" ref="roleHierarchy"/>
 		<beans:property name="dataSource" ref="dataSource"/>
-		<beans:property name="mapClass" value="egovframework.rte.fdl.security.userdetails.EgovUserDetailsMapping"/>
+		<beans:property name="mapClass" value="org.egovframe.rte.fdl.security.userdetails.EgovUserDetailsMapping"/>
 	</beans:bean>
 ```
 
-- class : egovframework.rte.fdl.security.userdetails.jdbc.EgovJdbcUserDetailsManager
+- class : org.egovframe.rte.fdl.security.userdetails.jdbc.EgovJdbcUserDetailsManager
 - usersByUsernameQuery : 사용자 인증을 위해 사용자 테이블에서 사용자정보를 조회한다.
 - authoritiesByUsernameQuery : 사용자 인증을 위해 사용자권한 테이블에서 사용자권한정보를 조회한다.
 - roleHierarchy : 역할의 계층적 관리를 위해 계층 역할을 설정한다.
@@ -243,12 +243,12 @@ resourceType을 pointcut으로 설정하여 securedObjectService의 getRolesAndP
   
 #### Configuration
 ```xml
-<beans:bean id="securedObjectService" class="egovframework.rte.fdl.security.securedobject.impl.SecuredObjectServiceImpl">
+<beans:bean id="securedObjectService" class="org.egovframe.rte.fdl.security.secureobject.impl.SecuredObjectServiceImpl">
 	<beans:property name="securedObjectDAO" ref="securedObjectDAO"/>
 	<beans:property name="requestMatcherType" value="regex"/>	<!--  default : ant -->
 </beans:bean>
  
-<beans:bean id="securedObjectDAO" class="egovframework.rte.fdl.security.securedobject.impl.SecuredObjectDAO" >
+<beans:bean id="securedObjectDAO" class="org.egovframe.rte.fdl.security.secureobject.impl.SecuredObjectDAO" >
 	<beans:property name="dataSource" ref="dataSource"/>
 </beans:bean>
 ```
@@ -283,7 +283,7 @@ AND a.resource_type = 'pointcut' ORDER BY a.sort_order
 ```
 SecuredObjectDAO 빈에 내장된 SQL을 사용하지 않을 경우 아래와 같이 SQL을 지정하여 설정한다.
 ```XML
-<beans:bean id="securedObjectDAO" class="egovframework.rte.fdl.security.securedobject.impl.SecuredObjectDAO" >
+<beans:bean id="securedObjectDAO" class="org.egovframe.rte.fdl.security.secureobject.impl.SecuredObjectDAO" >
 	<beans:property name="dataSource" ref="dataSource"/>
 	<beans:property name="sqlHierarchicalRoles">
 		<beans:value>

--- a/egovframe-runtime/integration-layer/integration-service-api.md
+++ b/egovframe-runtime/integration-layer/integration-service-api.md
@@ -45,8 +45,8 @@ package itl.sample;
  
 import jakarta.annotation.Resource;
  
-import egovframework.rte.itl.integration.EgovIntegrationContext;
-import egovframework.rte.itl.integration.EgovIntegrationService;
+import org.egovframe.rte.itl.integration.EgovIntegrationContext;
+import org.egovframe.rte.itl.integration.EgovIntegrationService;
  
 public class EgovIntegrationSample
 {
@@ -512,8 +512,8 @@ EgovIntegrationServiceProvider interface는 연계 서비스를 제공하기 위
 ```java
 package itl.sample;
  
-import egovframework.rte.itl.integration.EgovIntegrationMessage;
-import egovframework.rte.itl.integration.EgovIntegrationServiceProvider;
+import org.egovframe.rte.itl.integration.EgovIntegrationMessage;
+import org.egovframe.rte.itl.integration.EgovIntegrationServiceProvider;
  
 public class ServiceVerifyName implements EgovIntegrationServiceProvider
 {

--- a/egovframe-runtime/integration-layer/webservice.md
+++ b/egovframe-runtime/integration-layer/webservice.md
@@ -385,7 +385,7 @@ WebService를 위한 기본적인 설정이 포함된 “context-webservice.xml�
     <!-- EgovWebServiceContext 이다.
          organizationId 와 systemId 는 현재 시스템의 기관ID 및 시스템ID를 넣어야 한다. -->
     <bean id="egovWebServiceContext"
-          class="egovframework.rte.itl.webservice.EgovWebServiceContext"
+          class="org.egovframe.rte.itl.webservice.EgovWebServiceContext"
           init-method="init">
         <property name="organizationId" value="ORG_EGOV"/>
         <property name="systemId" value="SYS00001"/>
@@ -533,7 +533,7 @@ web.xml에 EgovWebServiceServlet 설정을 추가한다.
         <description></description>
         <display-name>EgovWebServiceServlet</display-name>
         <servlet-name>EgovWebServiceServlet</servlet-name>
-        <servlet-class>egovframework.rte.itl.webservice.EgovWebServiceServlet</servlet-class>
+        <servlet-class>org.egovframe.rte.itl.webservice.EgovWebServiceServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
     <servlet-mapping>

--- a/egovframe-runtime/persistence-layer/dataaccess-configuration_xml.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-configuration_xml.md
@@ -38,12 +38,12 @@ menu:
 	</settings>
  
 	<typeHandlers>
-		<typeHandler handler="egovframework.rte.psl.dataaccess.typehandler.CalendarMapperTypeHandler" />
+		<typeHandler handler="org.egovframe.rte.psl.dataaccess.typehandler.CalendarMapperTypeHandler" />
 	</typeHandlers>
  
 	<typeAliases>
-		<typeAlias alias="deptVO" type="egovframework.rte.psl.dataaccess.vo.DeptVO" />
-		<typeAlias alias="empVO" type="egovframework.rte.psl.dataaccess.vo.EmpVO" />
+		<typeAlias alias="deptVO" type="org.egovframe.rte.psl.dataaccess.vo.DeptVO" />
+		<typeAlias alias="empVO" type="org.egovframe.rte.psl.dataaccess.vo.EmpVO" />
 	.
 	.
 	. 

--- a/egovframe-runtime/persistence-layer/dataaccess-data_type.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-data_type.md
@@ -223,10 +223,10 @@ create table TYPETEST (
 <sqlMap namespace="TypeTest">
  
 	<typeAlias alias="typeTestVO"
-		type="egovframework.rte.psl.dataaccess.vo.TypeTestVO" />
+		type="org.egovframe.rte.psl.dataaccess.vo.TypeTestVO" />
  
 	<!-- CalendarTypeHandler 는 sql-map-config.xml 에 등록하였음 -->
-	<typeAlias alias="calendarTypeHandler" type="egovframework.rte.psl.dataaccess.typehandler.CalendarTypeHandler"/>
+	<typeAlias alias="calendarTypeHandler" type="org.egovframe.rte.psl.dataaccess.typehandler.CalendarTypeHandler"/>
  
 	<resultMap id="typeTestResult" class="typeTestVO">
 		<result property="id" column="ID" />

--- a/egovframe-runtime/persistence-layer/dataaccess-dynamic_sql.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-dynamic_sql.md
@@ -22,7 +22,7 @@ menu:
 
 ```xml
 	..
-	<typeAlias alias="jobHistVO" type="egovframework.rte.psl.dataaccess.vo.JobHistVO" />
+	<typeAlias alias="jobHistVO" type="org.egovframe.rte.psl.dataaccess.vo.JobHistVO" />
  
 	<select id="selectJobHistListUsingDynamicElement" parameterClass="jobHistVO" resultClass="jobHistVO">
 		<![CDATA[
@@ -99,7 +99,7 @@ menu:
 
 ```xml
 	..
-	<typeAlias alias="egovMap" type="egovframework.rte.psl.dataaccess.util.EgovMap" />
+	<typeAlias alias="egovMap" type="org.egovframe.rte.psl.dataaccess.util.EgovMap" />
  
 	<select id="selectDynamicUnary" parameterClass="map" remapResults="true" resultClass="egovMap">
 		select
@@ -240,7 +240,7 @@ menu:
 
 ```xml
 	..
-	<typeAlias alias="egovMap" type="egovframework.rte.psl.dataaccess.util.EgovMap" />
+	<typeAlias alias="egovMap" type="org.egovframe.rte.psl.dataaccess.util.EgovMap" />
  
 	<select id="selectDynamicBinary" parameterClass="map" remapResults="true" resultClass="egovMap">
 		select
@@ -525,7 +525,7 @@ menu:
 
 ```xml
 	..
-	<typeAlias alias="egovMap" type="egovframework.rte.psl.dataaccess.util.EgovMap" />
+	<typeAlias alias="egovMap" type="org.egovframe.rte.psl.dataaccess.util.EgovMap" />
  
 	<select id="selectDynamicParameterPresent" parameterClass="map" remapResults="true" resultClass="egovMap">
 		select 
@@ -597,8 +597,8 @@ menu:
 
 ```xml
 	..
- 	<typeAlias alias="jobHistVO" type="egovframework.rte.psl.dataaccess.vo.JobHistVO" />
-	<typeAlias alias="empIncludesEmpListVO" type="egovframework.rte.psl.dataaccess.vo.EmpIncludesEmpListVO" />
+ 	<typeAlias alias="jobHistVO" type="org.egovframe.rte.psl.dataaccess.vo.JobHistVO" />
+	<typeAlias alias="empIncludesEmpListVO" type="org.egovframe.rte.psl.dataaccess.vo.EmpIncludesEmpListVO" />
  
 	<select id="selectJobHistListUsingDynamicIterate" parameterClass="empIncludesEmpListVO" resultClass="jobHistVO">
 		<![CDATA[

--- a/egovframe-runtime/persistence-layer/dataaccess-getting_started.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-getting_started.md
@@ -75,7 +75,7 @@ SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(confi
 ```java
  SqlSession session = sqlSessionFactory.openSession();
  try {
-   Dept dept = session.selectOne("egovframework.rte.psl.dataaccess.DeptMapper.selectDept", 101);
+   Dept dept = session.selectOne("org.egovframe.rte.psl.dataaccess.DeptMapper.selectDept", 101);
  } finally {
    session.close();
  }
@@ -109,7 +109,7 @@ try {
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
      "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="egovframework.rte.psl.dataaccess.DeptMapper">
+<mapper namespace="org.egovframe.rte.psl.dataaccess.DeptMapper">
 	<select id="selectDept" 
                 parameterType="int" 
                      resultType="Dept">
@@ -123,9 +123,9 @@ try {
 
 ```
 
- 한 개의 매퍼 XML 파일에는 많은 수의 매핑 구문을 정의할 수 있다. XML 도입부의 헤더와 doctype 을 제외하면, 나머지는 쉽게 이해되는 구문의 형태이다. 여기선 egovframework.rte.psl.dataaccess.DeptMapper 명명공간에서 selectDept 라는 매핑 구문을 정의했고, 이는 결과적으로 egovframework.rte.psl.dataaccess.DeptMapper.selectDept 형태로 실제 명시되게 된다. 그래서 다음처럼 사용하게 되는 셈이다.
+ 한 개의 매퍼 XML 파일에는 많은 수의 매핑 구문을 정의할 수 있다. XML 도입부의 헤더와 doctype 을 제외하면, 나머지는 쉽게 이해되는 구문의 형태이다. 여기선 org.egovframe.rte.psl.dataaccess.DeptMapper 명명공간에서 selectDept 라는 매핑 구문을 정의했고, 이는 결과적으로 org.egovframe.rte.psl.dataaccess.DeptMapper.selectDept 형태로 실제 명시되게 된다. 그래서 다음처럼 사용하게 되는 셈이다.
 
- Dept dept = (Dept) session.selectOne(“egovframework.rte.psl.dataaccess.DeptMapper.selectDept”, 101); 이건 마치 패키지를 포함한 전체 경로의 클래스내 메서드를 호출하는 것과 비슷한 형태이다. 이 이름은 매핑된 select 구문의 이름과 파라미터 그리고 리턴 타입을 가진 명명공간과 같은 이름의 Mapper 클래스와 직접 매핑될 수 있다. 이건 위에서 본 것과 같은 Mapper 인터페이스의 메서드를 간단히 호출하도록 허용한다. 위 예제에 대응되는 형태는 아래와 같다.
+ Dept dept = (Dept) session.selectOne(“org.egovframe.rte.psl.dataaccess.DeptMapper.selectDept”, 101); 이건 마치 패키지를 포함한 전체 경로의 클래스내 메서드를 호출하는 것과 비슷한 형태이다. 이 이름은 매핑된 select 구문의 이름과 파라미터 그리고 리턴 타입을 가진 명명공간과 같은 이름의 Mapper 클래스와 직접 매핑될 수 있다. 이건 위에서 본 것과 같은 Mapper 인터페이스의 메서드를 간단히 호출하도록 허용한다. 위 예제에 대응되는 형태는 아래와 같다.
 
  DeptMapper mapper = session.getMapper(DeptMapper.class); Dept dept = mapper.selectDept(101); 두번째 방법은 많은 장점을 가진다. 먼저 문자열에 의존하지 않는다는 것이다. 이는 애플리케이션을 좀더 안전하게 만든다. 두번째는 개발자가 IDE 를 사용할 때, 매핑된 SQL 구문을 사용할 때의 수고를 덜어준다. 세번째는 리턴 타입에 대해 타입 캐스팅을 하지 않아도 된다. 그래서 DeptMapper 인터페이스는 깔끔하고 리턴 타입에 대해 타입에 안전하며 이는 파라미터에도 그대로 적용된다.
 

--- a/egovframe-runtime/persistence-layer/dataaccess-ibatis.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-ibatis.md
@@ -71,14 +71,14 @@ menu:
 
 ```xml
 <!-- SqlMap setup for iBATIS Database Layer -->
-<bean id="sqlMapClient" class="egovframework.rte.psl.orm.ibatis.SqlMapClientFactoryBean">
+<bean id="sqlMapClient" class="org.egovframe.rte.psl.orm.ibatis.SqlMapClientFactoryBean">
     <property name="configLocation" value="classpath:/META-INF/sqlmap/sql-map-config.xml"/>
     <property name="dataSource" ref="dataSource"/>
 </bean>
 ```
 
 - Spring 연동 기능을 사용하면 iBATIS 의 SqlMapClient(a thread safe client for SQL Maps) 를 별도의 iBATIS API 없이도 얻을 수 있게 된다.
-- 실행환경 3.5 부터는 Spring 4 변경에 따라 org.springframework.orm.ibatis.SqlMapClientFactoryBean 클래스가 egovframework.rte.psl.orm.ibatis.SqlMapClientFactoryBean 로 변경된다.
+- 실행환경 3.5 부터는 Spring 4 변경에 따라 org.springframework.orm.ibatis.SqlMapClientFactoryBean 클래스가 org.egovframe.rte.psl.orm.ibatis.SqlMapClientFactoryBean 로 변경된다.
 
  아래는 주된 iBATIS 의 SQL Map XML Configuration 파일(sql-map-config.xml 설정 파일)이다. iBATIS 단독으로 쓰일 때는 transactionManager, dataSource 설정 등을 추가로 포함해야 하지만 Spring 연동 환경에서는 이 부분은 Spring 이 넘겨주는 dataSource 를 자동으로 사용하게 되고 transaction 관리는 비즈니스 서비스 영역에 선언적으로 설정하여 iBATIS 관련 모듈에서는 고민할 필요가 없게 된다.
 
@@ -94,7 +94,7 @@ menu:
 	/>
  
 	<typeHandler javaType="java.util.Calendar" jdbcType="TIMESTAMP"
-		callback="egovframework.rte.psl.dataaccess.typehandler.CalendarTypeHandler" />
+		callback="org.egovframe.rte.psl.dataaccess.typehandler.CalendarTypeHandler" />
  
 	<sqlMap resource="META-INF/sqlmap/mappings/testcase-basic.xml" />
 	<sqlMap ../>
@@ -112,7 +112,7 @@ menu:
 
 ```xml
 	<!-- SqlMap setup for iBATIS Database Layer -->
-	<bean id="sqlMapClient" class="egovframework.rte.psl.orm.ibatis.SqlMapClientFactoryBean">
+	<bean id="sqlMapClient" class="org.egovframe.rte.psl.orm.ibatis.SqlMapClientFactoryBean">
 		<property name="configLocation" value="classpath:/META-INF/sqlmap/sql-map-config.xml"/>
 		<!-- Java 1.5 or higher and iBATIS 2.3.2 or higher REQUIRED -->
      		<property name="mappingLocations" value="classpath:/META-INF/sqlmap/mappings/**/*.xml" />

--- a/egovframe-runtime/persistence-layer/dataaccess-ibatis_configuration.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-ibatis_configuration.md
@@ -35,7 +35,7 @@ menu:
 		defaultStatementTimeout="1" />
  
 	<typeHandler javaType="java.util.Calendar" jdbcType="TIMESTAMP"
-		callback="egovframework.rte.psl.dataaccess.typehandler.CalendarTypeHandler" />
+		callback="org.egovframe.rte.psl.dataaccess.typehandler.CalendarTypeHandler" />
  
 	<transactionManager type="JDBC">
 		<dataSource type="DBCP">

--- a/egovframe-runtime/persistence-layer/dataaccess-inline_parameters.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-inline_parameters.md
@@ -21,7 +21,7 @@ menu:
 
 ```xml
 	..
-	<typeAlias alias="empVO" type="egovframework.rte.psl.dataaccess.vo.EmpVO" />
+	<typeAlias alias="empVO" type="org.egovframe.rte.psl.dataaccess.vo.EmpVO" />
  
 	<insert id="insertEmptUsingInLineParam">
 		<![CDATA[

--- a/egovframe-runtime/persistence-layer/dataaccess-mapper_xml_files.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-mapper_xml_files.md
@@ -33,9 +33,9 @@ Mapper XML File에는 다음과 같은 요소들을 사용할 수 있다.
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="egovframework.rte.psl.dataaccess.DeptMapper"> <!-- MyBatis에서는 namespace를 필수로 설정해야함 -->
+<mapper namespace="org.egovframe.rte.psl.dataaccess.DeptMapper"> <!-- MyBatis에서는 namespace를 필수로 설정해야함 -->
 
-    <resultMap id="deptResult" type="egovframework.rte.psl.dataaccess.vo.DeptVO"> <!-- [주의] iBatis의 class속성 -> type속성으로 변경 -->
+    <resultMap id="deptResult" type="org.egovframe.rte.psl.dataaccess.vo.DeptVO"> <!-- [주의] iBatis의 class속성 -> type속성으로 변경 -->
         <result property="deptNo" column="DEPT_NO" />
         <result property="deptName" column="DEPT_NAME" />
         <result property="loc" column="LOC" />
@@ -49,7 +49,7 @@ Mapper XML File에는 다음과 같은 요소들을 사용할 수 있다.
         ]]>
     </select>
 
-    <insert id="insertDept" parameterType="egovframework.rte.psl.dataaccess.vo.DeptVO">
+    <insert id="insertDept" parameterType="org.egovframe.rte.psl.dataaccess.vo.DeptVO">
         <![CDATA[
             insert into DEPT
                        (DEPT_NO, DEPT_NAME, LOC)
@@ -57,7 +57,7 @@ Mapper XML File에는 다음과 같은 요소들을 사용할 수 있다.
         ]]>
     </insert>
 
-    <update id="updateDept" parameterType="egovframework.rte.psl.dataaccess.vo.DeptVO">
+    <update id="updateDept" parameterType="org.egovframe.rte.psl.dataaccess.vo.DeptVO">
         <![CDATA[
             update DEPT
             set    DEPT_NAME = #{deptName},
@@ -66,7 +66,7 @@ Mapper XML File에는 다음과 같은 요소들을 사용할 수 있다.
         ]]>
     </update>
 
-    <delete id="deleteDept" parameterType="egovframework.rte.psl.dataaccess.vo.DeptVO">
+    <delete id="deleteDept" parameterType="org.egovframe.rte.psl.dataaccess.vo.DeptVO">
         <![CDATA[
             delete from DEPT
             where       DEPT_NO = #{deptNo}
@@ -138,7 +138,7 @@ SELECT 결과를 'deptResult'라는 이름을 가진 `<resultMap>` 설정에 따
 - 기본 예제
 
 ```xml
-<insert id="insertDept" parameterType="egovframework.rte.psl.dataaccess.vo.DeptVO">
+<insert id="insertDept" parameterType="org.egovframe.rte.psl.dataaccess.vo.DeptVO">
     <![CDATA[
         insert into DEPT (DEPT_NO, DEPT_NAME, LOC)
         values (#{deptNo}, #{deptName}, #{loc}) <!-- 파라미터 바인딩 표기법 #{property} -->
@@ -146,7 +146,7 @@ SELECT 결과를 'deptResult'라는 이름을 가진 `<resultMap>` 설정에 따
 </insert>
 ```
 
-위의 `<insert>` 구문은 'insertDept'를 이용하여 호출하며, 'egovframework.rte.psl.dataaccess.vo.DeptVO' 타입의 파라미터를 받아와 INSERT 절에 바인딩한다.
+위의 `<insert>` 구문은 'insertDept'를 이용하여 호출하며, 'org.egovframe.rte.psl.dataaccess.vo.DeptVO' 타입의 파라미터를 받아와 INSERT 절에 바인딩한다.
 
 ## 2. `<update>`
 
@@ -163,7 +163,7 @@ SELECT 결과를 'deptResult'라는 이름을 가진 `<resultMap>` 설정에 따
 ### 기본 예제
 
 ```xml
-<update id="updateDept" parameterType="egovframework.rte.psl.dataaccess.vo.DeptVO">
+<update id="updateDept" parameterType="org.egovframe.rte.psl.dataaccess.vo.DeptVO">
     <![CDATA[
         update DEPT
         set    DEPT_NAME = #{deptName}, <!-- 파라미터 바인딩 표기법 #{property} -->
@@ -173,7 +173,7 @@ SELECT 결과를 'deptResult'라는 이름을 가진 `<resultMap>` 설정에 따
 </update>
 ```
 
-위의 <update> 구문은 'updateDept'를 이용하여 호출하며, 'egovframework.rte.psl.dataaccess.vo.DeptVO' 타입의 파라미터를 받아와 UPDATE절에 바인딩한다.
+위의 <update> 구문은 'updateDept'를 이용하여 호출하며, 'org.egovframe.rte.psl.dataaccess.vo.DeptVO' 타입의 파라미터를 받아와 UPDATE절에 바인딩한다.
 
 ## 3. `<delete>`
 
@@ -190,7 +190,7 @@ SELECT 결과를 'deptResult'라는 이름을 가진 `<resultMap>` 설정에 따
 - 기본 예제
 
 ```xml
-<delete id="deleteDept" parameterType="egovframework.rte.psl.dataaccess.vo.DeptVO">
+<delete id="deleteDept" parameterType="org.egovframe.rte.psl.dataaccess.vo.DeptVO">
     <![CDATA[
         delete from DEPT
         where DEPT_NO = #{deptNo} -- 파라미터 바인딩 표기법 #{property}
@@ -198,14 +198,14 @@ SELECT 결과를 'deptResult'라는 이름을 가진 `<resultMap>` 설정에 따
 </delete>
 ```
 
-위의 `<delete>` 구문은 `deleteDept`를 이용하여 호출하며, `egovframework.rte.psl.dataaccess.vo.DeptVO` 타입의 파라미터를 받아와 WHERE절에 바인딩한다.
+위의 `<delete>` 구문은 `deleteDept`를 이용하여 호출하며, `org.egovframe.rte.psl.dataaccess.vo.DeptVO` 타입의 파라미터를 받아와 WHERE절에 바인딩한다.
 
 ### 참고
 parameterType에 지정한 전체 클래스명이 복잡하다면, 해당 클래스타입에 대한 Alias(별칭)로 대체할 수 있다.
 
 ```xml
 <!-- In MyBatis Configuration XML File -->
-<typeAlias type="egovframework.rte.psl.dataaccess.vo.DeptVO" alias="deptVO" />
+<typeAlias type="org.egovframe.rte.psl.dataaccess.vo.DeptVO" alias="deptVO" />
 
 <!-- Mapper XML File -->
 <delete id="deleteDept" parameterType="deptVO">
@@ -238,7 +238,7 @@ parameterType에 지정한 전체 클래스명이 복잡하다면, 해당 클래
 예제 코드에서 파라미터를 전달하는 간단한 구문을 살펴보도록 하겠다.
 
 ```xml
-<insert id="insertDept" parameterType="egovframework.rte.psl.dataaccess.vo.DeptVO">
+<insert id="insertDept" parameterType="org.egovframe.rte.psl.dataaccess.vo.DeptVO">
     <![CDATA[
         insert into DEPT
                    (DEPT_NO,
@@ -252,7 +252,7 @@ parameterType에 지정한 전체 클래스명이 복잡하다면, 해당 클래
 ```
 
 
-위에서 egovframework.rte.psl.dataaccess.vo.DeptVO 클래스 타입의 객체가 mapper 오브젝트를 통해 전달될 경우 해당 객체의 deptNo, deptName, loc를 찾아서 PreparedStatement 파라미터로 전달된다.
+위에서 org.egovframe.rte.psl.dataaccess.vo.DeptVO 클래스 타입의 객체가 mapper 오브젝트를 통해 전달될 경우 해당 객체의 deptNo, deptName, loc를 찾아서 PreparedStatement 파라미터로 전달된다.
 
 추가적으로 파라미터 전달 시 파라미터에 다음과 같은 형태로 데이터 타입을 명시할 수 있다:
 
@@ -274,13 +274,13 @@ parameterType에 지정한 전체 클래스명이 복잡하다면, 해당 클래
 
 ```
 <!-- 기본 예제 코드 -->
-<resultMap id="deptResult" type="egovframework.rte.psl.dataaccess.vo.DeptVO">
+<resultMap id="deptResult" type="org.egovframe.rte.psl.dataaccess.vo.DeptVO">
     <result property="deptNo" column="DEPT_NO" />
     <result property="deptName" column="DEPT_NAME" />
     <result property="loc" column="LOC" />
 </resultMap>
 
-<select id="selectDept" parameterType="egovframework.rte.psl.dataaccess.vo.DeptVO" resultMap="deptResult">
+<select id="selectDept" parameterType="org.egovframe.rte.psl.dataaccess.vo.DeptVO" resultMap="deptResult">
 		<![CDATA[
 			select DEPT_NO,DEPT_NAME,LOC
 			from   DEPT
@@ -296,7 +296,7 @@ SELECT문 결과값은 **`<select>`에 지정한 `resultMap` 속성값에 따라
 단, 아래와 같이 `resultType` 속성을 이용하는 경우에는 DB 컬럼명과 프로퍼티명이 동일해야 한다.
 
 ```xml
-<select id="selectDept" parameterType="egovframework.rte.psl.dataaccess.vo.DeptVO" resultType="egovframework.rte.psl.dataaccess.vo.DeptVO">
+<select id="selectDept" parameterType="org.egovframe.rte.psl.dataaccess.vo.DeptVO" resultType="org.egovframe.rte.psl.dataaccess.vo.DeptVO">
     <![CDATA[
         select deptno, deptname, loc
         from   DEPT

--- a/egovframe-runtime/persistence-layer/dataaccess-mybatis-dynamic-sql.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-mybatis-dynamic-sql.md
@@ -27,7 +27,7 @@ MyBatis에서 제공하는 Dynamic 요소의 기본적인 형태에 대해 알�
 아래 Sql 매퍼 파일은 파라미터 객체의 empNo 속성의 값 유무에 따라 `where EMP_NO = #{empNo}` 조건절을 동적으로 추가/제거할 수 있는 예이다.
 
 ```xml
-	<select id="selectJobHistListUsingDynamicElement" parameterType="egovframework.rte.psl.dataaccess.vo.JobHistVO" resultMap="egovframework.rte.psl.dataaccess.vo.JobHistVO">
+	<select id="selectJobHistListUsingDynamicElement" parameterType="org.egovframe.rte.psl.dataaccess.vo.JobHistVO" resultMap="org.egovframe.rte.psl.dataaccess.vo.JobHistVO">
 		<![CDATA[
 			select EMP_NO     as empNo,
 			       START_DATE as startDate,
@@ -56,7 +56,7 @@ where 절 안에 사용되며 if 안에 해당 값이 존재하지 않으면 모
 
 ```xml
         ..
-	<select id="selectEmployerList" parameterType="egovframework.rte.psl.dataaccess.vo.EmpVO" resultType="egovframework.rte.psl.dataaccess.vo.EmpVO">
+	<select id="selectEmployerList" parameterType="org.egovframe.rte.psl.dataaccess.vo.EmpVO" resultType="org.egovframe.rte.psl.dataaccess.vo.EmpVO">
 		<![CDATA[
 			select
 				EMP_NO as empNo,
@@ -89,7 +89,7 @@ where 절 안에 사용되며 if 안에 해당 값이 존재하지 않으면 모
 두 가지 값을 모두 제공하지 않는다면 HIRE 상태인 Employee 정보가 리턴될 것이다.
 
 ```xml
-	<select id="selectEmployeeList" parameterType="egovframework.rte.psl.dataaccess.vo.EmpVO" resultType="egovframework.rte.psl.dataaccess.vo.EmpVO">
+	<select id="selectEmployeeList" parameterType="org.egovframe.rte.psl.dataaccess.vo.EmpVO" resultType="org.egovframe.rte.psl.dataaccess.vo.EmpVO">
 		SELECT * FROM EMP WHERE JOB = 'Engineer'
 		<choose>
 			<when test="mgr ! null">
@@ -111,8 +111,8 @@ where 절 안에 사용되며 if 안에 해당 값이 존재하지 않으면 모
 
 ```xml
 	..
-	<select id="selectEmployerList" parameterType="egovframework.rte.psl.dataaccess.vo.EmpVO"
-		resultType="egovframework.rte.psl.dataaccess.vo.EmpVO">
+	<select id="selectEmployerList" parameterType="org.egovframe.rte.psl.dataaccess.vo.EmpVO"
+		resultType="org.egovframe.rte.psl.dataaccess.vo.EmpVO">
 		<![CDATA[
 			select
 				EMP_NO as empNo,
@@ -143,7 +143,7 @@ foreach 요소는 매우 강력한 기능을 제공하는데 그중 하나가 co
 foreach 요소에서는 item, index 두 가지 변수를 선언하며, 이 요소는 열고 닫는 문자열로 명시할 수 있고 반복 간에 둘 수 있는 구분자도 추가 가능하다.
 
 ```xml
-	<select id="selectJobHistListUsingDynamicNestedIterate" parameterType="egovframework.rte.psl.dataaccess.util.EgovMap" resultMap="jobHistVO">
+	<select id="selectJobHistListUsingDynamicNestedIterate" parameterType="org.egovframe.rte.psl.dataaccess.util.EgovMap" resultMap="jobHistVO">
 		<![CDATA[
 			select EMP_NO     as empNo,
 			       START_DATE as startDate,

--- a/egovframe-runtime/persistence-layer/dataaccess-mybatis-guide.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-mybatis-guide.md
@@ -118,8 +118,8 @@ public interface EmployerMapper  {
 Ex: context-mapper.xml
 
 ```xml
-<bean class="egovframework.rte.psl.dataaccess.mapper.MapperConfigurer">
-	<property name="basePackage" value="egovframework.rte.**.mapper" />
+<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+	<property name="basePackage" value="org.egovframe.rte.**.mapper" />
 </bean>
 ```
 

--- a/egovframe-runtime/persistence-layer/dataaccess-parametermap.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-parametermap.md
@@ -21,7 +21,7 @@ menu:
 
 ```xml
 	..
-	<typeAlias alias="empVO" type="egovframework.rte.psl.dataaccess.vo.EmpVO" />
+	<typeAlias alias="empVO" type="org.egovframe.rte.psl.dataaccess.vo.EmpVO" />
  
 	<parameterMap id="empParam" class="empVO">
 		<parameter property="empNo" javaType="decimal" jdbcType="NUMERIC" />

--- a/egovframe-runtime/persistence-layer/dataaccess-resultmap.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-resultmap.md
@@ -21,7 +21,7 @@ menu:
 
 ```xml
 	..
-	<typeAlias alias="empVO" type="egovframework.rte.psl.dataaccess.vo.EmpVO" />
+	<typeAlias alias="empVO" type="org.egovframe.rte.psl.dataaccess.vo.EmpVO" />
  
 	<resultMap id="empResult" class="empVO" >
 		<result property="empNo" column="EMP_NO" columnIndex="1"
@@ -149,7 +149,7 @@ public class EmpExtendsDeptVO extends DeptVO {
 
 ```xml
 	..
-	<typeAlias alias="empExtendsDeptVO" type="egovframework.rte.psl.dataaccess.vo.EmpExtendsDeptVO" />
+	<typeAlias alias="empExtendsDeptVO" type="org.egovframe.rte.psl.dataaccess.vo.EmpExtendsDeptVO" />
  
 	<!--
 		cf.) VO 의 상속관계와 resultMap의 상속관계가 같을 필요는 없음. 아래의 empExtendsDeptResult 가
@@ -270,7 +270,7 @@ public class EmpDeptSimpleCompositeVO implements Serializable {
 
 ```xml
 	..
-	<typeAlias alias="empDeptSimpleCompositeVO" type="egovframework.rte.psl.dataaccess.vo.EmpDeptSimpleCompositeVO" />
+	<typeAlias alias="empDeptSimpleCompositeVO" type="org.egovframe.rte.psl.dataaccess.vo.EmpDeptSimpleCompositeVO" />
  
 	<resultMap id="empDeptSimpleComposite" class="empDeptSimpleCompositeVO" >
 		<result property="empNo" column="EMP_NO"/>
@@ -400,7 +400,7 @@ public class EmpIncludesDeptVO implements Serializable {
 ```xml
 <sqlMap namespace="EmpComplexResult">
 	..
-	<typeAlias alias="empIncludesDeptVO" type="egovframework.rte.psl.dataaccess.vo.EmpIncludesDeptVO" />
+	<typeAlias alias="empIncludesDeptVO" type="org.egovframe.rte.psl.dataaccess.vo.EmpIncludesDeptVO" />
  
 	<resultMap id="empIncludesDeptResult" class="empIncludesDeptVO">
 		<result property="empNo" column="EMP_NO" />
@@ -522,7 +522,7 @@ public class DeptIncludesEmpListVO implements Serializable {
 ```xml
 <sqlMap namespace="EmpComplexResult">
 	..
-	<typeAlias alias="deptIncludesEmpListVO" type="egovframework.rte.psl.dataaccess.vo.DeptIncludesEmpListVO" />
+	<typeAlias alias="deptIncludesEmpListVO" type="org.egovframe.rte.psl.dataaccess.vo.DeptIncludesEmpListVO" />
  
 	<!-- 1:N 인 경우 groupBy 속성을 명시 -->
 	<resultMap id="deptIncludesEmpListResult" class="deptIncludesEmpListVO" groupBy="deptNo">
@@ -869,7 +869,7 @@ public class EmpIncludesMgrVO implements Serializable {
 ```xml
 <sqlMap namespace="EmpComplexResult">
 	..
-	<typeAlias alias="empIncludesMgrVO" type="egovframework.rte.psl.dataaccess.vo.EmpIncludesMgrVO" />
+	<typeAlias alias="empIncludesMgrVO" type="org.egovframe.rte.psl.dataaccess.vo.EmpIncludesMgrVO" />
  
 	<!-- Hierarchical relation 인 경우 ibatis resultMap select 에 의한 처리 예 -->
 	<resultMap id="empIncludesMgrResult" class="empIncludesMgrVO" extends="getEmpResult">

--- a/egovframe-runtime/persistence-layer/dataaccess-spring_ibatis_integration.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-spring_ibatis_integration.md
@@ -31,7 +31,7 @@ menu:
 	</bean>
  
 	<!-- SqlMap setup for iBATIS Database Layer -->
-	<bean id="sqlMapClient" class="egovframework.rte.psl.orm.ibatis.SqlMapClientFactoryBean">
+	<bean id="sqlMapClient" class="org.egovframe.rte.psl.orm.ibatis.SqlMapClientFactoryBean">
 		<property name="configLocation" value="classpath:/META-INF/sqlmap/sql-map-config.xml"/>
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
@@ -48,7 +48,7 @@ menu:
 
 ```xml
 	<!-- SqlMap setup for iBATIS Database Layer -->
-	<bean id="sqlMapClient" class="egovframework.rte.psl.orm.ibatis.SqlMapClientFactoryBean">
+	<bean id="sqlMapClient" class="org.egovframe.rte.psl.orm.ibatis.SqlMapClientFactoryBean">
 		<property name="configLocation"
 			value="classpath:/META-INF/sqlmap/sql-map-config.xml" />
 		<property name="mappingLocations"
@@ -73,7 +73,7 @@ menu:
 	/>
  
 	<typeHandler javaType="java.util.Calendar" jdbcType="TIMESTAMP"
-		callback="egovframework.rte.psl.dataaccess.typehandler.CalendarTypeHandler" />
+		callback="org.egovframe.rte.psl.dataaccess.typehandler.CalendarTypeHandler" />
  
 	<!-- Spring 2.5.5 이상, iBATIS 2.3.2 이상에서는 iBATIS 연동을 위한 SqlMapClientFactoryBean 정의 시 
                mappingLocations 속성으로 Sql 매핑 파일의 일괄 지정이 가능하다. 

--- a/egovframe-runtime/persistence-layer/mongodb-repositories.md
+++ b/egovframe-runtime/persistence-layer/mongodb-repositories.md
@@ -29,7 +29,7 @@ MongoDB에 대한 repository를 사용하기 위해서는 다음과 같은 mongo
     </bean>
 
     <!-- for Repository -->
-    <mongo:repositories base-package="egovframework.rte.psl.data.mongodb.repository" />
+    <mongo:repositories base-package="org.egovframe.rte.psl.data.mongodb.repository" />
 
 </beans>
 ```

--- a/egovframe-runtime/persistence-layer/mongodb-repositories3_5_1.md
+++ b/egovframe-runtime/persistence-layer/mongodb-repositories3_5_1.md
@@ -37,7 +37,7 @@ MongoDB에 대한 repository를 사용하기 위해서는 다음과 같은 mongo
     </bean>
 
     <!-- for Repository -->
-    <mongo:repositories base-package="egovframework.rte.psl.data.mongodb.repository" />
+    <mongo:repositories base-package="org.egovframe.rte.psl.data.mongodb.repository" />
 
 </beans>
 ```

--- a/egovframe-runtime/presentation-layer/web-servlet-view.md
+++ b/egovframe-runtime/presentation-layer/web-servlet-view.md
@@ -330,7 +330,7 @@ HTML select, option 태그에 commandName에 지정된 객체 프로퍼티를 �
 
 | 이름             | 설명                                                                                             | 필수여부 |
 |----------------|------------------------------------------------------------------------------------------------|------|
-| paginationInfo | 페이징리스트를 만들기 위해 필요한 데이터. 데이터 타입은 egovframework.rte.ptl.mvc.tags.ui.pagination.PaginationInfo이다. | yes  |
+| paginationInfo | 페이징리스트를 만들기 위해 필요한 데이터. 데이터 타입은 org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo이다. | yes  |
 | type           | 페이징리스트 렌더링을 담당할 클래스의 아이디. 이 아이디는 빈설정 파일에 선언된 프로퍼티 rendererType의 key값이다.                        | yes  |
 | jsFunction     | 페이지 번호에 걸리게 될 자바스크립트 함수 이름. 페이지 번호가 기본적인 argument로 전달된다.                                       | yes  |
 
@@ -345,9 +345,9 @@ type 속성은 빈 설정시에 rendererType 프로퍼티의 entry key값을 적
 <!-- For Pagination Tag -->	 
 <bean id="imageRenderer" class="com.easycompany.tag.ImagePaginationRenderer"/>
 
-<bean id="textRenderer" class="egovframework.rte.ptl.mvc.tags.ui.pagination.DefaultPaginationRenderer"/>
+<bean id="textRenderer" class="org.egovframe.rte.ptl.mvc.tags.ui.pagination.DefaultPaginationRenderer"/>
 
-<bean id="paginationManager" class="egovframework.rte.ptl.mvc.tags.ui.pagination.DefaultPaginationManager">
+<bean id="paginationManager" class="org.egovframe.rte.ptl.mvc.tags.ui.pagination.DefaultPaginationManager">
     <property name="rendererType">
         <map>
             <entry key="image" value-ref="imageRenderer"/>


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

실행환경 가이드가 4.0 이전의 클래스 표기를 그대로 쓰고 있습니다. 접두어가 `egovframework.rte` 인데 5.0.0 저장소에는 그 접두어로 시작하는 패키지 선언이 하나도 없습니다. 아래는 실행환경 저장소(`eGovFramework/egovframe-runtime`)에서 돌린 것입니다.

```
$ git log --oneline -1 origin/main
cc2b332 Merge pull request #379 from itcen-entec-2026/codex/fix-cmmn-service-logging-locale

$ git grep -lE '^package org\.egovframe\.rte' origin/main -- '*.java' | wc -l
     838

$ git grep -lE '^package egovframework\.rte' origin/main -- '*.java' | wc -l
       0

$ git show origin/main:pom.xml | grep -m1 -n "<version>"
7:    <version>5.0.0</version>
```

**파일 단위로 완결되게 고쳤습니다.** 문서 31개 129줄이고 손댄 문서에 옛 클래스 표기가 섞여 남지 않습니다. 대부분 접두어만 바뀌지만 패키지째 옮겨진 것도 있습니다. `fdl.security.intercept` 는 `fdl.security.bean` 으로, `fdl.security.securedobject` 는 `fdl.security.secureobject` 로, `fdl.cryptography` 는 `fdl.crypto` 로 갔습니다.

아래는 실행환경 저장소(`eGovFramework/egovframe-runtime`)에서 돌린 것입니다.

```
$ git ls-tree -r --name-only v4.3.0-Final | grep -c 'rte/fdl/security/intercept/'
6
$ git ls-tree -r --name-only v4.3.0-Final | grep -c 'rte/fdl/security/bean/'
0
$ git ls-tree -r --name-only v4.3.0-Final | grep -c 'rte/fdl/security/securedobject/'
6
$ git ls-tree -r --name-only v4.3.0-Final | grep -c 'rte/fdl/security/secureobject/'
0
$ git ls-tree -r --name-only v4.3.0-Final | grep -c 'rte/fdl/cryptography/'
30
$ git ls-tree -r --name-only v4.3.0-Final | grep -c 'rte/fdl/crypto/'
2
$ git ls-tree -r --name-only v5.0.1-Final | grep -c 'rte/fdl/security/intercept/'
0
$ git ls-tree -r --name-only v5.0.1-Final | grep -c 'rte/fdl/security/bean/'
14
$ git ls-tree -r --name-only v5.0.1-Final | grep -c 'rte/fdl/security/securedobject/'
0
$ git ls-tree -r --name-only v5.0.1-Final | grep -c 'rte/fdl/security/secureobject/'
7
$ git ls-tree -r --name-only v5.0.1-Final | grep -c 'rte/fdl/cryptography/'
0
$ git ls-tree -r --name-only v5.0.1-Final | grep -c 'rte/fdl/crypto/'
34
```

`bat.item.database.EgovMyBatisBatchItemWriter` 와 `fdl.cmmn.exception.handler.EgovServiceExceptionHandler` 는 옮겨진 경우가 아니라 문서가 처음부터 잘못 적은 경로입니다. v3.9.0 부터 어느 태그에도 그 경로에 해당 클래스가 없고 실제 경로인 `bat.core.item.database` 와 `fdl.exception.handler` 에는 계속 있었습니다. `fdl.cmmn.exception.handler` 패키지 자체는 5.0 에도 있습니다. 그 안에 `EgovServiceExceptionHandler` 가 없을 뿐입니다.

## 남겨둔 것

옛 표기가 남는 문서는 17개입니다.

```
$ git grep -l 'egovframework\.rte\.' HEAD -- 'egovframe-runtime/*'
HEAD:egovframe-runtime/batch-layer/batch-centercut-intro.md
HEAD:egovframe-runtime/batch-layer/batch-support-logback_logging.md
HEAD:egovframe-runtime/foundation-layer/cache-ehcache.md
HEAD:egovframe-runtime/foundation-layer/cache.md
HEAD:egovframe-runtime/foundation-layer/file-upload-service.md
HEAD:egovframe-runtime/foundation-layer/logging-log4j2-configuration_code.md
HEAD:egovframe-runtime/foundation-layer/marshalling-unmarshalling.md
HEAD:egovframe-runtime/foundation-layer/scheduling.md
HEAD:egovframe-runtime/foundation-layer/server-security-architecture.md
HEAD:egovframe-runtime/foundation-layer/server-security-upgrade.md
HEAD:egovframe-runtime/foundation-layer/xml-manipulation.md
HEAD:egovframe-runtime/integration-layer/restful.md
HEAD:egovframe-runtime/integration-layer/webservice.md
HEAD:egovframe-runtime/presentation-layer/security-validation-add-rules-in-common-validator.md
HEAD:egovframe-runtime/presentation-layer/ui-adaptor-service.md
HEAD:egovframe-runtime/presentation-layer/web-servlet-AnnotationCommandMapArgumentResolver.md
HEAD:egovframe-runtime/presentation-layer/web-servlet-handlermapping.md
```

그중 `webservice.md` 와 `batch-support-logback_logging.md` 는 `<groupId>`·`<artifactId>` 와 `${egovframework.rte.version}` 만 남습니다. 패키지 표기가 아니라 Maven 좌표라 접두어만 바꿔서는 맞는 값이 되지 않습니다 — 5.0 의 실제 좌표는 groupId `org.egovframe.rte` 에 artifactId `egovframe-rte-*` 형태입니다. 갱신이 필요한 건 맞지만 이 PR 이 다루는 종류가 아니어서 남겼습니다.

나머지 15개는 참조하는 클래스가 5.0.0 에 아예 없어 아직 손대지 않았습니다. `fdl.divert`·`fdl.sale`·`bat.centercut`·`ptl.mvc` 처럼 모듈이 빠졌거나 `SayHelloJob`·`LogTest` 같은 예제 클래스라, 접두어를 바꿔도 맞는 경로가 되지 않습니다. 문서를 어떻게 할지 따로 정해야 할 것 같습니다. `server-security-upgrade.md` 만 사정이 다릅니다. 2.7 에서 3.0 으로 올릴 때를 다루는 문서라 클래스 표기를 5.0 으로 바꾸면 3.0.0 의존성과 한 페이지 안에서 버전이 갈립니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 실행환경 (`egovframe-runtime/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
