### PR TITLE
docs: HTTP서비스모니터링 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/http-service-monitoring.md
+++ b/common-component/elementary-technology/http-service-monitoring.md
@@ -28,6 +28,18 @@ HTTP서비스모니터링을 등록하기 위한 목적으로 HTTP서비스모�
 6. **HTTP서비스모니터링로그목록조회**: HTTP서비스모니터링로그로 정의된 정보를 최근 등록 순서대로 조회하고, 그 결과 목록을 화면에 반영한다.
 7. **HTTP서비스모니터링로그조회**: 등록된 HTTP서비스모니터링로그정보를 조회한다.
 
+```mermaid
+flowchart LR
+    L[HTTP서비스모니터링 목록조회] -->|등록| R[HTTP서비스모니터링 등록]
+    L -->|상세조회| D[HTTP서비스모니터링 상세조회]
+    D -->|수정| U[HTTP서비스모니터링 수정]
+    D -->|삭제| L
+    R --> L
+    U --> L
+    S[Scheduler 10분 주기] -->|비정상시 메일통보| LL[HTTP서비스모니터링로그 목록조회]
+    LL -->|상세보기| LD[HTTP서비스모니터링로그 상세조회]
+```
+
 ### 관련소스
 
 | 유형 | 대상소스명 | 비고 |
@@ -79,7 +91,7 @@ HTTP서비스모니터링 스케줄러를 `context-scheduling.xml`에 등록한�
 
 <!-- HTTP서비스모니터링 트리거 -->
 <bean id="httpMntrngTrigger"
-    class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+    class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
     <property name="jobDetail" ref="httpMon" />
     <!-- 시작하고 1분 후에 실행한다. (milisecond) -->
     <property name="startDelay" value="60000" />
@@ -118,7 +130,7 @@ HTTP서비스모니터링 스케줄러를 `context-scheduling.xml`에 등록한�
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /utl/sys/htm/updateHttpMon | updateHttpMon | HttpMonDAO.updateHttpMon |
+| 수정 | /utl/sys/htm/updateHttpMon.do | updateHttpMon | HttpMonDAO.updateHttpMon |
 
 ### HTTP서비스모니터링 상세조회
 


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
HTTP서비스모니터링(`common-component/elementary-technology/http-service-monitoring.md`) 문서에서 확인한 오류 2건을 수정했습니다.
- 스케줄러 등록 예제의 트리거 빈 클래스가 `SimpleTriggerBean`으로 되어 있어 다른 검증된 Scheduling 문서들의 `SimpleTriggerFactoryBean`과 불일치 → 정정
- "HTTP서비스모니터링 수정" 테이블의 URL이 `/utl/sys/htm/updateHttpMon`으로 되어 있어 문서 내 다른 모든 URL이 갖는 `.do` 접미사가 누락됨 → 정정

목록조회 → 등록/수정/삭제, Scheduler 기반 로그 흐름을 시각화하는 Mermaid flowchart도 추가했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/http-service-monitoring.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
두 수정 모두 동일 문서 내 다른 행 및 검증된 sibling Scheduling 문서와의 비교를 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw