### PR TITLE
docs: 프록시서비스 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/proxy-service.md
+++ b/common-component/elementary-technology/proxy-service.md
@@ -135,8 +135,6 @@ INSERT INTO COMTECOPSEQ VALUES ('PROXYLOG_ID','0');
 - 프록시 로그를 저장하려면 서비스 상태가 정상으로 설정되어 있어야 한다.
 - 프록시 서버 정보(IP, Port 등)는 실제 운영 환경에 맞게 설정해야 한다.
 
-## 참고자료
-
 ### 관련화면 및 수행매뉴얼
 
 #### 프록시설정 목록조회
@@ -158,7 +156,7 @@ INSERT INTO COMTECOPSEQ VALUES ('PROXYLOG_ID','0');
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 저장 | /utl/sys/pxy/addProxySvc.do | insertProxySvc | proxySvcDAO.insertSynchrnServer |
+| 저장 | /utl/sys/pxy/addProxySvc.do | insertProxySvc | proxySvcDAO.insertProxySvc |
 | 목록 | /utl/sys/pxy/selectProxySvcList.do | selectProxySvcList | proxySvcDAO.selectProxySvcList |
 
 프록시설정 속성정보를 입력한 뒤 등록한다.
@@ -210,3 +208,7 @@ INSERT INTO COMTECOPSEQ VALUES ('PROXYLOG_ID','0');
 ![프록시로그 조회](./images/proxy-service-log-list.png)
 
 - **조회**: 기 등록된 프록시로그 목록을 조회한다.
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
프록시서비스(`common-component/elementary-technology/proxy-service.md`) 문서에서 확인한 오류 2건을 수정했습니다.
- "프록시설정 등록" 테이블의 QueryID가 `proxySvcDAO.insertSynchrnServer`로 되어 있어, 같은 행의 Controller method(`insertProxySvc`) 및 문서 전체의 명명 규칙과 전혀 다른 기능(동기화 서버 관련)에서 복사된 것으로 보였습니다. `proxySvcDAO.insertProxySvc`로 정정했습니다.
- `## 참고자료` 제목이 내용 없이 "관련화면 및 수행매뉴얼" 섹션 앞에 잘못 위치해 있었고, 문서 끝에는 참고자료 섹션이 없었습니다. sibling 문서들이 공통으로 문서 말미에 배치하는 참고자료 섹션(공통컴포넌트 소스 저장소 링크)으로 정정했습니다. (동일한 구조적 오류가 네트워크서비스모니터링 문서에서도 발견되어 수정된 바 있습니다.)

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/proxy-service.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
두 수정 모두 문서 내 다른 행 및 검증된 sibling 문서 구조와의 비교를 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw