### PR TITLE
docs: 프로세스모니터링 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/process-monitoring.md
+++ b/common-component/elementary-technology/process-monitoring.md
@@ -38,6 +38,18 @@ WINDOWS 및 UNIX 환경을 모두 지원하며, `globals.properties`의 `Globals
 6. **프로세스모니터링로그목록조회**: 프로세스모니터링로그로 정의된 정보를 최근 등록 순서대로 조회하고, 그 결과 목록을 화면에 반영한다.
 7. **프로세스모니터링로그조회**: 등록된 프로세스모니터링로그정보를 조회한다.
 
+```mermaid
+flowchart LR
+    L[프로세스모니터링 목록조회] -->|등록| R[프로세스모니터링 등록]
+    L -->|상세조회| D[프로세스모니터링 상세조회]
+    D -->|수정| U[프로세스모니터링 수정]
+    D -->|삭제| L
+    R --> L
+    U --> L
+    S[Scheduler 10분 주기] -->|비정상시 메일통보| LL[프로세스모니터링로그 목록조회]
+    LL -->|상세보기| LD[프로세스모니터링로그 상세조회]
+```
+
 ### 관련소스
 
 | 유형 | 대상소스명 | 비고 |
@@ -100,7 +112,7 @@ Globals.OsType = UNIX
 
 <!-- 프로세스모니터링 트리거 -->
 <bean id="processMntrngTrigger"
-    class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+    class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
     <property name="jobDetail" ref="processMntrng" />
     <property name="startDelay" value="60000" />
     <property name="repeatInterval" value="600000" />
@@ -146,7 +158,7 @@ Globals.OsType = UNIX
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /utl/sys/prm/updateProcessMon | updateProcessMon | ProcessMonDAO.updateProcessMon |
+| 수정 | /utl/sys/prm/updateProcessMon.do | updateProcessMon | ProcessMonDAO.updateProcessMon |
 
 ### 프로세스모니터링 상세조회
 


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
프로세스모니터링(`common-component/elementary-technology/process-monitoring.md`) 문서에서 확인한 오류 2건을 수정했습니다.
- 스케줄러 등록 예제의 트리거 빈 클래스가 `SimpleTriggerBean`으로 되어 있어 다른 검증된 Scheduling 문서들의 `SimpleTriggerFactoryBean`과 불일치 → 정정
- "프로세스모니터링 수정" 테이블의 URL이 `/utl/sys/prm/updateProcessMon`으로 되어 있어 문서 내 다른 모든 URL이 갖는 `.do` 접미사가 누락됨 → 정정 (HTTP서비스모니터링 문서에서도 동일한 패턴의 오류가 발견되어 수정된 바 있습니다)

목록조회 → 등록/수정/삭제, Scheduler 기반 로그 흐름을 시각화하는 Mermaid flowchart도 추가했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/process-monitoring.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
두 수정 모두 동일 문서 내 다른 행 및 검증된 sibling 모니터링 문서와의 비교를 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw