### PR TITLE
docs: 당직일괄등록 표의 Controller method·QueryID 를 실제 코드에 맞춰 정정

### DIFF
--- a/common-component/user-support/duty-management.md
+++ b/common-component/user-support/duty-management.md
@@ -161,9 +161,9 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 당직엑셀등록 화면조회 | /uss/ion/bnt/EgovBndtManageListPop.do | selectBndtManageBnde | "bndtManageDAO.selectBndtManageBnde" |
-| 당직엑셀등록 데이터 출력 | /uss/ion/bnt/EgovBndtManageListPopAction.do | selectBndtManageBnde | "bndtManageDAO.selectBndtManageBnde" |
-| 당직엑셀등록 처리 | /uss/ion/bnt/insertBndtManageBnde.do | insertBndtManageBnde | "bndtManageDAO.insertBndtManageBnde" |
+| 당직엑셀등록 화면조회 | /uss/ion/bnt/EgovBndtManageListPop.do | selectBndtManageBnde | |
+| 당직엑셀등록 데이터 출력 | /uss/ion/bnt/EgovBndtManageListPopAction.do | selectBndtManageBndeAction | "bndtManageDAO.selectBndtManageBnde" |
+| 당직엑셀등록 처리 | /uss/ion/bnt/insertBndtManageBnde.do | insertBndtManageBnde | "bndtManageDAO.insertBndtManage" |
 
  당직정보를 입력형식에 맞춰 엑셀에 등록된 내용을 일괄등록 처리한다.
  입력형식은


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

당직관리 가이드 당직일괄등록 절의 표에 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`) `main` 의 코드와 다른 칸이 있습니다.

컨트롤러에서 세 URL 의 매핑, 메서드 선언, 서비스 호출 줄을 뽑았습니다.

```
$ git show origin/main:src/main/java/egovframework/com/uss/ion/bnt/web/EgovBndtManageController.java | grep -n 'Mapping(\|public String\|egovBndtManageService\.' | sed -n '/EgovBndtManageListPop.do/,$p'
623:	@RequestMapping(value = "/uss/ion/bnt/EgovBndtManageListPop.do")
624:	public String selectBndtManageBnde(final HttpServletRequest request,
639:	@RequestMapping(value = "/uss/ion/bnt/EgovBndtManageListPopAction.do")
640:	public String selectBndtManageBndeAction(final MultipartHttpServletRequest multiRequest,
666:							List<BndtManageVO> bndeList = egovBndtManageService.selectBndtManageBndeX(is);
682:							model.addAttribute("bndtManageList", egovBndtManageService.selectBndtManageBnde(is));
704:	@PostMapping("/uss/ion/bnt/insertBndtManageBnde.do")
705:	public String insertBndtManageBnde(
747:		int iTemp = egovBndtManageService.selectBndtManageMonthCnt(bndtManageVO);
753:			egovBndtManageService.insertBndtManageBnde(bndtManageVO, checkedBndtManageForInsert);
```

엑셀 데이터 출력 요청 `EgovBndtManageListPopAction.do` 를 받는 메서드는 `selectBndtManageBndeAction` 입니다. 화면조회 요청 `EgovBndtManageListPop.do` 를 받는 `selectBndtManageBnde` 는 서비스를 부르지 않습니다.

처리 요청 `insertBndtManageBnde.do` 는 서비스의 `insertBndtManageBnde` 를 거쳐 DAO 의 `insertBndtManage` 를 부릅니다.

```
$ git show origin/main:src/main/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtManageServiceImpl.java | grep -n 'public void insertBndtManageBnde\|bndtManageDAO\.insertBndtManage'
134:		bndtManageDAO.insertBndtManage(bndtManageVO);
582:	public void insertBndtManageBnde(BndtManageVO bndtManageVO, String checkedBndtManageForInsert) throws Exception {
596:				bndtManageDAO.insertBndtManage(bndtManageTemp);
```

DAO 에서 `Bnde` 가 들어간 QueryID 는 `bndtManageDAO.selectBndtManageBnde` 하나뿐이고, `insertBndtManage` 는 `bndtManageDAO.insertBndtManage` 를 씁니다.

```
$ git show origin/main:src/main/java/egovframework/com/uss/ion/bnt/service/impl/BndtManageDAO.java | grep -n 'Bnde\|"bndtManageDAO\.insertBndtManage"'
60:		insert("bndtManageDAO.insertBndtManage", bndtManageVO);
192:	public BndtManageVO selectBndtManageBnde(BndtManageVO bndtManageVO) {
193:		return (BndtManageVO) selectOne("bndtManageDAO.selectBndtManageBnde", bndtManageVO);
```

코드에 맞춰 표의 세 줄에서 한 칸씩 고쳤습니다. 화면조회 줄의 QueryID 칸은 `common-component/user-support/map-management.md:189` 의 등록화면 줄처럼 비웠습니다.

| Action | 열 | AS-IS | TO-BE |
| --- | --- | --- | --- |
| 당직엑셀등록 화면조회 | QueryID | `"bndtManageDAO.selectBndtManageBnde"` | 빈 칸 |
| 당직엑셀등록 데이터 출력 | Controller method | `selectBndtManageBnde` | `selectBndtManageBndeAction` |
| 당직엑셀등록 처리 | QueryID | `"bndtManageDAO.insertBndtManageBnde"` | `"bndtManageDAO.insertBndtManage"` |

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
