### PR TITLE
docs: 공통환경 설정파일 표의 경로를 실제 경로에 맞춰 정정

### DIFF
--- a/common-component/intro/deployment-structure.md
+++ b/common-component/intro/deployment-structure.md
@@ -154,13 +154,13 @@ menu:
 | login Log Aspect config | /WEB-INF/config/egovframework/springmvc/egov-com-loginaop.xml | Login Log Aspect (로그인 메소드, 로그아웃 메소드) 설정 |
 | login check config | /WEB-INF/config/egovframework/springmvc/egov-com-interceptor.xml | IP 정보 기록 및 Login 체크가 필요한 URL과 로그인 여부를 체크해줄 인터셉터 설정 |
 | context bean 정의 | /resources/egovframework/spring/com/context-*.xml | bean 정의 |
-| 범용 properties 정의 | /resources/egovframework/egovProp/globals.properties | global 상수 정의 |
+| 범용 properties 정의 | /resources/egovframework/egovProps/globals.properties | global 상수 정의 |
 | 추가 properties 정의 | /WEB-INF/conf/*.properties | 추가적인 상수 정의 |
 | message properties 정의 | /resources/egovframework/message/com/*.properties | message 정의 |
-| 요소기술 환경설정 | /resources/egovframework/egovProp/conf/*.properties | 요소기술에 필요한 환경설정 |
-| 요소기술 프로그램 설정 | /resources/egovframework/egovProp/prg/*.sh(*.bat) | 요소기술에 필요한 실행 스크립트 |
-| sql config 파일 | /resources/egovframework/sqlmap/com/*.xml | sql map config 정의 |
+| 요소기술 환경설정 | /resources/egovframework/egovProps/conf/*.properties | 요소기술에 필요한 환경설정 |
+| 요소기술 프로그램 설정 | /resources/egovframework/egovProps/prg/*.sh(*.bat) | 요소기술에 필요한 실행 스크립트 |
+| sql config 파일 | /resources/egovframework/mapper/com/*.xml | sql map config 정의 |
 | validator rule 파일 | /resources/egovframework/validator/validator-rules.xml | validator를 이용할 시 rule을 정의 |
 | validator rule 파일 | /resources/egovframework/validator/com-rules.xml | validator를 이용할 시 공통컴포넌트 rule을 정의 |
-| log 설정 | /resources/log4j.xml | log 관련 설정 |
+| log 설정 | /resources/log4j2.xml | log 관련 설정 |
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

「공통환경 설정파일」 표의 경로 세 가지가 공통컴포넌트 저장소의 실제 경로와 다릅니다.

`egovProp` 은 `egovProps` 입니다. 이 문서 세 줄만 `s` 가 빠져 있고 가이드 전체의 나머지 표기는 `egovProps` 를 씁니다. 매퍼 XML 은 `sqlmap` 이 아니라 `mapper` 아래에 있습니다. 로그 설정은 `log4j.xml` 이 아니라 `log4j2.xml` 입니다.

아래는 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `main` 에서 돌린 것입니다.

```
$ git ls-files | grep -c "resources/egovframework/egovProp/"
0
$ git ls-files | grep -c "resources/egovframework/egovProps/"
52
$ git ls-files | grep -c "resources/egovframework/sqlmap/"
0
$ git ls-files | grep -c "resources/egovframework/mapper/"
1225
$ git ls-files | grep "src/main/resources/log4j"
src/main/resources/log4j2.xml
```

5줄을 맞췄습니다. 대응 파일이 실재하는 행만 손댔습니다 — `validator/` 두 행은 해당 트리가 5.0.0 에서 제거됐고, `/WEB-INF/conf/*.properties` 는 대응 디렉터리가 없어 그대로 두었습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
