### PR TITLE
docs: 경고메시지 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/warning_message.md
+++ b/common-component/elementary-technology/warning_message.md
@@ -72,7 +72,7 @@ String message = null;
 message = EgovMessageUtil.getWarnMsg("test.message");
  
 // 파라미터 처리 경고 메시지 취득 : String 배열의 값이 각각 {0}, {1}로 대치됨
-message = EgovMessageUtil.getWarnMsg("param.message", new String[2] {"경고", "해당되는 기대값이 없습니다."});
+message = EgovMessageUtil.getWarnMsg("param.message", new String[] {"경고", "해당되는 기대값이 없습니다."});
 ```
 
 ## 참고자료


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
경고메시지(`common-component/elementary-technology/warning_message.md`) 문서의 사용방법 예제 코드에서 `new String[2] {"경고", ...}` 배열 초기화 구문이 배열 크기 지정과 초기화 리스트를 동시에 사용하여 Java 컴파일 오류에 해당했습니다. `new String[] {"경고", ...}`로 정정했습니다. (동일한 오류가 sibling 문서 에러메시지(error_message.md)에서도 발견되어 별도 PR로 수정했습니다.)

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/warning_message.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
명백한 Java 배열 초기화 구문 오류입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw