### PR TITLE
docs: 파일·HTTP·프로세스 요소기술 가이드의 관련소스 경로를 실제 경로에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/file-sync.md
+++ b/common-component/elementary-technology/file-sync.md
@@ -41,11 +41,11 @@ AP 서버들 간 동기화를 통해 파일 첨부 및 다운로드 기능을 �
 | DAO | `egovframework.com.utl.sys.ssy.service.impl.SynchrnServerDAO.java` | 동기화대상 서버관리를 위한 데이터처리 클래스 |
 | Model | `egovframework.com.utl.sys.ssy.service.SynchrnServer.java` | 동기화대상 서버관리를 위한 Model 클래스 |
 | VO | `egovframework.com.utl.sys.ssy.service.SynchrnServer.java` | 동기화대상 서버관리를 위한 VO 클래스 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/ssy/EgovSynchrnServerList.jsp` | 동기화대상서버 목록조회 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/ssy/EgovSynchrnServerDetail.jsp` | 동기화대상서버 상세조회 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/ssy/EgovSynchrnServerRegist.jsp` | 동기화대상서버 등록 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/ssy/EgovSynchrnServerUpdt.jsp` | 동기화대상서버 수정 페이지 |
-| XML | `/egovframework/sqlmap/com/utl/sys/ssy/EgovSynchrnServer_SQL_*.xml` | 동기화대상서버정보 QUERY XML |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/ssy/EgovSynchrnServerList.jsp` | 동기화대상서버 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/ssy/EgovSynchrnServerDetail.jsp` | 동기화대상서버 상세조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/ssy/EgovSynchrnServerRegist.jsp` | 동기화대상서버 등록 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/ssy/EgovSynchrnServerUpdt.jsp` | 동기화대상서버 수정 페이지 |
+| XML | `/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_*.xml` | 동기화대상서버정보 QUERY XML |
 
 ### 관련테이블
 

--- a/common-component/elementary-technology/file-system-monitoring.md
+++ b/common-component/elementary-technology/file-system-monitoring.md
@@ -43,13 +43,13 @@ menu:
 | VO | `egovframework.com.utl.sys.fsm.service.FileSysMntrngVO.java` | 파일시스템모니터링을 위한 VO 클래스 |
 | VO | `egovframework.com.utl.sys.fsm.service.FileSysMntrngLogVO.java` | 파일시스템모니터링로그정보를 위한 VO 클래스 |
 | Scheduling | `egovframework.com.utl.sys.fsm.service.EgovFileSystemMntrngScheduling.java` | 파일시스템모니터링 스케줄링 클래스 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngList.jsp` | 파일시스템모니터링 목록조회 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngRegist.jsp` | 파일시스템모니터링 등록 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngUpdt.jsp` | 파일시스템모니터링 수정 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngDetail.jsp` | 파일시스템모니터링 상세조회 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngLogList.jsp` | 파일시스템모니터링로그 목록조회 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/fsm/EgovFileSysMntrngLogDetail.jsp` | 파일시스템모니터링로그 상세조회 페이지 |
-| XML | `/egovframework/sqlmap/com/utl/sys/fsm/EgovFileSysMntrng_SQL_*.xml` | 파일시스템모니터링 QUERY XML |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/fsm/EgovFileSysMntrngList.jsp` | 파일시스템모니터링 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/fsm/EgovFileSysMntrngRegist.jsp` | 파일시스템모니터링 등록 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/fsm/EgovFileSysMntrngUpdt.jsp` | 파일시스템모니터링 수정 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/fsm/EgovFileSysMntrngDetail.jsp` | 파일시스템모니터링 상세조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/fsm/EgovFileSysMntrngLogList.jsp` | 파일시스템모니터링로그 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/fsm/EgovFileSysMntrngLogDetail.jsp` | 파일시스템모니터링로그 상세조회 페이지 |
+| XML | `/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_*.xml` | 파일시스템모니터링 QUERY XML |
 
 ### 관련테이블
 

--- a/common-component/elementary-technology/http-service-monitoring.md
+++ b/common-component/elementary-technology/http-service-monitoring.md
@@ -39,13 +39,13 @@ HTTP서비스모니터링을 등록하기 위한 목적으로 HTTP서비스모�
 | Model | `egovframework.com.utl.sys.htm.service.HttpMon.java` | HTTP서비스모니터링을 위한 Model 클래스 |
 | Model | `egovframework.com.utl.sys.htm.service.HttpMonLog.java` | HTTP서비스모니터링로그정보를 위한 Model 클래스 |
 | Scheduling | `egovframework.com.utl.sys.htm.service.HttpMntrngScheduling.java` | HTTP서비스모니터링 스케줄링 클래스 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonList.jsp` | HTTP서비스모니터링 목록조회 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonRegist.jsp` | HTTP서비스모니터링 등록 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonUpdt.jsp` | HTTP서비스모니터링 수정 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonDetail.jsp` | HTTP서비스모니터링 상세조회 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonLogList.jsp` | HTTP서비스모니터링로그 목록조회 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/htm/EgovHttpMonLogDetail.jsp` | HTTP서비스모니터링로그 상세조회 페이지 |
-| XML | `/egovframework/sqlmap/com/utl/sys/htm/EgovHttpMon_SQL_*.xml` | HTTP서비스모니터링 QUERY XML |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/htm/EgovComUtlHttpMonList.jsp` | HTTP서비스모니터링 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/htm/EgovComUtlHttpMonRegist.jsp` | HTTP서비스모니터링 등록 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/htm/EgovComUtlHttpMonModify.jsp` | HTTP서비스모니터링 수정 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/htm/EgovComUtlHttpMonDetail.jsp` | HTTP서비스모니터링 상세조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/htm/EgovComUtlHttpMonLogList.jsp` | HTTP서비스모니터링로그 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/htm/EgovComUtlHttpMonDetailLog.jsp` | HTTP서비스모니터링로그 상세조회 페이지 |
+| XML | `/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_*.xml` | HTTP서비스모니터링 QUERY XML |
 
 ### 관련테이블
 

--- a/common-component/elementary-technology/process-monitoring.md
+++ b/common-component/elementary-technology/process-monitoring.md
@@ -49,13 +49,13 @@ WINDOWS 및 UNIX 환경을 모두 지원하며, `globals.properties`의 `Globals
 | Model | `egovframework.com.utl.sys.prm.service.ProcessMon.java` | 프로세스모니터링을 위한 Model 클래스 |
 | Model | `egovframework.com.utl.sys.prm.service.ProcessMonLog.java` | 프로세스모니터링로그정보를 위한 Model 클래스 |
 | Scheduling | `egovframework.com.utl.sys.prm.service.EgovProcessMonScheduling.java` | 프로세스모니터링 스케줄링 클래스 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonList.jsp` | 프로세스모니터링 목록조회 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonRegist.jsp` | 프로세스모니터링 등록 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonUpdt.jsp` | 프로세스모니터링 수정 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonDetail.jsp` | 프로세스모니터링 상세조회 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonLogList.jsp` | 프로세스모니터링로그 목록조회 페이지 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/prm/EgovProcessMonLogDetail.jsp` | 프로세스모니터링로그 상세조회 페이지 |
-| XML | `/egovframework/sqlmap/com/utl/sys/prm/EgovProcessMon_SQL_*.xml` | 프로세스모니터링 QUERY XML |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/prm/EgovComUtlProcessMonList.jsp` | 프로세스모니터링 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/prm/EgovComUtlProcessMonRegist.jsp` | 프로세스모니터링 등록 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/prm/EgovComUtlProcessMonModify.jsp` | 프로세스모니터링 수정 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/prm/EgovComUtlProcessMonDetail.jsp` | 프로세스모니터링 상세조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/prm/EgovComUtlProcessMonLogList.jsp` | 프로세스모니터링로그 목록조회 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/prm/EgovComUtlProcessMonLogDetail.jsp` | 프로세스모니터링로그 상세조회 페이지 |
+| XML | `/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_*.xml` | 프로세스모니터링 QUERY XML |
 
 ### 관련테이블
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

파일시스템모니터링·파일동기화·HTTP서비스모니터링·프로세스모니터링 가이드의 관련소스 표가 공통컴포넌트 저장소에 없는 경로를 가리킵니다.

JSP 행은 `egovframework` 바로 뒤의 `com` 이 빠져 있습니다. 같은 표의 Service·DAO 행은 `egovframework.com.utl.sys.fsm...` 처럼 `com` 을 포함해 한 표 안에서 어긋납니다. HTTP서비스모니터링과 프로세스모니터링은 `com` 만 넣어서는 맞지 않고 파일명도 다릅니다. 컨트롤러가 반환하는 뷰 이름이 실제 파일명이라 그것에 맞췄습니다.

QUERY XML 행은 `/egovframework/sqlmap/` 으로 적혀 있는데, 저장소에 `sqlmap` 디렉터리는 없고 매퍼 XML 은 `egovframework/mapper/` 아래에 있습니다. 이 두 문서는 여기서도 파일명이 `EgovUtlSysHttpMon_SQL_*.xml`·`EgovUtlSysProcessMon_SQL_*.xml` 입니다.

아래는 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `main` 에서 돌린 것입니다.

```
$ git ls-files "src/main/webapp/WEB-INF/jsp/egovframework/*" | sed "s|.*jsp/egovframework/||" | cut -d/ -f1 | sort -u
com
$ grep -rho '"egovframework/com/utl/sys/htm/[A-Za-z]*"' src/main/java | sort -u
"egovframework/com/utl/sys/htm/EgovComUtlHttpMonDetail"
"egovframework/com/utl/sys/htm/EgovComUtlHttpMonDetailLog"
"egovframework/com/utl/sys/htm/EgovComUtlHttpMonList"
"egovframework/com/utl/sys/htm/EgovComUtlHttpMonLogList"
"egovframework/com/utl/sys/htm/EgovComUtlHttpMonModify"
"egovframework/com/utl/sys/htm/EgovComUtlHttpMonRegist"
$ git ls-files | grep -c "resources/egovframework/sqlmap/"
0
```

네 문서에서 JSP 22줄과 XML 4줄을 맞췄습니다. 교정 후 경로는 JSP 22개 각각과 XML 8개 방언 모두 실재합니다. 네 문서에 남은 관련소스 경로 행은 전부 실재합니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
