### PR TITLE
docs: 공통상세코드 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/system-management/common-detail-code.md
+++ b/common-component/system-management/common-detail-code.md
@@ -118,7 +118,7 @@ flowchart LR
 | --- | --- | --- | --- | --- |
 | 등록화면 | /sym/ccm/cde/RegistCcmCmmnDetailCodeView.do | insertCmmnDetailCodeView | "CmmnClCodeManage" | "selectCmmnClCodeList" |
 |  |  |  | "CmmnDetailCodeManage" | "selectCmmnCodeList" |
-| 등록 | /sym/ccm/cde/RegistCcmCmmnDetailCode.do | insertCmmnCode | "CmmnDetailCodeManage" | "insertCmmnDetailCode" |
+| 등록 | /sym/ccm/cde/RegistCcmCmmnDetailCode.do | insertCmmnDetailCode | "CmmnDetailCodeManage" | "insertCmmnDetailCode" |
 
  ![image](./images/sym-comdetail-등록.jpg)
 


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
공통상세코드(`common-component/system-management/common-detail-code.md`) 문서의 "공통상세코드 등록" 관련화면 테이블에서 Controller method가 "insertCmmnCode"(sibling 문서 common-code.md에서 복사된 흔적)로 되어 있어 같은 행의 SQL QueryID("insertCmmnDetailCode") 및 문서 전체에서 일관되게 사용되는 "CmmnDetailCode" 명명 규칙과 불일치했습니다. "insertCmmnDetailCode"로 정정했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/system-management/common-detail-code.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
같은 행의 QueryID 값과 대조하여 확인한 단순 오기입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw