### PR TITLE
docs: Basic 로그 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/basiclog.md
+++ b/common-component/elementary-technology/basiclog.md
@@ -66,7 +66,7 @@ handlers 값을 다음과 같이 주어야 한다.
 | void | ignore(String message) | 기록이나 처리가 불필요한 경우 사용 |  |
 | void | debug(String message, Exception exception) | 디버그 정보를 기록하는 경우 사용 |  |
 | void | debug(String message) | 디버그 정보를 기록하는 경우 사용 |  |
-| void | info(String message)) | 일반적이 정보를 기록하는 경우 사용 |  |
+| void | info(String message) | 일반적이 정보를 기록하는 경우 사용 |  |
 
  다음은 ignore(String message)메소드를 이용하여 log를 콘솔에 출력하는 방법이다.
 


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
Basic 로그(`common-component/elementary-technology/basiclog.md`) 문서의 메소드 표에서 `info(String message))`에 괄호가 하나 더 붙어 있던 오타를 `info(String message)`로 정정했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/basiclog.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
명백한 괄호 오타입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw