### PR TITLE
docs: 출퇴근 관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/cmtmanage.md
+++ b/common-component/elementary-technology/cmtmanage.md
@@ -52,7 +52,7 @@ flowchart LR
 | QUERY XML | resources/egovframework/mapper/com/uss/cmt/EgovCmtManage\_SQL\_goldilocks.xml | 출퇴근관리 Goldilocks용 QUERY XML |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-Cmt.xml | 출퇴근관리 Id생성 Idgen XML |
 | Message | resources/egovframework/message/com/uss/cmt/message\_ko.properties | 출퇴근관리 message properties(한글) |
-| Message | resources/egovframework/message/com/uss/cmt/message\_ko.properties | 출퇴근관리 message properties(영문) |
+| Message | resources/egovframework/message/com/uss/cmt/message\_en.properties | 출퇴근관리 message properties(영문) |
 
 ### 클래스 다이어그램
 
@@ -119,7 +119,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('WRKTM_ID', 1);
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 등록 | uss/cmt/EgovCmtWrkStartInsert.do | insertWrkStartCmtInfo | "cmtManageDAO" | "insertWrkStartCmtInfo\_S" |
+| 등록 | /uss/cmt/EgovCmtWrkStartInsert.do | insertWrkStartCmtInfo | "cmtManageDAO" | "insertWrkStartCmtInfo\_S" |
 
  ![image](./images/cmt-출퇴근_출근.jpg)
 
@@ -133,7 +133,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('WRKTM_ID', 1);
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 등록 | uss/cmt/EgovCmtWrkEndInsert.do | insertWrkEndCmtInfo | "cmtManageDAO" | "insertWrkEndCmtInfo\_S" |
+| 등록 | /uss/cmt/EgovCmtWrkEndInsert.do | insertWrkEndCmtInfo | "cmtManageDAO" | "insertWrkEndCmtInfo\_S" |
 
  ![image](./images/cmt-출퇴근_퇴근.jpg)
 


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
출퇴근 관리(`common-component/elementary-technology/cmtmanage.md`) 문서에서 확인한 오류 3건을 수정했습니다.
- 영문 Message properties 행이 한글판과 동일한 파일(`message_ko.properties`)을 참조하고 있어 `message_en.properties`로 정정
- "출퇴근관리 출근"/"출퇴근관리 퇴근" 테이블의 URL 두 곳에 sibling 행("출퇴근관리 조회")과 달리 선행 슬래시(`/`)가 누락되어 있어 정정

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/cmtmanage.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
세 가지 수정 모두 문서 내 다른 행과의 비교를 근거로 확인한 오류입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw