### PR TITLE
docs: 배치 예제의 클래스 패키지 표기를 5.0 기준으로 정정

### DIFF
--- a/egovframe-development/implementation-tool/batch-ide-batch-job-launcher-wizard.md
+++ b/egovframe-development/implementation-tool/batch-ide-batch-job-launcher-wizard.md
@@ -116,7 +116,7 @@ Repository Type은 JobRepository 설정이 프로젝트 내에 존재하지 않�
 .
 .
 .
-<bean id="newJobLauncher.egovBatchRunner" class="egovframework.brte.core.launch.support.EgovBatchRunner">
+<bean id="newJobLauncher.egovBatchRunner" class="org.egovframe.rte.bat.core.launch.support.EgovBatchRunner">
     <constructor-arg ref="jobRepository" />
     <constructor-arg ref="jobOperatorExample" />
     <constructor-arg ref="jobExplorerExample" />

--- a/egovframe-runtime/batch-layer/batch-core-event_notice_template_mgmt.md
+++ b/egovframe-runtime/batch-layer/batch-core-event_notice_template_mgmt.md
@@ -98,7 +98,7 @@ public class EgovEmailEventNoticeTrigger extends EgovEventNoticeTrigger {
 ```xml
 <-- 프로세서(리스너) 설정 1 의 Job 설정파일 (계속) -->
 <bean id="EmailEventNoticeTrigger"
- 	class="egovframework.brte.sample.example.event.EgovEmailEventNoticeTrigger" />
+ 	class="org.egovframe.rte.bat.sample.example.event.EgovEmailEventNoticeTrigger" />
 ```
 
 

--- a/egovframe-runtime/batch-layer/batch-core-multidata_process.md
+++ b/egovframe-runtime/batch-layer/batch-core-multidata_process.md
@@ -70,7 +70,7 @@ file-1.txt  file-2.txt  ignored.txt
 		    <property name="fieldSetMapper">
 			<bean class="org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper">
 			    <property name="targetType" 
-                               value="egovframework.brte.sample.common.domain.trade.CustomerCredit" />
+                               value="org.egovframe.rte.bat.sample.domain.trade.CustomerCredit" />
 			</bean>
          	    </property>
 		 </bean>
@@ -129,10 +129,10 @@ Processor에서는 전달된 데이터 타입에 맞게 비즈니스 로직을 �
 | 
 ```xml
 <bean id="compositeItemReader"
-   class="egovframework.brte.core.item.composite.reader.EgovCompositeFileReader">
+   class="org.egovframe.rte.bat.core.item.composite.reader.EgovCompositeFileReader">
     <property name="itemsMapper">
         <bean
-           class="egovframework.brte.core.item.composite.EgovCompositeItemMapper" />
+           class="org.egovframe.rte.bat.core.item.composite.EgovCompositeItemMapper" />
     </property>
     <property name="returnType" value="vo" />
     <property name="itemReaderList">
@@ -146,10 +146,10 @@ Processor에서는 전달된 데이터 타입에 맞게 비즈니스 로직을 �
 
 ```xml
 <bean id="compositeItemReader"
-   class="egovframework.brte.core.item.composite.reader.EgovCompositeFileReader">
+   class="org.egovframe.rte.bat.core.item.composite.reader.EgovCompositeFileReader">
     <property name="itemsMapper">
         <bean
-           class="egovframework.brte.core.item.composite.EgovCompositeItemMapper" />
+           class="org.egovframe.rte.bat.core.item.composite.EgovCompositeItemMapper" />
     </property>
     <property name="returnType" value="reader" />
     <property name="itemReaderList">
@@ -182,10 +182,10 @@ Processor에서는 전달된 데이터 타입에 맞게 비즈니스 로직을 �
 
 ```xml
 <bean id="compositeItemReader"
-   class="egovframework.brte.core.item.composite.reader.EgovCompositeFileReader">
+   class="org.egovframe.rte.bat.core.item.composite.reader.EgovCompositeFileReader">
     <property name="itemsMapper">
         <bean
-           class="egovframework.brte.core.item.composite.EgovCompositeItemMapper" />
+           class="org.egovframe.rte.bat.core.item.composite.EgovCompositeItemMapper" />
     </property>
     <property name="returnType" value="vo" />
     <property name="itemReaderList">
@@ -208,7 +208,7 @@ Processor에서는 전달된 데이터 타입에 맞게 비즈니스 로직을 �
             </property>
             <property name="fieldSetMapper">
                 <bean class="org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper">
-                    <property name="targetType" value="egovframework.brte.sample.common.domain.trade.CustomerCredit" />
+                    <property name="targetType" value="org.egovframe.rte.bat.sample.domain.trade.CustomerCredit" />
                 </bean>
             </property>
         </bean>
@@ -226,7 +226,7 @@ Processor에서는 전달된 데이터 타입에 맞게 비즈니스 로직을 �
             </property>
             <property name="fieldSetMapper">
                 <bean class="org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper">
-                    <property name="targetType" value="egovframework.brte.sample.common.domain.trade.CustomerCredit" />	
+                    <property name="targetType" value="org.egovframe.rte.bat.sample.domain.trade.CustomerCredit" />	
                 </bean>
             </property>
         </bean>

--- a/egovframe-runtime/batch-layer/batch-example-sync_async_v3.7.md
+++ b/egovframe-runtime/batch-layer/batch-example-sync_async_v3.7.md
@@ -72,7 +72,7 @@ Job 수행시, 동기와 비동기 방식으로 데이터를 처리할 수 있�
 	</property>
 </bean>
 
-<bean id="delegateObject" class="egovframework.brte.sample.common.domain.person.PersonService" />
+<bean id="delegateObject" class="org.egovframe.rte.bat.sample.domain.person.PersonService" />
 ```
 
 ### Async Item Processor 구성

--- a/egovframe-runtime/batch-layer/batch-execution-job_runner.md
+++ b/egovframe-runtime/batch-layer/batch-execution-job_runner.md
@@ -68,7 +68,7 @@ EgovBatchRunner를 사용하기 위해서는 XML 파일에 JobOperator, JobExplo
 EgovBatchRunner의 생성자에 JobOperator, JobExplorer, JobRepository를 전달한다.
 
 ```xml
-<bean id="jobBatchRunner" class="egovframework.brte.core.launch.support.EgovBatchRunner">
+<bean id="jobBatchRunner" class="org.egovframe.rte.bat.core.launch.support.EgovBatchRunner">
 	<constructor-arg ref="jobOperator" />
 	<constructor-arg ref="jobExplorer" />
 	<constructor-arg ref="jobRepository" />


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

배치 관련 가이드의 XML 예제에서 클래스 이름이 `egovframework.brte.…` 로 적혀 있습니다. 실행환경 저장소에 `brte` 패키지는 java 파일이 하나도 없고, 같은 클래스들은 `org.egovframe.rte.bat.…` 아래에 있습니다. 예제를 그대로 붙여 넣으면 빈 생성에서 실패합니다.

다섯 문서에서 13곳을 5.0 패키지로 맞췄습니다. 클래스 이름은 그대로이고 패키지만 바뀝니다. 예제 도메인 클래스는 `sample.common.domain.…` 에서 `common` 이 빠져 `sample.domain.…` 이 됐습니다.

아래는 실행환경 저장소(`eGovFramework/egovframe-runtime`)의 `main` 에서 돌린 것입니다. 두 번째 명령은 이번에 손댄 클래스 여섯 개를 그대로 조회합니다.

```
$ git ls-files "*.java" | grep -c "/brte/"
0
$ git ls-files "*.java" | sed "s|.*/java/||;s|/|.|g;s|\.java$||" | grep -E "EgovBatchRunner$|EgovEmailEventNoticeTrigger$|EgovCompositeFileReader$|EgovCompositeItemMapper$|sample.domain.person.PersonService$|sample.domain.trade.CustomerCredit$" | sort
org.egovframe.rte.bat.core.item.composite.EgovCompositeItemMapper
org.egovframe.rte.bat.core.item.composite.reader.EgovCompositeFileReader
org.egovframe.rte.bat.core.launch.support.EgovBatchRunner
org.egovframe.rte.bat.sample.domain.person.PersonService
org.egovframe.rte.bat.sample.domain.trade.CustomerCredit
org.egovframe.rte.bat.sample.example.event.EgovEmailEventNoticeTrigger
```

손댄 다섯 문서에는 옛 표기가 한 곳도 남지 않습니다. `batch-core-item_writer.md` 는 뺐습니다 — 그 문서의 `EmployeeItemPreparedStatementSetter` 는 5.0 에 대응 클래스가 없어, 나머지만 고치면 한 파일 안에서 표기가 갈립니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
