### PR TITLE
docs: 네트워크서비스모니터링 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/network-service-monitoring.md
+++ b/common-component/elementary-technology/network-service-monitoring.md
@@ -117,7 +117,7 @@ INSERT INTO COMTECOPSEQ VALUES ('NTWRKSVC_LOGID','0');
 
 <!-- 네트워크서비스모니터링 트리거-->
 <bean id="ntwrkSvcMntrngTrigger"
-    class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+    class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
     <property name="jobDetail" ref="ntwrkSvcMntrng" />
     <!-- 시작하고 1분후에 실행한다. (milisecond) -->
     <property name="startDelay" value="60000" />
@@ -139,8 +139,6 @@ INSERT INTO COMTECOPSEQ VALUES ('NTWRKSVC_LOGID','0');
     </property>
 </bean>
 ```
-
-## 참고자료
 
 ### 관련 화면 및 수행 매뉴얼
 
@@ -198,3 +196,7 @@ INSERT INTO COMTECOPSEQ VALUES ('NTWRKSVC_LOGID','0');
 ![네트워크서비스모니터링로그 상세조회](./images/network-service-monitoring-log-detail.png)
 
 - **목록** : 네트워크서비스모니터링로그 목록조회 화면으로 이동한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
네트워크서비스모니터링(`common-component/elementary-technology/network-service-monitoring.md`) 문서에서 확인한 오류 2건을 수정했습니다.
- 스케줄러 등록 예제의 트리거 빈 클래스가 `SimpleTriggerBean`으로 되어 있어 다른 검증된 Scheduling 문서들의 `SimpleTriggerFactoryBean`과 불일치 → 정정
- `## 참고자료` 제목이 내용 없이 "관련 화면 및 수행 매뉴얼" 섹션 앞에 잘못 위치해 있었고, 문서 끝에는 참고자료 섹션이 없었음. sibling 모니터링 문서들(파일시스템모니터링, HTTP서비스모니터링 등)이 공통으로 문서 말미에 배치하는 `## 참고자료` 섹션(공통컴포넌트 소스 저장소 링크)으로 정정

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/network-service-monitoring.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
두 수정 모두 동일 저장소 내 검증된 sibling 모니터링 문서들과의 구조/내용 비교를 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw