### PR TITLE
docs: 당직일지 표의 요청 URL·Controller method·Query ID 를 실제 매핑에 맞춰 정정

### DIFF
--- a/common-component/user-support/duty-management.md
+++ b/common-component/user-support/duty-management.md
@@ -182,7 +182,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 등록 | /uss/ion/bnt/insertBndtManage.do | insertBndtManage | "bndtManageDAO.insertBndtManage" |
+| 등록 | /uss/ion/bnt/insertBndtDiary.do | insertBndtDiary | "bndtManageDAO.insertBndtDiary" |
 
  당직체크코드 중 사용여부 필드중 사용으로 정의된 필드를 토대로 당직일지의 정보가 화면에 출력된다.
 
@@ -195,8 +195,8 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /uss/ion/bnt/selectBndtManage.do | selectBndtManage | "bndtManageDAO.selectBndtManage" |
-| 삭제 | /uss/ion/bnt/deleteBndtManage.do | deleteBndtManage | "bndtManageDAO.deleteBndtManage" |
+| 상세조회 | /uss/ion/bnt/selectBndtDiary.do | selectBndtDiary | "bndtManageDAO.selectBndtDiary" |
+| 삭제 | /uss/ion/bnt/deleteBndtDiary.do | deleteBndtDiary | "bndtManageDAO.deleteBndtDiary" |
 
  당직일지의 상세조회 화면이다. 수정 버튼을 통해서 수정화면으로 이동하고, 삭제 버튼을 통해서 당직일지를 삭제한다.
 
@@ -210,8 +210,8 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /uss/ion/bnt/updtBndtManage.do | updtBndtManage | "bndtManageDAO.updtBndtManage" |
-| 상세조회 | /uss/ion/bnt/selectBndtManage.do | selectBndtManage | "bndtManageDAO.selectBndtManage" |
+| 수정 | /uss/ion/bnt/updtBndtDiary.do | updtBndtDiary | "bndtManageDAO.updtBndtDiary" |
+| 상세조회 | /uss/ion/bnt/selectBndtDiary.do | selectBndtDiary | "bndtManageDAO.selectBndtDiary" |
 
  당직일지의 속성정보를 변경한 후 저장한다. 다음 화면은 당직일지 상세조회 화면과 동일하다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

당직관리 가이드의 당직일지 등록·상세·수정 세 절에 있는 표가 URL·Controller method·QueryID 세 열 모두 당직일지가 아니라 당직 쪽 값을 담고 있습니다. 그중 상세조회 두 줄의 `/uss/ion/bnt/selectBndtManage.do` 는 공통컴포넌트 저장소의 어느 컨트롤러에도 매핑돼 있지 않습니다.

당직일지 처리는 `EgovBndtManageController` 의 별도 매핑 네 개가 맡습니다. 아래는 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `main` 에서 돌린 것으로, 그 컨트롤러가 매핑하는 `.do` 전부입니다.

```
$ git show origin/main:src/main/java/egovframework/com/uss/ion/bnt/web/EgovBndtManageController.java | grep -o '/uss/ion/bnt/[A-Za-z]*\.do' | sort -u
/uss/ion/bnt/deleteBndtCeckManage.do
/uss/ion/bnt/deleteBndtDiary.do
/uss/ion/bnt/deleteBndtManage.do
/uss/ion/bnt/EgovBndtCeckManage.do
/uss/ion/bnt/EgovBndtCeckManageList.do
/uss/ion/bnt/EgovBndtCeckManageRegist.do
/uss/ion/bnt/EgovBndtManageDetail.do
/uss/ion/bnt/EgovBndtManageList.do
/uss/ion/bnt/EgovBndtManageListPop.do
/uss/ion/bnt/EgovBndtManageListPopAction.do
/uss/ion/bnt/EgovBndtManageRegist.do
/uss/ion/bnt/insertBndtCeckManage.do
/uss/ion/bnt/insertBndtDiary.do
/uss/ion/bnt/insertBndtManage.do
/uss/ion/bnt/insertBndtManageBnde.do
/uss/ion/bnt/selectBndtDiary.do
/uss/ion/bnt/selectBndtManageList.do
/uss/ion/bnt/updtBndtCeckManage.do
/uss/ion/bnt/updtBndtDiary.do
/uss/ion/bnt/updtBndtManage.do
```

`selectBndtDiary.do` 가 세 절이 설명하는 화면을 그대로 반환합니다.

```
$ git show origin/main:src/main/java/egovframework/com/uss/ion/bnt/web/EgovBndtManageController.java | grep -n 'EgovBndtDiary'
480:			return "egovframework/com/uss/ion/bnt/EgovBndtDiaryRegist";
482:			return "egovframework/com/uss/ion/bnt/EgovBndtDiaryUpdt";
484:			return "egovframework/com/uss/ion/bnt/EgovBndtDiaryDetail";
```

QueryID 열은 DAO 에서 확인됩니다. Namespace 는 `bndtManageDAO` 그대로이고 뒤의 statement 이름만 다릅니다.

```
$ git show origin/main:src/main/java/egovframework/com/uss/ion/bnt/service/impl/BndtManageDAO.java | grep -n 'bndtManageDAO\.[a-zA-Z]*BndtDiary'
85:        return (Integer)selectOne("bndtManageDAO.selectBndtDiaryTotCnt", bndtManageVO);
158:		return selectList("bndtManageDAO.selectBndtDiary", bndtDiaryVO);
167:		insert("bndtManageDAO.insertBndtDiary", bndtDiaryVO);
175:		update("bndtManageDAO.updtBndtDiary", bndtDiaryVO);
183:        delete("bndtManageDAO.deleteBndtDiary",bndtDiaryVO);
```

이 값들에 맞춰 세 절의 표를 고쳤습니다. 다섯 줄 모두 세 열이 함께 바뀝니다.

| 절 | Action | AS-IS | TO-BE |
| --- | --- | --- | --- |
| 당직일지 등록 | 등록 | `insertBndtManage` | `insertBndtDiary` |
| 당직일지 상세 | 상세조회 | `selectBndtManage` | `selectBndtDiary` |
| 당직일지 상세 | 삭제 | `deleteBndtManage` | `deleteBndtDiary` |
| 당직일지 수정 | 수정 | `updtBndtManage` | `updtBndtDiary` |
| 당직일지 수정 | 상세조회 | `selectBndtManage` | `selectBndtDiary` |

### 영향 범위

당직일지 세 절에 한정했습니다. 관련소스 표의 JSP·Query XML 목록은 이미 당직일지 항목을 담고 있어 그대로 두었습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
