### PR TITLE
docs: 목록조회 요청 URL 을 실제 컨트롤러 매핑에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/db-service-monitoring.md
+++ b/common-component/elementary-technology/db-service-monitoring.md
@@ -172,8 +172,8 @@ DB서비스모니터링 스케줄러를 등록하기 위해서 `context-scheduli
 
 | Action | URL | Controller Method | Query ID |
 | :--- | :--- | :--- | :--- |
-| 조회 | `/utl/sys/dbm/selectDbMntrngList.do` | `selectDbMntrngList` | `DbMntrngDao.selectDbMntrngList` |
-| 조회 | `/utl/sys/dbm/selectDbMntrngList.do` | `selectDbMntrngList` | `DbMntrngDao.selectDbMntrngListCnt` |
+| 조회 | `/utl/sys/dbm/getDbMntrngList.do` | `selectDbMntrngList` | `DbMntrngDao.selectDbMntrngList` |
+| 조회 | `/utl/sys/dbm/getDbMntrngList.do` | `selectDbMntrngList` | `DbMntrngDao.selectDbMntrngListCnt` |
 
 DB서비스모니터링 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
 검색 조건은 DB명(연계명), 관리자명에 대해 제공된다.
@@ -230,8 +230,8 @@ DB서비스모니터링 목록은 페이지당 10건씩 조회되며 페이징�
 
 | Action | URL | Controller Method | Query ID |
 | :--- | :--- | :--- | :--- |
-| 조회 | `/utl/sys/dbm/selectDbMntrngLogList.do` | `selectDbMntrngLogList` | `DbMntrngDao.selectDbMntrngLogList` |
-| 조회 | `/utl/sys/dbm/selectDbMntrngLogList.do` | `selectDbMntrngLogList` | `DbMntrngDao.selectDbMntrngLogListCnt` |
+| 조회 | `/utl/sys/dbm/getDbMntrngLogList.do` | `selectDbMntrngLogList` | `DbMntrngDao.selectDbMntrngLogList` |
+| 조회 | `/utl/sys/dbm/getDbMntrngLogList.do` | `selectDbMntrngLogList` | `DbMntrngDao.selectDbMntrngLogListCnt` |
 
 스케줄러에 의해 주기적으로 실행된 모니터링 로그 목록을 조회한다.
 검색 조건은 DB명(연계명), 관리자명, 모니터링시각 범위에 대해 제공된다.

--- a/common-component/elementary-technology/send-receive-monitoring.md
+++ b/common-component/elementary-technology/send-receive-monitoring.md
@@ -113,7 +113,7 @@ INSERT INTO COMTECOPSEQ VALUES('TR_MNTRNG_LOG_ID', '0');
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | `/utl/sys/trm/selectTrsmrcvMntrngList.do` | `selectTrsmrcvMntrngList` | `TrsmrcvMntrngDAO.selectTrsmrcvMntrngList`<br>`TrsmrcvMntrngDAO.selectTrsmrcvMntrngListCnt` |
+| 조회 | `/utl/sys/trm/getTrsmrcvMntrngList.do` | `selectTrsmrcvMntrngList` | `TrsmrcvMntrngDAO.selectTrsmrcvMntrngList`<br>`TrsmrcvMntrngDAO.selectTrsmrcvMntrngListCnt` |
 
 송수신모니터링 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 검색조건은 연계명, 관리자명에 대해서 수행된다.
 
@@ -167,7 +167,7 @@ INSERT INTO COMTECOPSEQ VALUES('TR_MNTRNG_LOG_ID', '0');
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | `/utl/sys/trm/selectTrsmrcvMntrngLogList.do` | `selectTrsmrcvMntrngLogList` | `TrsmrcvMntrngDAO.selectTrsmrcvMntrngLogList`<br>`TrsmrcvMntrngDAO.selectTrsmrcvMntrngLogListCnt` |
+| 조회 | `/utl/sys/trm/getTrsmrcvMntrngLogList.do` | `selectTrsmrcvMntrngLogList` | `TrsmrcvMntrngDAO.selectTrsmrcvMntrngLogList`<br>`TrsmrcvMntrngDAO.selectTrsmrcvMntrngLogListCnt` |
 
 송수신모니터링로그 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 검색조건은 연계명, 관리자명, 모니터링시각에 대해서 수행된다.
 

--- a/common-component/system-management/batch-job-management.md
+++ b/common-component/system-management/batch-job-management.md
@@ -99,8 +99,8 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/bat/selectBatchOpertList.do | selectBatchOpertList | "BatchOpertDAO.selectBatchOpertList" |
-| 조회 | /sym/bat/selectBatchOpertList.do | selectBatchOpertList | "BatchOpertDAO.selectBatchOpertListCnt" |
+| 조회 | /sym/bat/getBatchOpertList.do | selectBatchOpertList | "BatchOpertDAO.selectBatchOpertList" |
+| 조회 | /sym/bat/getBatchOpertList.do | selectBatchOpertList | "BatchOpertDAO.selectBatchOpertListCnt" |
 
  배치작업 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
  검색조건은 배치작업명,배치프로그램에 대해서 수행된다.

--- a/common-component/system-management/batch-result-management.md
+++ b/common-component/system-management/batch-result-management.md
@@ -95,8 +95,8 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/bat/selectBatchResultList.do | selectBatchResultList | "BatchResultDAO.selectBatchResultList" |
-| 조회 | /sym/bat/selectBatchResultList.do | selectBatchResultList | "BatchResultDAO.selectBatchResultListCnt" |
+| 조회 | /sym/bat/getBatchResultList.do | selectBatchResultList | "BatchResultDAO.selectBatchResultList" |
+| 조회 | /sym/bat/getBatchResultList.do | selectBatchResultList | "BatchResultDAO.selectBatchResultListCnt" |
 
  배치결과 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
  검색조건은 배치작업명,배치스케줄ID에 대해서 수행된다.


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

DB서비스모니터링·송수신모니터링·배치작업관리·배치결과관리 가이드의 표에 적힌 목록조회 요청 URL 이 공통컴포넌트 저장소의 어느 컨트롤러에도 매핑돼 있지 않습니다. 문서는 `select…List.do` 로 적었는데 매핑은 `get…List.do` 입니다.

같은 표의 Controller 메소드 열이 그 `get…List.do` 매핑의 메소드명과 그대로 일치해, 가리키는 대상이 무엇인지는 표 안에서 확정됩니다.

네 문서에서 10줄을 실제 매핑으로 맞췄습니다. 아래는 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `main` 에서 돌린 것입니다.

```
$ grep -rhA1 -e getDbMntrngList.do -e getTrsmrcvMntrngList.do -e getBatchOpertList.do -e getBatchResultList.do src/main/java | grep -oE "\"/[A-Za-z/]+\.do\"|String [A-Za-z]+\("
"/sym/bat/getBatchOpertList.do"
"/sym/bat/getBatchOpertList.do"
String selectBatchOpertList(
"/sym/bat/getBatchResultList.do"
"/sym/bat/getBatchResultList.do"
String selectBatchResultList(
"/utl/sys/trm/getTrsmrcvMntrngList.do"
String selectTrsmrcvMntrngList(
"/utl/sys/dbm/getDbMntrngList.do"
String selectDbMntrngList(
$ grep -rl -e selectDbMntrngList.do -e selectBatchOpertList.do src/main/java | wc -l
       0
```

로그 목록조회 URL(`getDbMntrngLogList.do`·`getTrsmrcvMntrngLogList.do`)도 같은 모양이라 함께 맞췄습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
