### PR TITLE
docs: 기업회원관리 가이드의 요청 URL 을 실제 매핑에 맞춰 정정

### DIFF
--- a/common-component/user-support/company-member-management.md
+++ b/common-component/user-support/company-member-management.md
@@ -159,9 +159,9 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 |---|---|---|---|---|
-| 목록조회 | /uss/umt/EgovEntrprsMberManage.do | selectEntrprsMberList | "entrprsManageDAO" | "selectEntrprsMberList" |
+| 목록조회 | /uss/umt/EgovEntrprsManage.do | selectEntrprsMberList | "entrprsManageDAO" | "selectEntrprsMberList" |
 |  |  |  | "entrprsManageDAO" | "selectEntrprsMberListTotCnt" |
-| 삭제 | /uss/umt/EgovEntrprsMberDelete.do | deleteEntrprsMber | "entrprsManageDAO" | "deleteEntrprs_S" |
+| 삭제 | /uss/umt/EgovEntrprsDelete.do | deleteEntrprsMber | "entrprsManageDAO" | "deleteEntrprs_S" |
 
 - 기업회원 목록은 페이지 당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.  
 - 페이지 당 검색 범위를 변경하고자 하는 경우 `context-properties.xml` 파일의 `pageUnit`, `pageSize`를 변경한다(전체 공통서비스 기능에 영향).
@@ -187,8 +187,8 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 |---|---|---|---|---|
-| 등록화면 | /uss/umt/EgovEntrprsMberInsertView.do | insertEntrprsMberView |  |  |
-| 등록 | /uss/umt/EgovEntrprsMberInsert.do | insertEntrprsMber | "entrprsManageDAO" | "insertEntrprs_S" |
+| 등록화면 | /uss/umt/EgovEntrprsInsertView.do | insertEntrprsMberView |  |  |
+| 등록 | /uss/umt/EgovEntrprsInsert.do | insertEntrprsMber | "entrprsManageDAO" | "insertEntrprs_S" |
 
 ![기업회원관리 등록](./images/company-manage4.png)
 
@@ -209,9 +209,9 @@ N/A
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 |---|---|---|---|---|
-| 상세조회 | /uss/umt/EgovEntrprsMberSelectUpdtView.do | updateEntrprsMberView | "entrprsManageDAO" | "selectEntrprs_S" |
-| 수정 | /uss/umt/EgovEntrprsMberSelectUpdt.do | updateEntrprsMber | "entrprsManageDAO" | "updateEntrprs_S" |
-| 삭제 | /uss/umt/EgovEntrprsMberDelete.do | deleteEntrprsMber | "entrprsManageDAO" | "deleteEntrprs_S" |
+| 상세조회 | /uss/umt/EgovEntrprsSelectUpdtView.do | updateEntrprsMberView | "entrprsManageDAO" | "selectEntrprs_S" |
+| 수정 | /uss/umt/EgovEntrprsSelectUpdt.do | updateEntrprsMber | "entrprsManageDAO" | "updateEntrprs_S" |
+| 삭제 | /uss/umt/EgovEntrprsDelete.do | deleteEntrprsMber | "entrprsManageDAO" | "deleteEntrprs_S" |
 
 ![기업회원관리 수정](./images/company-manage5.png)
 
@@ -280,8 +280,8 @@ N/A
 #### 관련화면 및 수행 매뉴얼
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 |---|---|---|---|---|
-| 가입신청화면 | /uss/umt/EgovEntrprsMberSbscrbView.do | sbscrbEntrprsMberView |  |  |
-| 가입신청 | /uss/umt/EgovEntrprsMberSbscrb.do | sbscrbEntrprsMber | "entrprsManageDAO" | "insertEntrprs_S" |
+| 가입신청화면 | /uss/umt/EgovEntrprsSbscrbView.do | sbscrbEntrprsMberView |  |  |
+| 가입신청 | /uss/umt/EgovEntrprsSbscrb.do | sbscrbEntrprsMber | "entrprsManageDAO" | "insertEntrprs_S" |
 
 ![기업회원관리등록](./images/company-manage8.png)
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

