### PR TITLE
docs: 간부일정관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/collaboration/executive-schedule.md
+++ b/common-component/collaboration/executive-schedule.md
@@ -21,15 +21,13 @@ menu:
 
 간부일정관리는 간부일정 정보를 관리하기 위한 목적으로 간부일정 정보의 등록, 수정, 삭제, 조회, 목록조회의 기능을 수반한다.
 
-```text
-① 월별간부일정목록조회 : 간부일정으로 정의된 정보를 월별로 조회하고, 그 결과 목록을 화면에 반영한다.
-② 주별간부일정목록조회 : 간부일정으로 정의된 정보를 주별로 조회하고, 그 결과 목록을 화면에 반영한다.
-③ 일별간부일정목록조회 : 간부일정으로 정의된 정보를 일별로 조회하고, 그 결과 목록을 화면에 반영한다.
-④ 간부일정등록 : 간부일정정보를 등록하고, 등록 결과를 조회한다.
-⑤ 간부일정수정 : 기 등록된 간부일정정보의 항목들을 수정한다.
-⑥ 간부일정삭제 : 기 등록된 간부일정정보를 삭제한다.
-⑦ 간부일정상세조회 : 등록된 간부일정정보를 조회한다.
-```
+ ① 월별간부일정목록조회 : 간부일정으로 정의된 정보를 월별로 조회하고, 그 결과 목록을 화면에 반영한다.
+ ② 주별간부일정목록조회 : 간부일정으로 정의된 정보를 주별로 조회하고, 그 결과 목록을 화면에 반영한다.
+ ③ 일별간부일정목록조회 : 간부일정으로 정의된 정보를 일별로 조회하고, 그 결과 목록을 화면에 반영한다.
+ ④ 간부일정등록 : 간부일정정보를 등록하고, 등록 결과를 조회한다.
+ ⑤ 간부일정수정 : 기 등록된 간부일정정보의 항목들을 수정한다.
+ ⑥ 간부일정삭제 : 기 등록된 간부일정정보를 삭제한다.
+ ⑦ 간부일정상세조회 : 등록된 간부일정정보를 조회한다.
 
 ### 패키지 참조 관계
 
@@ -53,8 +51,8 @@ menu:
 | DAO | egovframework.com.cop.smt.lsm.service.impl.LeaderSchdulDAO.java | 간부일정관리를 위한 데이터처리 클래스 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovEmplyrList.jsp | 사용자 목록조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovEmplyrListPopup.jsp | 사용자 팝업 목록조회를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovLeaderSchdulList.jsp | 일지관리 수정 페이지 |
-| JSP | /WEB-INF/jsp/egovframework/com/cop/smt/dsm/EgovDiaryManageDetail.jsp | 간부일정 목록조회를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovLeaderSchdulList.jsp | 간부일정 목록조회를 위한 jsp페이지 |
+| JSP | /WEB-INF/jsp/egovframework/com/cop/smt/dsm/EgovDiaryManageDetail.jsp | 일지관리 수정 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovLeaderSchdulMonthList.jsp | 월별 간부일정 목록조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovLeaderSchdulWeekList.jsp | 주별 간부일정 목록조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovLeaderSchdulDailyList.jsp | 일별 간부일정 목록조회를 위한 jsp페이지 |


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
간부일정관리(`common-component/collaboration/executive-schedule.md`) 문서의 관련소스 표에서 두 행의 설명(비고)이 서로 뒤바뀌어 있었습니다.
- `EgovLeaderSchdulList.jsp`(간부일정관리 lsm 패키지)의 설명이 "일지관리 수정 페이지"로 되어 있었음
- `EgovDiaryManageDetail.jsp`(일지관리 dsm 패키지)의 설명이 "간부일정 목록조회를 위한 jsp페이지"로 되어 있었음

각 파일명·패키지 경로와 실제로 어울리는 설명으로 두 행을 맞바꿔 정정했습니다. 또한 기능 설명 번호 목록(①~⑦)의 불필요한 코드펜스를 제거해 형식을 통일했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/collaboration/executive-schedule.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
새로운 내용을 추정하지 않고, 문서에 이미 존재하는 두 설명 문구의 위치만 교정했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw