### PR TITLE
docs: 문서 안 링크가 가리키는 앵커와 잉여 괄호 정정

### DIFF
--- a/egovframe-development/deployment-tool/maven.md
+++ b/egovframe-development/deployment-tool/maven.md
@@ -67,7 +67,7 @@ pom.xml 파일은 프로젝트의 세부 메타 데이터 정보를 포함하며
 ![pom.xml 구조](./images/pom-tier.gif)
 
 * **General Information**  
-  프로젝트 이름, 설명, 버전 정보 등을 기술한다. - [프로젝트 정보 생성](#프로젝트-정보-생성)) 참조
+  프로젝트 이름, 설명, 버전 정보 등을 기술한다. - [프로젝트 정보 생성](#프로젝트-정보-생성) 참조
 * Organization : 프로젝트 조직 정보: 이름, 홈페이지 URL
 * Project Team and Collaborations tools  
   형상관리 서버, 이슈 트랙커, 통합 빌드 서버 정보 등

--- a/egovframe-runtime/foundation-layer/id-generation.md
+++ b/egovframe-runtime/foundation-layer/id-generation.md
@@ -46,7 +46,7 @@ UUID는 다음 5개의 Version이 존재한다.
   - SHA-1 Hashing을 이용하여 UUID를 생성한다.
 
 ## 설명
-ID 생성 방식으로는 [UUID](#Universally-Unique-Identifier(UUID))를 생성하는 [UUID Generation Service](#UUID-Generation-Service)와 sequence를 활용하는 [Sequence Id Generation Service](#Sequence-Id-Generation-Service), 그리고 키제공을 위한 테이블을 지정하여 생성하는 [Table Id Generation Service](#Table-Id-Generation-Service) 3가지가 있다.
+ID 생성 방식으로는 [UUID](#universally-unique-identifieruuid)를 생성하는 [UUID Generation Service](#uuid-generation-service)와 sequence를 활용하는 [Sequence Id Generation Service](#sequence-id-generation-service), 그리고 키제공을 위한 테이블을 지정하여 생성하는 [Table Id Generation Service](#table-id-generation-service) 3가지가 있다.
 
 ### UUID Generation Service
 
@@ -54,7 +54,7 @@ ID 생성 방식으로는 [UUID](#Universally-Unique-Identifier(UUID))를 생성
 
 String 타입의 ID 생성과 BigDecimal 타입의 ID 생성 두가지 유형 ID 생성을 지원한다.
 
-지원하는 방법은 설정에 따라서 [Mac Address Base Service](#Mac-Address-Base-Service), [IP Address Base Service](#IP-Address-Base-Service), [No Address Base Service](#No-Address-Base-Service) 세가지 유형이 있다.
+지원하는 방법은 설정에 따라서 [Mac Address Base Service](#mac-address-base-service), [IP Address Base Service](#ip-address-base-service), [No Address Base Service](#no-address-base-service) 세가지 유형이 있다.
 
 #### Mac Address Base Service
 
@@ -136,7 +136,7 @@ public void testUUIdGenerationNoAddress() throws Exception {
 
 ### Sequence Id Generation Service
 
-새로운 ID를 생성하기 위해 Database의 SEQUENCE를 사용하는 서비스이다. 서비스를 이용하는 시스템에서 Query를 지정하여 아이디를 생성할 수 있도록 하고 [Basic Type Service](#Basic-Type-Service)와 [BigDecimal Type Service](#BigDecimal-Type-Service) 두가지를 지원한다.
+새로운 ID를 생성하기 위해 Database의 SEQUENCE를 사용하는 서비스이다. 서비스를 이용하는 시스템에서 Query를 지정하여 아이디를 생성할 수 있도록 하고 [Basic Type Service](#basic-type-service)와 [BigDecimal Type Service](#bigdecimal-type-service) 두가지를 지원한다.
 
 #### Basic Type Service
 
@@ -178,7 +178,7 @@ public void testPrimaryTypeIdGeneration() throws Exception {
 
 #### BigDecimal Type Service
 
-BigDecimal ID를 제공하는 서비스로 [기본타입 ID 제공 서비스](#Basic-Type-Service) 설정에 추가적으로 `useBigDecimals`을 `true`로 설정하여 BigDecimal 사용하도록 한다.
+BigDecimal ID를 제공하는 서비스로 [기본타입 ID 제공 서비스](#basic-type-service) 설정에 추가적으로 `useBigDecimals`을 `true`로 설정하여 BigDecimal 사용하도록 한다.
 
 ##### DB Schema
 
@@ -260,7 +260,7 @@ SELECT NEXT VALUE FOR <sequence name> FROM SYSIBM.SYSDUMMY1
 
 table_name(`CHAR` 또는 `VARCHAR`타입), next_id(`integer` 또는 `DECIMAL` type)와 같이 두 칼럼을 필요로 한다.
 
-별도의 테이블에 설정된 정보만을 사용하여 제공하는 [Basic Service](#Basic-Service), prefix와 채울 문자열을 지정하여 String ID를 생성할 수 있는 [Strategy Base Service](#Strategy-Base-Service)를 제공한다.
+별도의 테이블에 설정된 정보만을 사용하여 제공하는 [Basic Service](#basic-service), prefix와 채울 문자열을 지정하여 String ID를 생성할 수 있는 [Strategy Base Service](#strategy-base-service)를 제공한다.
 
 #### Basic Service
 
@@ -323,7 +323,7 @@ public void testBasicService() throws Exception {
 
 아이디 생성을 위한 룰을 등록하고 룰에 맞는 아이디를 생성할 수 있도록 지원하는 서비스이다.
 
-위의 [Basic Service](#Basic-Service)에서 추가적으로 Strategy 정보 설정을 추가하여 사용 할 수 있다.
+위의 [Basic Service](#basic-service)에서 추가적으로 Strategy 정보 설정을 추가하여 사용 할 수 있다.
 
 단, 이 서비스는 `String` 타입의 `ID`만을 제공한다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

Id Generation 서비스 가이드의 문서 안 링크 13곳이 `#UUID-Generation-Service` 처럼 대문자가 섞여 있습니다. github.com 에서 이 파일을 열면 13곳 모두 대상 제목을 못 찾습니다. 제목 id 는 소문자로 만들어지는데 링크 쪽 표기는 그대로 두기 때문입니다.

배포 사이트에서는 이 문제가 드러나지 않습니다. 테마의 링크 렌더 훅이 `anchorize` 로 낮춰 주기 때문입니다. 그래서 앵커 표기 변경은 배포 산출물을 바꾸지 않고, 저장소에서 문서를 읽을 때만 달라집니다.

13곳을 제목 id 와 같은 표기로 맞췄습니다. 괄호가 든 제목 하나는 id 에서 괄호가 빠져 `#universally-unique-identifieruuid` 입니다.

개인빌드(Maven) 가이드에서는 링크 뒤에 닫는 괄호가 하나 더 붙어 배포된 문장에 `) 참조` 로 찍힙니다. 그 괄호를 지웠습니다.

```
$ curl -s -H "Accept: application/vnd.github.html+json" "https://api.github.com/repos/eGovFramework/egovframe-docs/contents/egovframe-runtime/foundation-layer/id-generation.md?ref=main" | grep -oE 'href="#[^"]*"' | grep -cE "[A-Z]|\("
13
$ git show origin/hugo-project:themes/krds-theme/layouts/_default/_markup/render-link.html | sed -n '24p' | tr -d '\015'
    {{ $anchor = printf "#%s" ((index $parts 1) | anchorize) }}
$ git show origin/main:egovframe-development/deployment-tool/maven.md | sed -n "70p" | grep -o "(#프로젝트-정보-생성)) 참조"
(#프로젝트-정보-생성)) 참조
```

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
