### PR TITLE
docs: 스크랩관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/collaboration/scrap-management.md
+++ b/common-component/collaboration/scrap-management.md
@@ -212,7 +212,7 @@ N/A
 | 수정화면 | /cop/scp/updateArticleScrapView.do | updateArticleScrapView | "ArticleScrap" | "selectArticleScrapDetail" |
 | 수정 | /cop/scp/updateArticleScrap.do | updateArticleScrap | "ArticleScrap" | "updateArticleScrap" |
 
-![스크랩 수정](./images//scrap-management-update.png)
+![스크랩 수정](./images/scrap-management-update.png)
 
 수정: 수정된 정보들이 저장 처리된다.
 


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
스크랩관리(`common-component/collaboration/scrap-management.md`) 문서의 "스크랩 수정" 섹션 이미지 경로가 `./images//scrap-management-update.png`로 슬래시가 중복되어 있어(깨진 링크), 같은 문서 내 다른 모든 이미지 경로(`./images/scrap-management-*.png`)와 대조하여 `./images/scrap-management-update.png`로 정정했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/collaboration/scrap-management.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
동일 문서 내 다른 이미지 경로들과의 비교를 근거로 확인한 명백한 오타입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw