### PR TITLE
docs: 쿠키/세션 가이드 예제 코드 오류 수정

### DIFF
--- a/common-component/elementary-technology/cookie-session.md
+++ b/common-component/elementary-technology/cookie-session.md
@@ -55,7 +55,7 @@ import egovframework.com.utl.cas.service.EgovSessionCookieUtil;
 
 // 쿠키정보 생성
 String cookieNm = safeGetParameter(request, "NAME"); 
-String cookieVal = safeGetParameter(request, "김기수"); 
+String cookieVal = safeGetParameter(request, "VALUE"); 
 
 EgovSessionCookieUtil.setCookie(response, cookieNm, cookieVal); 
 


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [x] Bug fix (documentation content error)

## Description
- `common-component/elementary-technology/cookie-session.md`의 쿠키 사용방법 예제에서 `cookieVal` 값을 가져오는 코드가 `safeGetParameter(request, "김기수")`로 되어 있던 것을(파라미터명 자리에 값 문자열이 잘못 들어감), 바로 위 `cookieNm` 조회가 파라미터명 `"NAME"`을 사용하는 것과 동일한 패턴으로 `"VALUE"`로 정정했습니다.

## Related Issues
- 없음 (자체 문서 검수 중 발견)

## Affected Areas
- common-component/elementary-technology/cookie-session.md

## Checklist
- [x] `python scripts/docs_lint.py common-component/elementary-technology` 실행 결과 0 findings 확인
- [x] frontmatter(`---` 블록) 변경 없음
- [x] 로컬 미리보기로 렌더링 확인
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw