### PR TITLE
docs: 표 행의 셀 위치와 잔여 주석 종료 기호 정정

### DIFF
--- a/common-component/elementary-technology/validation-check.md
+++ b/common-component/elementary-technology/validation-check.md
@@ -133,7 +133,7 @@ Spring의 `Validator` 인터페이스를 구현한 커스텀 Validator로 처리
 | --- | --- | --- | --- |
 | egovframework.com.sym.bat.validation.BatchOpertValidator | `batchOpertValidator` | `BatchOpert` | 배치작업에 지정한 배치프로그램이 실제 파일로 존재하는지, 파일이 맞는지, 접근 가능한지 검사 |
 | egovframework.com.sym.sym.bak.validation.BackupOpertValidator | `backupOpertValidator` | `BackupOpert` | 백업 원본 디렉토리와 백업 대상 디렉토리가 실제로 존재하는지 검사 |
-| egovframework.com.uss.umt.validation.PasswordManageMapValidator | `passwordManageMapValidator` | `PasswordManageVO` | 비밀번호 필수 입력·길이(8~20자)·연속문자·반복문자·3가지 조합 및 비밀번호 확인값 일치 검사 | -->
+| egovframework.com.uss.umt.validation.PasswordManageMapValidator | `passwordManageMapValidator` | `PasswordManageVO` | 비밀번호 필수 입력·길이(8~20자)·연속문자·반복문자·3가지 조합 및 비밀번호 확인값 일치 검사 |
 
 `BatchOpertValidator`와 `BackupOpertValidator`는 각각 `EgovBatchOpertController`, `EgovBackupOpertController`에서
 주입받아 직접 호출한다. `PasswordManageMapValidator`는 빈으로 등록되어 있으므로 비밀번호 변경 화면 등

--- a/egovframe-runtime/presentation-layer/ajax.md
+++ b/egovframe-runtime/presentation-layer/ajax.md
@@ -90,7 +90,7 @@ Ajax 지원 서비스에서는 Ajax를 이용해 자주 사용되는 기능을 c
 | source         | 추천 검색어 리스트를 보여줄 텍스트 필드 이름. 입력 필드에 추천 검색리스트를 보여준다면 target과 source를 동일하게 입력한다. | yes  |
 | target         | 사용자가 입력하는 텍스트 필드 이름.                                                         | yes  |
 | parameters     | baseUrl에 추가할 파라미터들.여러개일 경우 comma로 구별한다.                                      | no   |
-| eventType      | no                                                                           |
+| eventType      |                                                                              | no   |
 | executeOnLoad  | 응답 데이터로 select box를 구성하는 중일 때 구성중인지를 별도 표시를 할지 여부.[default=false]             | no   |
 | defaultOptions | Ajax 응답값이 없을 때 보여줄 기본 리스트. comma로 구별하여 작성한다.                                  | no   |
 | preFunction    | Ajax 요청이 시작되기 전에 동작하는 function 이름.                                           | no   |


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

Ajax 지원 서비스 가이드의 `ajax:select` 파라미터 표에서 `eventType` 행이 한 칸씩 밀려 있습니다. 셀이 두 개뿐이라 필수여부 값 `no` 가 설명 칸에 들어가고 필수여부 칸이 빕니다. 형제 행은 모두 세 칸입니다. 빈 설명 칸을 넣어 `no` 를 필수여부 칸으로 옮겼습니다.

요소기술 Validation 체크 가이드의 커스텀 Validator 표는 마지막 행 끝에 `-->` 가 붙어 있는데, 이 문서에 여는 `<!--` 가 없습니다. 헤더보다 칸이 하나 많아 렌더링에서 버려지지만 원문에 남은 잔재라 지웠습니다.

```
$ curl -s 'https://egovframework.github.io/egovframe-docs/egovframe-runtime/presentation-layer/ajax/' | grep -o '<td>eventType</td>.\{0,30\}'
<td>eventType</td><td>no</td><td></td></tr><tr><
$ git show origin/main:common-component/elementary-technology/validation-check.md | grep -c '<!--'
0
$ git show origin/main:common-component/elementary-technology/validation-check.md | grep -o -- '| -->'
| -->
```

설명 칸은 원문에 값이 없어 비워 두었습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
