### PR TITLE
docs: 세션처리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/handling_session.md
+++ b/common-component/elementary-technology/handling_session.md
@@ -70,7 +70,7 @@ EgovSessionCookieUtil.setSessionAttribute(request, "USER_NAME", "홍길동");
 logger.info("Session Infos : " + EgovSessionCookieUtil.getSessionValuesString(request));
  
 // 특정 세션 정보 취득
-String userId = (String)EgovSessionCookieUtil.getSessionAttribute("USER_ID");
+String userId = (String)EgovSessionCookieUtil.getSessionAttribute(request, "USER_ID");
  
 // 세션 정보 삭제
 EgovSessionCookieUtil.removeSessionAttribute(request, "USER_ID");


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
세션처리(`common-component/elementary-technology/handling_session.md`) 문서의 사용방법 예제에서 `getSessionAttribute("USER_ID")`가 `request` 인자 없이 호출되고 있었습니다. 문서에 명시된 메소드 시그니처(`getSessionAttribute(HttpServletRequest request, String key)`) 및 같은 코드 블록 내 다른 호출들과 대조하여 누락된 `request` 인자를 추가했습니다. (동일한 오류가 sibling 문서 cookie-session.md에서도 발견되어 이전 PR에서 수정된 바 있습니다.)

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/handling_session.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
문서 자체의 메소드 시그니처 표 및 동일 코드 블록 내 다른 호출과의 대조를 근거로 확인한 누락 인자입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw