### PR TITLE
docs: 송수신모니터링 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/send-receive-monitoring.md
+++ b/common-component/elementary-technology/send-receive-monitoring.md
@@ -86,7 +86,7 @@ INSERT INTO COMTECOPSEQ VALUES('TR_MNTRNG_LOG_ID', '0');
 </bean>
 
 <!-- 송수신모니터링 트리거 -->
-<bean id="trsmrcvMntrngTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+<bean id="trsmrcvMntrngTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
     <property name="jobDetail" ref="trsmrcvMntrng" />
     <property name="startDelay" value="60000" />
     <property name="repeatInterval" value="600000" />


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
송수신모니터링(`common-component/elementary-technology/send-receive-monitoring.md`) 문서의 스케줄러 등록 예제에서 트리거 빈 클래스가 `SimpleTriggerBean`으로 되어 있어, 다른 검증된 Scheduling 문서들이 공통으로 사용하는 `SimpleTriggerFactoryBean`과 불일치했습니다. 정정했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/send-receive-monitoring.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
동일 저장소 내 검증된 Scheduling 문서 패턴(파일시스템모니터링, HTTP서비스모니터링, 네트워크서비스모니터링 등)과의 비교를 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw