### PR TITLE
docs: 백업관리·스케줄처리 가이드의 Query ID 네임스페이스 표기 정정

### DIFF
--- a/common-component/system-management/backup-management.md
+++ b/common-component/system-management/backup-management.md
@@ -166,8 +166,8 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/sym/bak/getBackupOpertList.do | selectBackupOpertList | "BackupOpertDAO.selectBackupOpertList" |
-| 조회 | /sym/sym/bak/getBackupOpertList.do | selectBackupOpertList | "BackupOpertDAO.selectBackupOpertListCnt" |
+| 조회 | /sym/sym/bak/getBackupOpertList.do | selectBackupOpertList | "BackupOpertDao.selectBackupOpertList" |
+| 조회 | /sym/sym/bak/getBackupOpertList.do | selectBackupOpertList | "BackupOpertDao.selectBackupOpertListCnt" |
 
  백업작업 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
  검색조건은 백업작업명,백업원본디렉토리에 대해서 수행된다.
@@ -181,7 +181,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 등록 | /sym/sym/bak/addBackupOpert.do | insertBackupOpert | "BackupOpertDAO.insertBackupOpert" |
+| 등록 | /sym/sym/bak/addBackupOpert.do | insertBackupOpert | "BackupOpertDao.insertBackupOpert" |
 
  백업작업의 속성정보를 입력한 뒤 등록한다.
 
@@ -194,7 +194,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /sym/sym/bak/updateBackupOpert.do | updateBackupOpert | "BackupOpertDAO.updateBackupOpert" |
+| 수정 | /sym/sym/bak/updateBackupOpert.do | updateBackupOpert | "BackupOpertDao.updateBackupOpert" |
 
  백업작업의 속성정보를 변경한 후 저장한다.
 
@@ -207,8 +207,8 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /sym/sym/bak/getBackupOpert.do | selectBackupOpert | "BackupOpertDAO.selectBackupOpert" |
-| 삭제 | /sym/sym/bak/deleteBackupOpert.do | deleteBackupOpert | "BackupOpertDAO.deleteBackupOpert" |
+| 상세조회 | /sym/sym/bak/getBackupOpert.do | selectBackupOpert | "BackupOpertDao.selectBackupOpert" |
+| 삭제 | /sym/sym/bak/deleteBackupOpert.do | deleteBackupOpert | "BackupOpertDao.deleteBackupOpert" |
 
  백업작업의 속성정보를 조회한다.
 
@@ -222,8 +222,8 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/sym/bak/getBackupResultList.do | selectBackupResultList | "BackupResultDAO.selectBackupResultList" |
-| 조회 | /sym/sym/bak/getBackupResultList.do | selectBackupResultList | "BackupResultDAO.selectBackupResultListCnt" |
+| 조회 | /sym/sym/bak/getBackupResultList.do | selectBackupResultList | "BackupResultDao.selectBackupResultList" |
+| 조회 | /sym/sym/bak/getBackupResultList.do | selectBackupResultList | "BackupResultDao.selectBackupResultListCnt" |
 
  백업결과 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
  검색조건은 백업작업명,백업작업ID에 대해서 수행된다.
@@ -238,8 +238,8 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /sym/sym/bak/getBackupResult.do | selectBackupResult | "BackupResultDAO.selectBackupResult" |
-| 삭제 | /sym/sym/bak/deleteBackupResult.do | deleteBackupResult | "BackupResultDAO.deleteBackupResult" |
+| 상세조회 | /sym/sym/bak/getBackupResult.do | selectBackupResult | "BackupResultDao.selectBackupResult" |
+| 삭제 | /sym/sym/bak/deleteBackupResult.do | deleteBackupResult | "BackupResultDao.deleteBackupResult" |
 
  백업결과의 속성정보를 조회한다.
 

--- a/common-component/system-management/schedule-processing.md
+++ b/common-component/system-management/schedule-processing.md
@@ -102,8 +102,8 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/bat/getBatchSchdulList.do | selectBatchSchdulList | "BatchSchdulDAO.selectBatchSchdulList" |
-| 조회 | /sym/bat/getBatchSchdulList.do | selectBatchSchdulList | "BatchSchdulDAO.selectBatchSchdulListCnt" |
+| 조회 | /sym/bat/getBatchSchdulList.do | selectBatchSchdulList | "BatchSchdulDao.selectBatchSchdulList" |
+| 조회 | /sym/bat/getBatchSchdulList.do | selectBatchSchdulList | "BatchSchdulDao.selectBatchSchdulListCnt" |
 
  배치스케줄 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
  검색조건은 배치작업명,배치프로그램에 대해서 수행된다.
@@ -117,7 +117,7 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 등록 | /sym/bat/addBatchSchdul.do | insertBatchSchdul | "BatchSchdulDAO.insertBatchSchdul" |
+| 등록 | /sym/bat/addBatchSchdul.do | insertBatchSchdul | "BatchSchdulDao.insertBatchSchdul" |
 
  배치스케줄의 속성정보를 입력한 뒤 등록한다.
 
@@ -130,7 +130,7 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /sym/bat/updateBatchSchdul | updateBatchSchdul | "BatchSchdulDAO.updateBatchSchdul" |
+| 수정 | /sym/bat/updateBatchSchdul | updateBatchSchdul | "BatchSchdulDao.updateBatchSchdul" |
 
  배치스케줄의 속성정보를 변경한 후 저장한다.
 
@@ -143,8 +143,8 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /sym/bat/getBatchSchdul.do | selectBatchSchdul | "BatchSchdulDAO.selectBatchSchdul" |
-| 삭제 | /sym/bat/deleteBatchSchdul.do | deleteBatchSchdul | "BatchSchdulDAO.deleteBatchSchdul" |
+| 상세조회 | /sym/bat/getBatchSchdul.do | selectBatchSchdul | "BatchSchdulDao.selectBatchSchdul" |
+| 삭제 | /sym/bat/deleteBatchSchdul.do | deleteBatchSchdul | "BatchSchdulDao.deleteBatchSchdul" |
 
  배치스케줄의 속성정보를 조회한다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

백업관리·스케줄처리 가이드의 표에 적힌 Query ID 의 네임스페이스가 `…DAO` 인데, 이 두 문서가 다루는 매퍼 XML 은 `…Dao` 로 선언합니다. MyBatis 네임스페이스는 대소문자를 구분하므로 문서에 적힌 Query ID 로는 매퍼를 찾지 못합니다.

저장소 전체로 보면 `…DAO` 네임스페이스가 다수입니다. 고유 네임스페이스 149개 중 `…Dao` 는 7개뿐인데, 이 두 문서가 쓰는 셋이 그 7개에 들어갑니다.

두 문서에서 16줄을 매퍼 실제 네임스페이스로 맞췄습니다. Query ID 뒷부분(메소드명)은 그대로입니다. 아래는 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `main` 에서 돌린 것입니다.

```
$ grep -rhoE 'namespace="[^"]*"' src/main/resources/egovframework/mapper | sort -u | grep -E "(Backup|BatchSchdul)"
namespace="BackupOpertDao"
namespace="BackupResultDao"
namespace="BatchSchdulDao"
$ grep -rhoE 'namespace="[^"]*"' src/main/resources/egovframework/mapper | sort -u | grep -c "Dao\""
7
$ grep -rl "BackupOpertDAO\.\|BackupResultDAO\.\|BatchSchdulDAO\." src/main/java src/main/resources | wc -l
       0
```

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
