### PR TITLE
docs: AspectJ 포인트컷 표의 파이프 이스케이프와 중복 행 정정

### DIFF
--- a/egovframe-runtime/foundation-layer-core/aop-aspectj.md
+++ b/egovframe-runtime/foundation-layer-core/aop-aspectj.md
@@ -91,7 +91,6 @@ private void tradingOperation() {}
 | --- | --- |
 | execution(public \* \*(..)) | public 메소드 실행 |
 | execution(\* set\*(..)) | 이름이 set으로 시작하는 모든 메소드명 실행 |
-| execution(\* set\*(..)) | 이름이 set으로 시작하는 모든 메소드명 실행 |
 | execution(\* com.xyz.service.AccountService.\*(..)) | AccountService 인터페이스의 모든 메소드 실행 |
 | execution(\* com.xyz.service.\*.\*(..)) | service 패키지의 모든 메소드 실행 |
 | execution(\* com.xyz.service..\*.\*(..)) | service 패키지와 하위 패키지의 모든 메소드 실행 |
@@ -110,7 +109,7 @@ private void tradingOperation() {}
 | bean(account\*) | 이름이 'account'로 시작되는 모든 빈 |
 | bean(\*Repository) | 이름이 “Repository”로 끝나는 모든 빈 |
 | bean(accounting/\*) | 이름이 “accounting/“로 시작하는 모든 빈 |
-| bean(\*dataSource) || bean(\*DataSource) | 이름이 “dataSource” 나 “DataSource” 으로 끝나는 모든 빈 |
+| bean(\*dataSource) \|\| bean(\*DataSource) | 이름이 “dataSource” 나 “DataSource” 으로 끝나는 모든 빈 |
 
 ### 충고(Advice) 정의하기
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

@AspectJ 어노테이션을 이용한 AOP 지원 가이드의 「포인트컷 정의 예제」 표에서 두 곳을 고쳤습니다.

`bean(*dataSource) || bean(*DataSource)` 행은 AspectJ 의 OR 연산자 `||` 가 마크다운 표에서 셀 구분자로 읽혀, 배포된 가이드와 GitHub 양쪽에서 설명 칸이 비고 `|| bean(*DataSource)` 도 사라집니다. 파이프를 이스케이프했습니다.

`execution(* set*(..))` 행은 바로 위 행과 글자 그대로 같아 표에 두 번 나옵니다. 뒤엣것을 지웠습니다.

```
$ curl -s 'https://egovframework.github.io/egovframe-docs/egovframe-runtime/foundation-layer-core/aop/aop-aspectj/' > p.html
$ grep -o '<td>bean(\*dataSource).\{0,40\}' p.html
<td>bean(*dataSource)</td><td></td></tr></tbody></table></div
$ grep -o '<td>execution(\* set\*(..))</td>' p.html | wc -l
       2
```

이스케이프 뒤에는 설명 칸이 살아납니다.

```
$ git show origin/main:egovframe-runtime/foundation-layer-core/aop-aspectj.md | sed -n '90,113p' > before.md
$ gh api /markdown -X POST -f mode=markdown -f text="$(cat before.md)" | grep -A1 'bean(\*dataSource)'
<td>bean(*dataSource)</td>
<td></td>
$ sed -n '90,112p' egovframe-runtime/foundation-layer-core/aop-aspectj.md > after.md
$ gh api /markdown -X POST -f mode=markdown -f text="$(cat after.md)" | grep -A1 'bean(\*dataSource)'
<td>bean(*dataSource) || bean(*DataSource)</td>
<td>이름이 “dataSource” 나 “DataSource” 으로 끝나는 모든 빈</td>
```

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 실행환경 (`egovframe-runtime/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
