### PR TITLE
docs: 웹에디터(2.0) 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/webeditor_20.md
+++ b/common-component/elementary-technology/webeditor_20.md
@@ -128,7 +128,7 @@ var config = new HTMLArea.Config();
   config.toolbar = [
 [ "fontname", "space",
   "fontsize", "space",
-  "formatblock", "space", ㅡㅏ
+  "formatblock", "space",
   "bold", "italic", "underline", "separator",
   "strikethrough", "subscript", "superscript", "separator",
   "copy", "cut", "paste", "space", "undo", "redo" ],


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
웹에디터(공통컴포넌트 2.0) 문서(`common-component/elementary-technology/webeditor_20.md`)의 툴바 설정 변경 JavaScript 예제 코드에 한글 자모(IME 오타로 추정되는 "ㅡㅏ")가 배열 리터럴 안에 잘못 삽입되어 있어, 예제를 그대로 복사할 경우 구문 오류가 발생했습니다. 해당 문자를 제거했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/webeditor_20.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
명백한 오타(한글 자모가 JS 배열 리터럴에 삽입)로 판단하여 제거했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw