### PR TITLE
docs: 모니터링 요소기술 가이드의 관련소스 경로를 실제 경로에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/db-service-monitoring.md
+++ b/common-component/elementary-technology/db-service-monitoring.md
@@ -69,12 +69,12 @@ DB서비스모니터링은 등록된 DB의 연결 정보 및 설정에 따라 �
 | 스케줄링 | `egovframework.com.utl.sys.dbm.service.EgovDbMntrngScheduling.java` | DB서비스모니터링로그정보를 위한 스케줄링 클래스 |
 | 스케줄링 | `egovframework.com.utl.sys.dbm.service.DbMntrngChecker.java` | DB서비스모니터링로그정보를 위한 스케줄링 클래스 |
 | 기타 | `egovframework.com.utl.sys.dbm.service.DbMntrngResult.java` | DB서비스모니터링로그정보에 대한 결과를 처리하기 위한 클래스 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/dbm/EgovDbMntrngList.jsp` | DB서비스모니터링 목록 조회를 위한 JSP 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/dbm/EgovDbMntrngRegist.jsp` | DB서비스모니터링 등록을 위한 JSP 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/dbm/EgovDbMntrngUpdt.jsp` | DB서비스모니터링 수정을 위한 JSP 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/dbm/EgovDbMntrngDetail.jsp` | 등록된 DB서비스모니터링을 조회하기 위한 JSP 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/dbm/EgovDbMntrngLogList.jsp` | DB서비스모니터링 로그 목록 조회를 위한 JSP 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/dbm/EgovDbMntrngLogDetail.jsp` | 등록된 DB서비스모니터링 로그를 조회하기 위한 JSP 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/dbm/EgovDbMntrngList.jsp` | DB서비스모니터링 목록 조회를 위한 JSP 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/dbm/EgovDbMntrngRegist.jsp` | DB서비스모니터링 등록을 위한 JSP 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/dbm/EgovDbMntrngUpdt.jsp` | DB서비스모니터링 수정을 위한 JSP 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/dbm/EgovDbMntrngDetail.jsp` | 등록된 DB서비스모니터링을 조회하기 위한 JSP 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/dbm/EgovDbMntrngLogList.jsp` | DB서비스모니터링 로그 목록 조회를 위한 JSP 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/dbm/EgovDbMntrngLogDetail.jsp` | 등록된 DB서비스모니터링 로그를 조회하기 위한 JSP 페이지 |
 | Query XML | `resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_altibase.xml` | DB서비스모니터링을 위한 Altibase용 Query XML |
 | Query XML | `resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_cubrid.xml` | DB서비스모니터링을 위한 Cubrid용 Query XML |
 | Query XML | `resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_maria.xml` | DB서비스모니터링을 위한 MariaDB용 Query XML |

--- a/common-component/elementary-technology/network-service-monitoring.md
+++ b/common-component/elementary-technology/network-service-monitoring.md
@@ -46,12 +46,12 @@ menu:
 | 스케줄링 | `egovframework/com/utl/sys/nsm/service/EgovNtwrkSvcMntrngScheduling.java` | 네트워크서비스모니터링을 위한 스케줄링 클래스 |
 | 스케줄링 | `egovframework/com/utl/sys/nsm/service/NtwrkSvcMntrngChecker.java` | 네트워크서비스모니터링을 위한 스케줄링 클래스 |
 | 기타 | `egovframework/com/utl/sys/nsm/service/NtwrkSvcMntrngResult.java` | 네트워크서비스 모니터링에 대한 결과를 처리하기 위한 클래스 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/nsm/EgovNtwrkSvcMntrngList.jsp` | 네트워크서비스모니터링목록조회를 위한 jsp페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/nsm/EgovNtwrkSvcMntrngRegist.jsp` | 네트워크서비스모니터링 등록을 위한 jsp페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/nsm/EgovNtwrkSvcMntrngUpdt.jsp` | 네트워크서비스모니터링 수정을 위한 jsp페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/nsm/EgovNtwrkSvcMntrngDetail.jsp` | 등록된 네트워크서비스모니터링을 조회하기 위한 jsp페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/nsm/EgovNtwrkSvcMntrngLogList.jsp` | 네트워크서비스모니터링로그목록조회를 위한 jsp페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/nsm/EgovNtwrkSvcMntrngLogDetail.jsp` | 등록된 네트워크서비스모니터링로그를 조회하기 위한 jsp페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/nsm/EgovNtwrkSvcMntrngList.jsp` | 네트워크서비스모니터링목록조회를 위한 jsp페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/nsm/EgovNtwrkSvcMntrngRegist.jsp` | 네트워크서비스모니터링 등록을 위한 jsp페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/nsm/EgovNtwrkSvcMntrngUpdt.jsp` | 네트워크서비스모니터링 수정을 위한 jsp페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/nsm/EgovNtwrkSvcMntrngDetail.jsp` | 등록된 네트워크서비스모니터링을 조회하기 위한 jsp페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/nsm/EgovNtwrkSvcMntrngLogList.jsp` | 네트워크서비스모니터링로그목록조회를 위한 jsp페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/nsm/EgovNtwrkSvcMntrngLogDetail.jsp` | 등록된 네트워크서비스모니터링로그를 조회하기 위한 jsp페이지 |
 | Query XML | `resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_*.xml` | 네트워크서비스모니터링을 위한 각 DB용 Query XML |
 | Validator Rule XML | `resources/egovframework/validator/validator-rules.xml` | Validator Rule을 정의한 XML |
 | Validator XML | `resources/egovframework/validator/com/utl/sys/nsm/EgovNtwrkSvcMntrng.xml` | 네트워크서비스모니터링을 위한 Validator XML |

--- a/common-component/elementary-technology/send-receive-monitoring.md
+++ b/common-component/elementary-technology/send-receive-monitoring.md
@@ -46,13 +46,13 @@ menu:
 | DAO | `egovframework.com.utl.sys.trm.service.impl.TrsmrcvMntrngDao.java` | 송수신모니터링을 위한 데이터처리 클래스 |
 | Model | `egovframework.com.utl.sys.trm.service.TrsmrcvMntrng.java` | 송수신모니터링을 위한 Model 클래스 |
 | Model | `egovframework.com.utl.sys.trm.service.TrsmrcvMntrngLog.java` | 송수신모니터링로그정보를 위한 Model 클래스 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/trm/EgovTrsmrcvMntrngList.jsp` | 송수신모니터링목록조회를 위한 JSP 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/trm/EgovTrsmrcvMntrngRegist.jsp` | 송수신모니터링 등록을 위한 JSP 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/trm/EgovTrsmrcvMntrngUpdt.jsp` | 송수신모니터링 수정을 위한 JSP 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/trm/EgovTrsmrcvMntrngDetail.jsp` | 등록된 송수신모니터링을 조회하기 위한 JSP 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/trm/EgovTrsmrcvMntrngLogList.jsp` | 송수신모니터링로그목록조회를 위한 JSP 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/trm/EgovTrsmrcvMntrngLogDetail.jsp` | 등록된 송수신모니터링로그를 조회하기 위한 JSP 페이지 |
-| XML | `/egovframework/sqlmap/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_*.xml` | 송수신모니터링 QUERY XML |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/trm/EgovTrsmrcvMntrngList.jsp` | 송수신모니터링목록조회를 위한 JSP 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/trm/EgovTrsmrcvMntrngRegist.jsp` | 송수신모니터링 등록을 위한 JSP 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/trm/EgovTrsmrcvMntrngUpdt.jsp` | 송수신모니터링 수정을 위한 JSP 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/trm/EgovTrsmrcvMntrngDetail.jsp` | 등록된 송수신모니터링을 조회하기 위한 JSP 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/trm/EgovTrsmrcvMntrngLogList.jsp` | 송수신모니터링로그목록조회를 위한 JSP 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/trm/EgovTrsmrcvMntrngLogDetail.jsp` | 등록된 송수신모니터링로그를 조회하기 위한 JSP 페이지 |
+| XML | `/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_*.xml` | 송수신모니터링 QUERY XML |
 
 ### 클래스 다이어그램
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

DB서비스모니터링·네트워크서비스모니터링·송수신모니터링 가이드의 관련소스 표에 적힌 JSP 경로가 공통컴포넌트 저장소에 없는 경로를 가리킵니다. `egovframework` 바로 뒤의 `com` 이 빠져 있습니다. 같은 표의 Service·DAO 행은 `egovframework.com.utl.sys.dbm...` 처럼 `com` 을 포함해 한 표 안에서 어긋납니다.

송수신모니터링의 QUERY XML 행은 `/egovframework/sqlmap/` 으로 적혀 있는데, 저장소에 `sqlmap` 디렉터리는 없고 매퍼 XML 은 `egovframework/mapper/` 아래에 있습니다.

세 문서에서 JSP 18줄과 XML 1줄을 저장소 실제 경로로 맞췄습니다. 교정 후 경로는 18개 JSP 각각과 XML 8개 방언 모두 실재합니다.

아래는 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `main` 에서 돌린 것입니다.

```
$ git ls-files | grep -c "WEB-INF/jsp/egovframework/utl/sys/"
0
$ git ls-files | grep -c "WEB-INF/jsp/egovframework/com/utl/sys/"
56
$ git ls-files | grep -c "resources/egovframework/sqlmap/"
0
$ git ls-files | grep -c "resources/egovframework/mapper/"
1225
```

대응 파일이 실재하는 행만 손댔습니다. DB서비스·네트워크서비스 문서에 남은 `resources/egovframework/validator/` 행은 해당 트리가 5.0.0 에서 제거돼 맞춰 넣을 경로가 없어 그대로 두었습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
