### PR TITLE
docs: 게시판·블로그 관련코드 표에 빈 열이 붙는 구분선 칸 수 정정

### DIFF
--- a/common-component/collaboration/blog-management.md
+++ b/common-component/collaboration/blog-management.md
@@ -103,7 +103,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('BLOG_ID', 1);
 ### 블로그 카테고리 관련 코드
 
 | 코드분류 | 코드분류명 | 코드ID | 코드명 |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | COM101 | 게시판유형 | BBST01 | 통합게시판 |
 | COM101 | 게시판유형 | BBST02 | 블로그형게시판 |
 | COM101 | 게시판유형 | BBST03 | 방명록 |

--- a/common-component/collaboration/board-management.md
+++ b/common-component/collaboration/board-management.md
@@ -103,7 +103,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('BBS_ID', 1);
 ### 관련코드
 
 | 코드분류 | 코드분류명 | 코드ID | 코드명 |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | COM101 | 게시판유형 | BBST01 | 통합게시판 |
 | COM101 | 게시판유형 | BBST02 | 블로그형게시판 |
 | COM101 | 게시판유형 | BBST03 | 방명록 |


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

블로그관리의 「블로그 카테고리 관련 코드」 표와 게시판관리의 「관련코드」 표는 헤더가 네 칸인데 구분선만 다섯 칸입니다. Hugo 가 쓰는 goldmark 는 구분선 칸 수로 열 개수를 정해서, 배포된 가이드에 빈 열이 하나 더 붙습니다. github.com 의 파일 화면은 반대로 이 표를 표로 인식하지 않고 마크다운 원문을 문단으로 내보냅니다.

두 문서에서 구분선 한 줄씩을 네 칸으로 맞췄습니다.

```
$ curl -s 'https://egovframework.github.io/egovframe-docs/common-component/collaboration/board/blog-management/' | grep -o '코드분류</th>.\{0,80\}'
코드분류</th><th>코드분류명</th><th>코드ID</th><th>코드명</th><th></th></tr></thead><tbody><tr><td>COM1
$ sed -n '105,106p' common-component/collaboration/blog-management.md
| 코드분류 | 코드분류명 | 코드ID | 코드명 |
| --- | --- | --- | --- | --- |
$ gh api /markdown -X POST -f mode=markdown -f text="$(sed -n '105,109p' common-component/collaboration/blog-management.md)" | head -1
<p>| 코드분류 | 코드분류명 | 코드ID | 코드명 |
```

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
