### PR TITLE
docs: 일정관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/collaboration/schedule-management.md
+++ b/common-component/collaboration/schedule-management.md
@@ -51,8 +51,8 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_postgres.xml | 일정관리를 위한 PostgreSQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_tibero.xml | 일정관리를 위한 Tibero용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_goldilocks.xml | 일정관리를 위한 Goldilocks용 Query XML |
-| Message properties | resources/egovframework/message/com/cop/smt/sim/message_ko.properties | 마이페이지 Message properties(한글) |
-| Message properties | resources/egovframework/message/com/cop/smt/sim/message_en.properties | 마이페이지 Message properties(영문) |
+| Message properties | resources/egovframework/message/com/cop/smt/sim/message_ko.properties | 일정관리 Message properties(한글) |
+| Message properties | resources/egovframework/message/com/cop/smt/sim/message_en.properties | 일정관리 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-indvdlSchdulManage.xml | 일정관리 Id생성 Idgen XML |
 
 ### 클래스 다이어그램
@@ -218,7 +218,7 @@ N/A
 | 등록화면 | /cop/smt/sim/EgovIndvdlSchdulManageRegist.do | indvdlSchdulManageRegist | | |
 | 등록 | /cop/smt/sim/EgovIndvdlSchdulManageRegistActor.do | indvdlSchdulManageRegistActor | "IndvdlSchdulManage" | "insertIndvdlSchdulManage" |
 
-![일정관리 등록](./images/department-schedule-regist.jpg)
+![일정관리 등록](./images/schedule-management-regist.png)
 
 등록 : 입력한 일정관리 정보들이 저장 처리된다.
 


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
일정관리(`common-component/collaboration/schedule-management.md`) 문서에서 확인한 오류 2건을 수정했습니다.
- Message properties 두 행의 설명이 "마이페이지 Message properties"로 되어 있어(다른 문서에서 복사된 흔적), 관련소스 표의 다른 모든 행이 사용하는 "일정관리"와 불일치 → "일정관리 Message properties"로 정정
- "일정관리 등록" 화면 이미지가 `./images/department-schedule-regist.jpg`(다른 컴포넌트인 부서일정관리의 이미지)를 참조하고 있었음. 실제로 `schedule-management-regist.png` 파일이 이미지 디렉터리에 존재하며, 문서 내 다른 모든 이미지가 `schedule-management-*` 명명 규칙을 따르고 있어 이를 근거로 정정

## Related Issues
N/A

## Affected Areas
- common-component/collaboration/schedule-management.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
이미지 파일 존재 여부를 실제로 확인(`schedule-management-regist.png` 존재, `department-schedule-regist.jpg`는 별도 컴포넌트 소속)한 뒤 정정했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw