### PR TITLE
docs: 기관코드 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/system-management/org-code.md
+++ b/common-component/system-management/org-code.md
@@ -118,7 +118,7 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
     </bean>
 
     <bean id="insttCodeReceiverTrigger"
-        class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+        class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
         <property name="jobDetail" ref="insttCodeReceiver" />
         <!-- 시작하고 1분후에 실행한다. (milisecond) -->
         <property name="startDelay" value="60000" />
@@ -174,7 +174,7 @@ flowchart LR
     insttCodeRecptn.setFxnum            (tokenData[17]);    // 팩스번호                    :: 팩스번호
     insttCodeRecptn.setCreatDe          (tokenData[18]);    // 생성일자                    :: 생성일자
     insttCodeRecptn.setAblDe            (tokenData[19]);    // 폐지일자                    :: 폐지일자
-    insttCodeRecptn.setAblEnnc          (tokenData[20]);    // 폐지구분                    :: 폐지유무
+    insttCodeRecptn.setAblEnnc          (tokenData[20]);    // 폐지유무                    :: 폐지유무
     insttCodeRecptn.setChangede         (tokenData[21]);    // 변경일자                    :: 변경일자
     insttCodeRecptn.setChangeTime       (tokenData[22]);    // 변경시간                    :: 변경시간
     insttCodeRecptn.setBsisDe           (tokenData[23]);    // 기초날짜                    :: 기초일자


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
기관코드(`common-component/system-management/org-code.md`) 문서에서 확인한 오류 2건을 수정했습니다.
- scheduler 등록 예제의 트리거 빈 클래스가 `SimpleTriggerBean`으로 되어 있어 다른 Scheduling 문서들이 공통으로 사용하는 `SimpleTriggerFactoryBean`과 불일치 → 정정
- ServiceImpl 매핑 예시에서 `setAblEnnc` 필드의 주석이 `폐지구분 :: 폐지유무`로 좌우가 불일치했는데, 동일 필드명을 사용하는 sibling 문서(법정동코드, legal-dong-code.md)에서는 `폐지유무 :: 폐지유무`로 일관되게 쓰여 있어 이를 근거로 `폐지유무 :: 폐지유무`로 정정

## Related Issues
N/A

## Affected Areas
- common-component/system-management/org-code.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
두 수정 모두 sibling 문서 및 문서 내 다른 행과의 비교를 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw