### PR TITLE
docs: 문자열변환 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/string-conversion.md
+++ b/common-component/elementary-technology/string-conversion.md
@@ -34,7 +34,7 @@ menu:
 | `nullConvert(Object src)` | `String` | 인자로 받은 String이 null일 경우 &quot;&quot;로 리턴한다 |
 | `nullConvert(String src)` | `String` | 인자로 받은 String이 null일 경우 &quot;&quot;로 리턴한다 |
 | `zeroConvert(Object src)` | `int` | 인자로 받은 String이 null일 경우 &quot;0&quot;로 리턴한다 |
-| `zeroConvert(String src)` | `int` | 인자로 받은 String이 null일 경우 &quot;&quot;로 리턴한다 |
+| `zeroConvert(String src)` | `int` | 인자로 받은 String이 null일 경우 &quot;0&quot;로 리턴한다 |
 | `cutString(String source, String output, int slength)` | `String` | 문자열을 지정한 길이에 맞게 처리한다. |
 | `cutString(String source, int slength)` | `String` | 문자열이 지정한 길이를 초과했을때 해당 문자열을 삭제하는 메서드 |
 | `decode(String sourceStr, String compareStr, String returnStr, String defaultStr)` | `String` | 오라클의 decode 함수와 동일한 기능을 가진 메서드이다 |


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
문자열변환(`common-component/elementary-technology/string-conversion.md`) 문서의 주요 메서드 표에서 `zeroConvert(String src)` 메서드(반환형 `int`)의 설명이 `nullConvert`에서 복사된 것으로 보이는 `""로 리턴한다` 문구로 되어 있어, 반환형 및 바로 위 `zeroConvert(Object src)` 행의 설명("0"으로 리턴한다)과 불일치했습니다. `"0"로 리턴한다`로 정정했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/string-conversion.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
같은 표 내 병렬 행(zeroConvert(Object src))과의 대조를 근거로 확인한 복사-붙여넣기 오류입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw