### PR TITLE
docs: 수정 요청 URL 에 빠진 .do 정정

### DIFF
--- a/common-component/system-management/batch-job-management.md
+++ b/common-component/system-management/batch-job-management.md
@@ -127,7 +127,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /sym/bat/updateBatchOpert | updateBatchOpert | "BatchOpertDao.updateBatchOpert" |
+| 수정 | /sym/bat/updateBatchOpert.do | updateBatchOpert | "BatchOpertDao.updateBatchOpert" |
 
  배치작업의 속성정보를 변경한 후 저장한다.
 

--- a/common-component/system-management/schedule-processing.md
+++ b/common-component/system-management/schedule-processing.md
@@ -130,7 +130,7 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /sym/bat/updateBatchSchdul | updateBatchSchdul | "BatchSchdulDao.updateBatchSchdul" |
+| 수정 | /sym/bat/updateBatchSchdul.do | updateBatchSchdul | "BatchSchdulDao.updateBatchSchdul" |
 
  배치스케줄의 속성정보를 변경한 후 저장한다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

배치작업관리·스케줄처리 가이드의 수정 행 요청 URL 에 `.do` 가 빠져 있습니다. 같은 문서의 다른 요청 URL 은 모두 `.do` 로 끝나고, 컨트롤러 매핑도 `.do` 가 붙은 쪽입니다.

두 문서에서 각 1줄에 `.do` 를 붙였습니다. 아래는 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `main` 에서 돌린 것입니다.

```
$ grep -rhA2 -e "\"/sym/bat/updateBatchOpert.do\"" -e "\"/sym/bat/updateBatchSchdul.do\"" src/main/java | grep -oE "\"/[A-Za-z/]+\.do\"|String [A-Za-z]+\("
"/sym/bat/updateBatchOpert.do"
String updateBatchOpert(
"/sym/bat/updateBatchSchdul.do"
String updateBatchSchdul(
$ grep -rl -e "/sym/bat/updateBatchOpert\"" -e "/sym/bat/updateBatchSchdul\"" src/main/java | wc -l
       0
```

그 행의 Controller method 열(`updateBatchOpert`·`updateBatchSchdul`)도 그 매핑의 메소드명과 일치합니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
