### PR TITLE
docs: 로그인세션·웹표준 요소기술 가이드의 JSP 경로를 실제 경로에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/login-session-check.md
+++ b/common-component/elementary-technology/login-session-check.md
@@ -28,7 +28,7 @@ menu:
 | --- | --- | --- |
 | Controller | `egovframework.com.utl.sys.rsc.web.EgovLoginSesionController.java` | 로그인세션정보체크를 위한 컨트롤러 클래스 |
 | Util | `egovframework.com.utl.sys.rsc.service.EgovLoginSesionCeckUtil.java` | 로그인세션정보체크를 위한 Util 클래스 |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/rsc/EgovLoginSesionCheck.jsp` | 로그인세션정보체크 페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/rsc/EgovLoginSesionCheck.jsp` | 로그인세션정보체크 페이지 |
 
 ## 관련화면 및 수행매뉴얼
 

--- a/common-component/elementary-technology/web-standard-check.md
+++ b/common-component/elementary-technology/web-standard-check.md
@@ -25,7 +25,7 @@ menu:
 
 | 유형 | 대상소스명 | 비고 |
 | --- | --- | --- |
-| JSP | `/WEB-INF/jsp/egovframework/utl/sys/wsi/EgovWebStandardInspection.jsp` | 웹표준검사 위한 jsp페이지 |
+| JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/wsi/EgovWebStandardInspection.jsp` | 웹표준검사 위한 jsp페이지 |
 
 ## 참고자료
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

로그인세션정보체크·웹표준검사 가이드의 관련소스 표에 적힌 JSP 경로에서 `egovframework` 바로 뒤의 `com` 이 빠져 있어 공통컴포넌트 저장소에 없는 경로를 가리킵니다.

저장소의 `WEB-INF/jsp/egovframework/` 아래는 `com` 하나뿐입니다. 로그인세션정보체크는 컨트롤러가 반환하는 뷰 이름도 `egovframework/com/utl/sys/rsc/EgovLoginSesionCheck` 라, 뷰리졸버의 접두어 `/WEB-INF/jsp/` 와 접미어 `.jsp` 를 붙이면 교정 후 경로와 같아집니다.

두 문서에서 각 1줄을 저장소 실제 경로로 맞췄습니다.

아래는 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `main` 에서 돌린 것입니다.

```
$ git ls-files "src/main/webapp/WEB-INF/jsp/egovframework/*" | sed "s|.*jsp/egovframework/||" | cut -d/ -f1 | sort -u
com
$ git ls-files | grep -E "utl/sys/rsc/EgovLoginSesionCheck.jsp|utl/sys/wsi/EgovWebStandardInspection.jsp"
src/main/webapp/WEB-INF/jsp/egovframework/com/utl/sys/rsc/EgovLoginSesionCheck.jsp
src/main/webapp/WEB-INF/jsp/egovframework/com/utl/sys/wsi/EgovWebStandardInspection.jsp
$ grep -rho '"egovframework/com/utl/sys/rsc/[A-Za-z]*"' src/main/java | sort -u
"egovframework/com/utl/sys/rsc/EgovLoginSesionCheck"
```

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
