### PR TITLE
docs: 로그인정책관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/user-authentication/login-policy-management.md
+++ b/common-component/user-authentication/login-policy-management.md
@@ -28,6 +28,14 @@ menu:
  
 ```
 
+```mermaid
+flowchart LR
+    L[로그인정책 목록조회] -->|등록| R[로그인정책 등록]
+    L -->|목록클릭| D[로그인정책 상세조회 및 수정]
+    D -->|저장| L
+    D -->|삭제| L
+```
+
 ### 패키지 참조 관계
 
  로그인정책관리 패키지는 요소기술의 공통(cmm) 패키지와 로그인 패키지에 대해서 직접적인 함수적 참조 관계를 가진다. 하지만, 컴포넌트 배포 시 오류 없이 실행되기 위하여 패키지 간의 참조관계에 따라 패키지와 포맷/날짜/계산, 메일연동 인터페이스, 시스템 패키지와 함께 배포 파일을 구성한다.
@@ -103,7 +111,8 @@ menu:
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 목록조회 | /uat/uap/selectLoginPolicyList.do | selectLoginPolicyList | "loginPolicyDAO.selectLoginPolicyList", <br> "loginPolicyDAO.selectLoginPolicyListTotCnt" |
+| 목록조회 | /uat/uap/selectLoginPolicyList.do | selectLoginPolicyList | "loginPolicyDAO.selectLoginPolicyList" |
+|  |  |  | "loginPolicyDAO.selectLoginPolicyListTotCnt" |
 
  ![로그인정책 목록조회](./images/uia-loginpolicyimg1.jpg)
 


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/user-authentication/login-policy-management.md`의 "로그인정책 목록조회" 표 QueryID 셀이 `<br>` 태그로 병합되어 있던 것을, 다른 문서와 동일한 표준 2행(QueryID + TotCnt) 표기 규칙으로 정정했습니다.
- 로그인정책 목록조회 → 등록/상세조회 → 수정/삭제로 이어지는 흐름을 시각화한 Mermaid 플로우차트를 추가했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/user-authentication/login-policy-management.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/user-authentication` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw