### PR TITLE
docs: 웹표준검사 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/web-standard-check.md
+++ b/common-component/elementary-technology/web-standard-check.md
@@ -27,9 +27,7 @@ menu:
 | --- | --- | --- |
 | JSP | `/WEB-INF/jsp/egovframework/com/utl/sys/wsi/EgovWebStandardInspection.jsp` | 웹표준검사 위한 jsp페이지 |
 
-## 참고자료
-
-### 웹표준검사 관련화면 및 수행매뉴얼
+## 웹표준검사 관련화면 및 수행매뉴얼
 
 <!-- markdownlint-disable MD013 -->
 | Action | URL | Controller method | QueryID |
@@ -45,3 +43,7 @@ menu:
 - 상세검사: 웹표준 Validation Output을 팝업 화면으로 제공한다.
 
 ![웹표준검사 상세검사](./images/webstandardinspectiondetail.png)
+
+## 참고자료
+
+- [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Description
웹표준검사(`common-component/elementary-technology/web-standard-check.md`) 문서에서 `## 참고자료` 제목이 내용 없이 "관련화면 및 수행매뉴얼" 섹션 앞에 잘못 위치해 있었고, 문서 끝에는 참고자료 섹션이 없었습니다. sibling 문서들이 공통으로 문서 말미에 배치하는 참고자료 섹션(공통컴포넌트 소스 저장소 링크)으로 정정했습니다. (동일한 구조적 오류가 네트워크서비스모니터링, 프록시서비스 문서에서도 발견되어 이전 PR들에서 수정된 바 있습니다.)

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/web-standard-check.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
동일 저장소 내 다른 문서들에서 이미 검증된 참고자료 섹션 배치 패턴과의 비교를 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw