### PR TITLE
docs: 상세조회 요청 URL 을 실제 컨트롤러 매핑에 맞춰 정정

### DIFF
--- a/common-component/digital-asset-management/org-knowledge-map-management.md
+++ b/common-component/digital-asset-management/org-knowledge-map-management.md
@@ -79,7 +79,7 @@ flowchart LR
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
 | 조회 | /dam/map/tea/EgovComDamMapTeamList.do | selectMapTeamList | "MapTeamDAO.selectMapTeamList" |
-| 상세조회 | /dam/map/tea/EgovComDamMapTeam.do | selectMapTeamDetail | "MapTeamDAO.selectMapTeamDetail" |
+| 상세조회 | /dam/map/tea/EgovComDamMapTeamDetail.do | selectMapTeamDetail | "MapTeamDAO.selectMapTeamDetail" |
 
  지식맵(조직별)관리 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
  검색조건은 지식유형, 지식명에 대해서 수행된다.
@@ -120,7 +120,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /dam/map/tea/EgovComDamMapTeam.do | selectMapTeamDetail | "MapTeamDAO.selectMapTeamDetail" |
+| 상세조회 | /dam/map/tea/EgovComDamMapTeamDetail.do | selectMapTeamDetail | "MapTeamDAO.selectMapTeamDetail" |
 | 삭제 | /dam/map/tea/EgovComDamMapTeamRemove.do | deleteMapTeam | "MapTeamDAO.deleteMapTeam" |
 
  지식맵(조직별)의 속성정보를 조회한다.

--- a/common-component/system-management/privacy-log-management.md
+++ b/common-component/system-management/privacy-log-management.md
@@ -206,7 +206,7 @@ return idGnrService;
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /sym/log/plg/InqirePrivacyLog.do | selectWebLog | "PrivacyLog" | "selectPrivacyLog" |
+| 상세조회 | /sym/log/plg/SelectPrivacyLogDetail.do | selectWebLog | "PrivacyLog" | "selectPrivacyLog" |
 
  ![image](./images/sym-privlog-상세.jpg)
 

--- a/common-component/user-support/duty-management.md
+++ b/common-component/user-support/duty-management.md
@@ -134,7 +134,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /uss/ion/bnt/selectBndtManage.do | selectBndtManage | "bndtManageDAO.selectBndtManage" |
+| 상세조회 | /uss/ion/bnt/EgovBndtManageDetail.do | selectBndtManage | "bndtManageDAO.selectBndtManage" |
 | 삭제 | /uss/ion/bnt/deleteBndtManage.do | deleteBndtManage | "bndtManageDAO.deleteBndtManage" |
 
  당직의 상세조회화면이다. 수정 버튼을 통해서 수정화면으로 이동하고, 삭제 버튼을 통해서 당직을 삭제한다.
@@ -150,7 +150,7 @@ flowchart LR
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
 | 수정 | /uss/ion/bnt/updtBndtManage.do | updtBndtManage | "bndtManageDAO.updtBndtManage" |
-| 상세조회 | /uss/ion/bnt/selectBndtManage.do | selectBndtManage | "bndtManageDAO.selectBndtManage" |
+| 상세조회 | /uss/ion/bnt/EgovBndtManageDetail.do | selectBndtManage | "bndtManageDAO.selectBndtManage" |
 
  당직의 속성정보를 변경한 후 저장한다. 다음 화면은 당직 상세조회 화면과 동일하다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

개인정보조회로그관리·당직관리·지식맵관리(조직) 가이드의 URL 열에 적힌 상세조회 요청 URL 이 공통컴포넌트 저장소의 어느 컨트롤러에도 매핑돼 있지 않습니다.

같은 표의 Controller method 열이 실제 매핑의 메소드명과 그대로 일치해, 그 메소드가 달린 매핑으로 맞췄습니다. 개인정보조회로그관리는 `/sym/log/plg/` 접두어와 SQL Namespace 열(`"PrivacyLog"`)이 함께 대상을 좁힙니다.

세 문서에서 5줄을 고쳤습니다. 아래는 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `main` 에서 돌린 것입니다.

```
$ grep -rhA1 -e SelectPrivacyLogDetail.do -e EgovBndtManageDetail.do -e EgovComDamMapTeamDetail.do src/main/java | grep -oE "\"/[A-Za-z/]+\.do\"|String [A-Za-z]+\("
"/sym/log/plg/SelectPrivacyLogDetail.do"
String selectWebLog(
"/uss/ion/bnt/EgovBndtManageDetail.do"
String selectBndtManage(
"/dam/map/tea/EgovComDamMapTeamDetail.do"
String selectMapTeamDetail(
$ grep -rl -e InqirePrivacyLog.do -e /uss/ion/bnt/selectBndtManage.do -e /dam/map/tea/EgovComDamMapTeam.do src/main/java | wc -l
       0
```

당직관리는 당직 상세·수정 두 절만 손댔습니다. 당직일지 쪽 표는 URL 뿐 아니라 Controller method·QueryID 열까지 당직 쪽 값이 들어가 있어(실제는 `selectBndtDiary`) 별건으로 두었습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
