### PR TITLE
docs: 송수신모니터링·배치작업관리·배치결과관리 가이드의 Query ID 네임스페이스 표기 정정

### DIFF
--- a/common-component/elementary-technology/send-receive-monitoring.md
+++ b/common-component/elementary-technology/send-receive-monitoring.md
@@ -113,7 +113,7 @@ INSERT INTO COMTECOPSEQ VALUES('TR_MNTRNG_LOG_ID', '0');
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | `/utl/sys/trm/getTrsmrcvMntrngList.do` | `selectTrsmrcvMntrngList` | `TrsmrcvMntrngDAO.selectTrsmrcvMntrngList`<br>`TrsmrcvMntrngDAO.selectTrsmrcvMntrngListCnt` |
+| 조회 | `/utl/sys/trm/getTrsmrcvMntrngList.do` | `selectTrsmrcvMntrngList` | `TrsmrcvMntrngDao.selectTrsmrcvMntrngList`<br>`TrsmrcvMntrngDao.selectTrsmrcvMntrngListCnt` |
 
 송수신모니터링 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 검색조건은 연계명, 관리자명에 대해서 수행된다.
 
@@ -126,7 +126,7 @@ INSERT INTO COMTECOPSEQ VALUES('TR_MNTRNG_LOG_ID', '0');
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 등록 | `/utl/sys/trm/addTrsmrcvMntrng.do` | `insertTrsmrcvMntrng` | `TrsmrcvMntrngDAO.insertTrsmrcvMntrng` |
+| 등록 | `/utl/sys/trm/addTrsmrcvMntrng.do` | `insertTrsmrcvMntrng` | `TrsmrcvMntrngDao.insertTrsmrcvMntrng` |
 
 송수신모니터링의 속성정보를 입력한 뒤 등록한다.
 
@@ -139,7 +139,7 @@ INSERT INTO COMTECOPSEQ VALUES('TR_MNTRNG_LOG_ID', '0');
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | `/utl/sys/trm/updateTrsmrcvMntrng.do` | `updateTrsmrcvMntrng` | `TrsmrcvMntrngDAO.updateTrsmrcvMntrng` |
+| 수정 | `/utl/sys/trm/updateTrsmrcvMntrng.do` | `updateTrsmrcvMntrng` | `TrsmrcvMntrngDao.updateTrsmrcvMntrng` |
 
 송수신모니터링의 속성정보를 변경한 후 저장한다.
 
@@ -152,8 +152,8 @@ INSERT INTO COMTECOPSEQ VALUES('TR_MNTRNG_LOG_ID', '0');
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | `/utl/sys/trm/getTrsmrcvMntrng.do` | `selectTrsmrcvMntrng` | `TrsmrcvMntrngDAO.selectTrsmrcvMntrng` |
-| 삭제 | `/utl/sys/trm/deleteTrsmrcvMntrng.do` | `deleteTrsmrcvMntrng` | `TrsmrcvMntrngDAO.deleteTrsmrcvMntrng` |
+| 상세조회 | `/utl/sys/trm/getTrsmrcvMntrng.do` | `selectTrsmrcvMntrng` | `TrsmrcvMntrngDao.selectTrsmrcvMntrng` |
+| 삭제 | `/utl/sys/trm/deleteTrsmrcvMntrng.do` | `deleteTrsmrcvMntrng` | `TrsmrcvMntrngDao.deleteTrsmrcvMntrng` |
 
 송수신모니터링의 속성정보를 조회한다.
 
@@ -167,7 +167,7 @@ INSERT INTO COMTECOPSEQ VALUES('TR_MNTRNG_LOG_ID', '0');
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | `/utl/sys/trm/getTrsmrcvMntrngLogList.do` | `selectTrsmrcvMntrngLogList` | `TrsmrcvMntrngDAO.selectTrsmrcvMntrngLogList`<br>`TrsmrcvMntrngDAO.selectTrsmrcvMntrngLogListCnt` |
+| 조회 | `/utl/sys/trm/getTrsmrcvMntrngLogList.do` | `selectTrsmrcvMntrngLogList` | `TrsmrcvMntrngDao.selectTrsmrcvMntrngLogList`<br>`TrsmrcvMntrngDao.selectTrsmrcvMntrngLogListCnt` |
 
 송수신모니터링로그 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다. 검색조건은 연계명, 관리자명, 모니터링시각에 대해서 수행된다.
 
@@ -179,7 +179,7 @@ INSERT INTO COMTECOPSEQ VALUES('TR_MNTRNG_LOG_ID', '0');
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | `/utl/sys/trm/getTrsmrcvMntrngLog.do` | `selectTrsmrcvMntrngLog` | `TrsmrcvMntrngDAO.selectTrsmrcvMntrngLog` |
+| 상세조회 | `/utl/sys/trm/getTrsmrcvMntrngLog.do` | `selectTrsmrcvMntrngLog` | `TrsmrcvMntrngDao.selectTrsmrcvMntrngLog` |
 
 송수신모니터링로그의 속성정보를 조회한다.
 

--- a/common-component/system-management/batch-job-management.md
+++ b/common-component/system-management/batch-job-management.md
@@ -99,8 +99,8 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/bat/getBatchOpertList.do | selectBatchOpertList | "BatchOpertDAO.selectBatchOpertList" |
-| 조회 | /sym/bat/getBatchOpertList.do | selectBatchOpertList | "BatchOpertDAO.selectBatchOpertListCnt" |
+| 조회 | /sym/bat/getBatchOpertList.do | selectBatchOpertList | "BatchOpertDao.selectBatchOpertList" |
+| 조회 | /sym/bat/getBatchOpertList.do | selectBatchOpertList | "BatchOpertDao.selectBatchOpertListCnt" |
 
  배치작업 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
  검색조건은 배치작업명,배치프로그램에 대해서 수행된다.
@@ -114,7 +114,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 등록 | /sym/bat/addBatchOpert.do | insertBatchOpert | "BatchOpertDAO.insertBatchOpert" |
+| 등록 | /sym/bat/addBatchOpert.do | insertBatchOpert | "BatchOpertDao.insertBatchOpert" |
 
  배치작업의 속성정보를 입력한 뒤 등록한다.
 
@@ -127,7 +127,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /sym/bat/updateBatchOpert | updateBatchOpert | "BatchOpertDAO.updateBatchOpert" |
+| 수정 | /sym/bat/updateBatchOpert | updateBatchOpert | "BatchOpertDao.updateBatchOpert" |
 
  배치작업의 속성정보를 변경한 후 저장한다.
 
@@ -140,8 +140,8 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /sym/bat/getBatchOpert.do | selectBatchOpert | "BatchOpertDAO.selectBatchOpert" |
-| 삭제 | /sym/bat/deleteBatchOpert.do | deleteBatchOpert | "BatchOpertDAO.deleteBatchOpert" |
+| 상세조회 | /sym/bat/getBatchOpert.do | selectBatchOpert | "BatchOpertDao.selectBatchOpert" |
+| 삭제 | /sym/bat/deleteBatchOpert.do | deleteBatchOpert | "BatchOpertDao.deleteBatchOpert" |
 
  배치작업의 속성정보를 조회한다.
 

--- a/common-component/system-management/batch-result-management.md
+++ b/common-component/system-management/batch-result-management.md
@@ -95,8 +95,8 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /sym/bat/getBatchResultList.do | selectBatchResultList | "BatchResultDAO.selectBatchResultList" |
-| 조회 | /sym/bat/getBatchResultList.do | selectBatchResultList | "BatchResultDAO.selectBatchResultListCnt" |
+| 조회 | /sym/bat/getBatchResultList.do | selectBatchResultList | "BatchResultDao.selectBatchResultList" |
+| 조회 | /sym/bat/getBatchResultList.do | selectBatchResultList | "BatchResultDao.selectBatchResultListCnt" |
 
  배치결과 목록은 페이지당 10건씩 조회되며 페이징은 10페이지씩 이루어진다.
  검색조건은 배치작업명,배치스케줄ID에 대해서 수행된다.
@@ -109,8 +109,8 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /sym/bat/getBatchResult.do | selectBatchResult | "BatchResultDAO.selectBatchResult" |
-| 삭제 | /sym/bat/deleteBatchResult.do | deleteBatchResult | "BatchOpertDAO.deleteBatchResult" |
+| 상세조회 | /sym/bat/getBatchResult.do | selectBatchResult | "BatchResultDao.selectBatchResult" |
+| 삭제 | /sym/bat/deleteBatchResult.do | deleteBatchResult | "BatchResultDao.deleteBatchResult" |
 
  배치결과의 속성정보를 조회한다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

송수신모니터링·배치작업관리·배치결과관리 가이드의 표에 적힌 Query ID 의 네임스페이스가 `…DAO` 인데, 이 세 문서가 다루는 매퍼 XML 은 `…Dao` 로 선언합니다. MyBatis 네임스페이스는 대소문자를 구분하므로 문서에 적힌 Query ID 로는 매퍼를 찾지 못합니다.

배치결과관리의 삭제 행은 대소문자만이 아니라 DAO 자체가 다릅니다. `BatchOpertDAO.deleteBatchResult` 로 적혀 있는데 이 쿼리를 부르는 곳은 `BatchResultDao` 입니다.

세 문서에서 Query ID 19개를 매퍼 실제 네임스페이스로 맞췄습니다. `<br>` 로 두 개가 한 줄에 든 행이 둘이라 바뀐 줄은 17입니다. 아래는 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `main` 에서 돌린 것입니다.

```
$ grep -rhoE 'namespace="[^"]*"' src/main/resources/egovframework/mapper | sort -u | grep -E "(TrsmrcvMntrng|BatchOpert|BatchResult)"
namespace="BatchOpertDao"
namespace="BatchResultDao"
namespace="TrsmrcvMntrngDao"
$ grep -rl "TrsmrcvMntrngDAO\.\|BatchOpertDAO\.\|BatchResultDAO\." src/main/java src/main/resources | wc -l
       0
$ grep -rn 'delete("BatchResultDao' src/main/java
src/main/java/egovframework/com/sym/bat/service/impl/BatchResultDao.java:36:		delete("BatchResultDao.deleteBatchResult", batchResult);
```

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