기업회원관리 가이드의 「관련화면 및 수행 매뉴얼」 표가 요청 URL 을 `/uss/umt/EgovEntrprsMberManage.do` 처럼 적고 있는데, 공통컴포넌트 5.0.0 의 매핑에는 `Mber` 가 없습니다. `EgovEntrprsManageController` 가 5.0.0 에서 URL 에서 `Mber` 를 뺐고 문서가 따라오지 않았습니다.

같은 문서 안에서도 갈립니다. 비밀번호변경 표는 이미 `/uss/umt/EgovEntrprsPasswordUpdtView.do` 로 `Mber` 없이 적고 있습니다.

아래는 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)에서 돌린 것입니다.

```
$ cd egovframe-common-components && git log --oneline -1 origin/main
a88a3e313 Merge community contribution (#1311)

$ git show 1e764b1b7 -- src/main/java/egovframework/com/uss/umt/web/EgovEntrprsManageController.java | grep -E '^[+-].*@RequestMapping.*EgovEntrprs'
-	@RequestMapping("/uss/umt/EgovEntrprsMberInsertView.do")
+	@RequestMapping("/uss/umt/EgovEntrprsInsertView.do")
-	@RequestMapping("/uss/umt/EgovEntrprsMberInsert.do")
+	@RequestMapping("/uss/umt/EgovEntrprsInsert.do")
-	@RequestMapping("/uss/umt/EgovEntrprsMberSelectUpdtView.do")
+	@RequestMapping("/uss/umt/EgovEntrprsSelectUpdtView.do")
-	@RequestMapping("/uss/umt/EgovEntrprsMberLockIncorrect.do")
+	@RequestMapping("/uss/umt/EgovEntrprsLockIncorrect.do")
-	@RequestMapping("/uss/umt/EgovEntrprsMberSelectUpdt.do")
+	@RequestMapping("/uss/umt/EgovEntrprsSelectUpdt.do")
-	@RequestMapping("/uss/umt/EgovEntrprsMberDelete.do")
+	@RequestMapping("/uss/umt/EgovEntrprsDelete.do")
-	@RequestMapping(value = "/uss/umt/EgovEntrprsMberManage.do")
+	@RequestMapping(value = "/uss/umt/EgovEntrprsManage.do")
-	@RequestMapping("/uss/umt/EgovEntrprsMberSbscrbView.do")
+	@RequestMapping("/uss/umt/EgovEntrprsSbscrbView.do")
-	@RequestMapping("/uss/umt/EgovEntrprsMberSbscrb.do")
+	@RequestMapping("/uss/umt/EgovEntrprsSbscrb.do")

$ git grep -ohE '"/uss/umt/[A-Za-z]*Entrprs[A-Za-z]*\.do"' origin/main -- '*.java' | tr -d '"' | sort -u
/uss/umt/EgovEntrprsDelete.do
/uss/umt/EgovEntrprsInsert.do
/uss/umt/EgovEntrprsInsertView.do
/uss/umt/EgovEntrprsLockIncorrect.do
/uss/umt/EgovEntrprsManage.do
/uss/umt/EgovEntrprsPasswordUpdt.do
/uss/umt/EgovEntrprsPasswordUpdtView.do
/uss/umt/EgovEntrprsSbscrb.do
/uss/umt/EgovEntrprsSbscrbView.do
/uss/umt/EgovEntrprsSelectUpdt.do
/uss/umt/EgovEntrprsSelectUpdtView.do
/uss/umt/EgovEntrprsWithdraw.do
/uss/umt/EgovStplatCnfirmEntrprs.do
```

같은 표의 Controller method 열(`selectEntrprsMberList`·`deleteEntrprsMber` 등)은 실제 메소드명 그대로라 손대지 않았습니다. 메소드 이름에는 `Mber` 가 남아 있고 URL 에서만 빠졌습니다.

URL 아홉 곳을 실제 매핑으로 맞췄습니다. 수정 뒤 이 문서에 남은 `.do` 경로 열한 개는 모두 위 목록에 있습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
