### PR TITLE
docs: 트리메뉴 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/elementary-technology/tree-menu.md
+++ b/common-component/elementary-technology/tree-menu.md
@@ -80,5 +80,5 @@ N/A
 
 ## 참고자료
 
-- [메인메뉴](main-menu) — 트리메뉴에서 사용하는 DAT 파일의 생성·관리
+- [메인메뉴](./main-menu.md) — 트리메뉴에서 사용하는 DAT 파일의 생성·관리
 - [공통컴포넌트 소스 저장소 (egovframe-common-components)](https://github.com/eGovFramework/egovframe-common-components)


### PR DESCRIPTION
## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## Description
트리메뉴(`common-component/elementary-technology/tree-menu.md`) 문서의 참고자료 내부 링크가 `./` 접두사와 `.md` 확장자 없이 작성되어 있어, 같은 디렉터리 내 다른 문서에서 사용하는 상대경로 링크 규칙(`./filename.md`)과 불일치했습니다. 형식을 통일했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/elementary-technology/tree-menu.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
동일 디렉터리 내 다른 문서들의 일관된 상대경로 링크 규칙과의 비교를 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw