### PR TITLE
docs: 법정동코드 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/system-management/legal-dong-code.md
+++ b/common-component/system-management/legal-dong-code.md
@@ -119,7 +119,7 @@ CNTC.ADMINISTCODE.INFO.userpw   = 서버인증서패스워드
     </bean>
 
     <bean id="administCodeReceiverTrigger"
-        class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+        class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
         <property name="jobDetail" ref="administCodeReceiver" />
         <!-- 시작하고 1분후에 실행한다. (milisecond) -->
         <property name="startDelay" value="60000" />


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
법정동코드(`common-component/system-management/legal-dong-code.md`) 문서의 scheduler 등록 예제에서 트리거 빈 클래스가 `SimpleTriggerBean`으로 되어 있어, 다른 Scheduling 문서들(로그관리, 사용로그관리, 웹로그관리, 송수신로그관리)이 공통으로 사용하는 `SimpleTriggerFactoryBean`과 불일치했습니다. `SimpleTriggerFactoryBean`으로 정정했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/system-management/legal-dong-code.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
동일 저장소 내 검증된 Scheduling 문서 패턴과의 비교를 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw