### PR TITLE
docs: 송수신 로그관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/system-management/send-receive-log-management.md
+++ b/common-component/system-management/send-receive-log-management.md
@@ -27,6 +27,14 @@ menu:
  ④ 송수신로그삭제 : 송수신로그정보를 삭제한다. - 실행환경의 Scheduling 기능을 이용
  ⑤ 송수신로그요약 : 송수신로그정보를 요약하여 Summary를 생성한다. - 실행환경의 Scheduling 기능을 이용
 
+```mermaid
+flowchart LR
+    T[송수신 테스트] -->|등록| R[송수신로그 등록]
+    R --> L[송수신로그 목록조회]
+    L -->|상세보기| D[송수신로그 상세조회]
+    S[Scheduler 1시간 주기] -->|요약/삭제| L
+```
+
 ### 패키지 참조 관계
 
  송수신로그관리 패키지는 요소기술의 공통(cmm) 패키지에 대해서만 직접적인 함수적 참조 관계를 가진다. 하지만, 컴포넌트 배포 시 오류 없이 실행되기 위하여 패키지 간의 참조관계에 따라 송수신모니터링, 달력 패키지와 함께 배포 파일을 구성한다.
@@ -111,14 +119,14 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 <!-- 송수신 로그 요약  -->
   <bean id="trsmrcvLogging"
     class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
-    <property name="targetObject" ref="egovLogManageScheduling" />
+    <property name="targetObject" ref="egovTrsmrcvLogScheduling" />
     <property name="targetMethod" value="trsmrcvLogSummary" />
     <property name="concurrent" value="false" />
   </bean>
  
   <!-- 송수신 로그 요약  트리거-->
   <bean id="trsmrcvLogTrigger"
-    class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+    class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
     <property name="jobDetail" ref="trsmrcvLogging" />
     <!-- 시작하고 1분후에 실행한다. (milisecond) -->
     <property name="startDelay" value="60000" />
@@ -144,7 +152,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 ```java
 @Service("egovTrsmrcvLogScheduling")
-public class EgovTrsmrcvLogScheduling {
+public class EgovTrsmrcvLogScheduling extends EgovAbstractServiceImpl {
 @Resource(name="EgovTrsmrcvLogService")
 private EgovTrsmrcvLogService trsmrcvLogService;
 /**


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
송수신 로그관리(`common-component/system-management/send-receive-log-management.md`) 문서의 Scheduling 설정/코드 예제에서 sibling 문서(로그관리, 사용로그관리, 웹로그관리)와 대조하여 확인한 오류 3건을 수정했습니다.
- `targetObject` 참조가 `egovLogManageScheduling`으로 되어 있어 실제 정의된 빈 id(`egovTrsmrcvLogScheduling`)와 불일치 → 정정
- 트리거 빈 클래스가 `SimpleTriggerBean`으로 되어 있어 sibling 문서들이 공통으로 쓰는 `SimpleTriggerFactoryBean`과 불일치 → 정정
- `EgovTrsmrcvLogScheduling` 클래스가 sibling Scheduling 클래스들과 달리 `EgovAbstractServiceImpl`을 상속하지 않음 → 추가

목록조회 → 상세조회, Scheduler 기반 요약/삭제 흐름을 시각화하는 Mermaid flowchart도 추가했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/system-management/send-receive-log-management.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
세 가지 수정 모두 동일 문서군(log-management.md, use-log-management.md, web-log-management.md)의 검증된 Scheduling 패턴과의 직접 비교를 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw