### PR TITLE
docs: 확인메시지 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/confirm_message.md
+++ b/common-component/elementary-technology/confirm_message.md
@@ -68,11 +68,11 @@ import egovframework.com.utl.cas.service.EgovMessageUtil;
 ...
 String message = null;
  
-// 일반 정보 메시지 취득
+// 일반 확인 메시지 취득
 message = EgovMessageUtil.getConfirmMsg("test.message");
  
-// 파라미터 처리 정보 메시지 취득 : String 배열의 값이 각각 {0}, {1}로 대치됨
-message = EgovMessageUtil.getConfirmMsg("param.message", new String[2] {"확인", "해당되는 기대값이 없습니다."});
+// 파라미터 처리 확인 메시지 취득 : String 배열의 값이 각각 {0}, {1}로 대치됨
+message = EgovMessageUtil.getConfirmMsg("param.message", new String[] {"확인", "해당되는 기대값이 없습니다."});
 ```
 
 ## 참고자료


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
확인메시지(`common-component/elementary-technology/confirm_message.md`) 문서에서 확인한 오류 2건을 수정했습니다.
- 사용방법 예제 코드의 주석이 "정보 메시지 취득"으로 되어 있어(sibling 문서 info_message.md에서 복사된 흔적), 이 문서의 실제 주제인 "확인"과 불일치 → "확인 메시지 취득"으로 정정
- `new String[2] {"확인", ...}` 배열 초기화 구문이 배열 크기 지정과 초기화 리스트를 동시에 사용하여 Java 컴파일 오류에 해당 → `new String[] {"확인", ...}`로 정정 (동일한 배열 구문 오류 패턴이 error_message.md, warning_message.md, info_message.md에서도 발견되어 각각 수정했습니다)

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/confirm_message.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
message-process 문서군 4개 파일(정보/경고/에러/확인) 전체에서 동일한 두 가지 복사-붙여넣기 결함 패턴이 반복 발견되어 이번 배치에서 모두 정정했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw