### PR TITLE
docs: HTTP서비스모니터링 가이드 표의 요청 URL·Controller method·QueryID 를 실제 매핑에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/http-service-monitoring.md
+++ b/common-component/elementary-technology/http-service-monitoring.md
@@ -115,8 +115,8 @@ HTTP서비스모니터링 스케줄러를 `context-scheduling.xml`에 등록한�
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /utl/sys/htm/selectHttpMonList.do | selectHttpMonList | HttpMonDAO.selectHttpMonList |
-| 조회 | /utl/sys/htm/selectHttpMonList.do | selectHttpMonList | HttpMonDAO.selectHttpMonListCnt |
+| 조회 | /utl/sys/htm/EgovComUtlHttpMonList.do | selectHttpMonList | HttpMonDAO.selectHttpMonList |
+| 조회 | /utl/sys/htm/EgovComUtlHttpMonList.do | selectHttpMonList | HttpMonDAO.selectHttpMonTotCnt |
 
 목록은 페이지당 10건씩 조회되며 검색조건은 상태·관리자명에 대해 수행된다. 상태가 비정상일 때 관리자에게 이메일을 발송한다.
 
@@ -124,27 +124,27 @@ HTTP서비스모니터링 스케줄러를 `context-scheduling.xml`에 등록한�
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 등록 | /utl/sys/htm/addHttpMon.do | insertHttpMon | HttpMonDAO.insertHttpMon |
+| 등록 | /utl/sys/htm/EgovComUtlHttpMonRegist.do | insertHttpMon | HttpMonDAO.insertHttpMon |
 
 ### HTTP서비스모니터링 수정
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /utl/sys/htm/updateHttpMon.do | updateHttpMon | HttpMonDAO.updateHttpMon |
+| 수정 | /utl/sys/htm/EgovComUtlHttpMonModify.do | updateHttpMon | HttpMonDAO.updateHttpMon |
 
 ### HTTP서비스모니터링 상세조회
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /utl/sys/htm/getHttpMon.do | selectHttpMon | HttpMonDAO.selectHttpMon |
-| 삭제 | /utl/sys/htm/deleteHttpMon.do | deleteHttpMon | HttpMonDAO.deleteHttpMon |
+| 상세조회 | /utl/sys/htm/EgovComUtlHttpMonDetail.do | selectHttpMonDetail | HttpMonDAO.selectHttpMonDetail |
+| 삭제 | /utl/sys/htm/EgovComUtlHttpMonRemove.do | deleteHttpMon | HttpMonDAO.deleteHttpMon |
 
 ### HTTP서비스모니터링로그 목록조회
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 조회 | /utl/sys/htm/selectHttpMonLogList.do | selectHttpMonLogList | HttpMonDAO.selectHttpMonLogList |
-| 조회 | /utl/sys/htm/selectHttpMonLogList.do | selectHttpMonLogList | HttpMonDAO.selectHttpMonLogListCnt |
+| 조회 | /utl/sys/htm/EgovComUtlHttpMonLogList.do | selectHttpMonLogList | HttpMonDAO.selectHttpMonLogList |
+| 조회 | /utl/sys/htm/EgovComUtlHttpMonLogList.do | selectHttpMonLogList | HttpMonDAO.selectHttpMonLogTotCnt |
 
 검색조건은 상태·관리자명·모니터링시각에 대해 수행된다.
 
@@ -152,7 +152,7 @@ HTTP서비스모니터링 스케줄러를 `context-scheduling.xml`에 등록한�
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 상세조회 | /utl/sys/htm/getHttpMonLog.do | selectHttpMonLog | HttpMonDAO.selectHttpMonLog |
+| 상세조회 | /utl/sys/htm/EgovComUtlHttpMonDetailLog.do | selectHttpMonDetailLog | HttpMonDAO.selectHttpMonDetailLog |
 
 ## 참고자료
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

HTTP서비스모니터링 가이드의 관련화면 표 여섯 개가 적은 요청 URL(`/utl/sys/htm/addHttpMon.do`, `/utl/sys/htm/getHttpMon.do` 등)은 `EgovHttpMonController` 가 매핑하는 URL 이 아닙니다. 두 상세조회 행의 Controller method·QueryID 와 두 목록 표의 건수 QueryID 도 컨트롤러와 DAO 에 없는 이름입니다.

공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `main` 에서 컨트롤러가 매핑하는 URL 과 그 핸들러 메서드를 뽑은 결과입니다.

```
$ git show origin/main:src/main/java/egovframework/com/utl/sys/htm/web/EgovHttpMonController.java | grep -n -o -E '"/utl/sys/htm/[A-Za-z]+\.do"|public String [A-Za-z]+'
81:"/utl/sys/htm/EgovComUtlHttpMonList.do"
82:public String selectHttpMonList
116:"/utl/sys/htm/EgovComUtlHttpMonDetail.do"
117:public String selectHttpMonDetail
140:"/utl/sys/htm/EgovComUtlHttpMonRegist.do"
142:public String insertHttpMon
175:"/utl/sys/htm/EgovComUtlHttpMonModifyView.do"
177:public String selectHttpMonForUpdate
193:"/utl/sys/htm/EgovComUtlHttpMonModify.do"
195:public String updateHttpMon
220:"/utl/sys/htm/EgovComUtlHttpMonRemove.do"
222:public String deleteHttpMon
237:"/utl/sys/htm/selectHttpMonSttus.do"
239:public String selectProcessSttus
265:"/utl/sys/htm/EgovComUtlHttpMonLogList.do"
266:public String selectHttpMonLogList
315:"/utl/sys/htm/EgovComUtlHttpMonDetailLog.do"
316:public String selectHttpMonDetailLog
```

QueryID 열에 들어갈 statement 이름은 DAO 에 있습니다. 목록 건수는 `selectHttpMonTotCnt`·`selectHttpMonLogTotCnt` 입니다.

```
$ git show origin/main:src/main/java/egovframework/com/utl/sys/htm/service/impl/HttpMonDAO.java | grep -n -o '"HttpMonDAO\.[A-Za-z]*"'
35:"HttpMonDAO.selectHttpMonList"
47:"HttpMonDAO.selectHttpMonTotCnt"
59:"HttpMonDAO.selectHttpMonDetail"
70:"HttpMonDAO.insertHttpMon"
81:"HttpMonDAO.updateHttpMon"
92:"HttpMonDAO.deleteHttpMon"
104:"HttpMonDAO.selectHttpMonLogList"
116:"HttpMonDAO.selectHttpMonLogTotCnt"
128:"HttpMonDAO.selectHttpMonDetailLog"
139:"HttpMonDAO.insertHttpMonLog"
150:"HttpMonDAO.updateHttpMonSttus"
```

두 상세조회 행의 대상은 화면의 링크가 정합니다. 목록 화면은 `EgovComUtlHttpMonDetail.do` 로, 로그 목록 화면은 `EgovComUtlHttpMonDetailLog.do` 로 넘어갑니다.

```
$ git grep -n -o '/utl/sys/htm/EgovComUtlHttpMonDetail[A-Za-z]*\.do' origin/main -- src/main/webapp
origin/main:src/main/webapp/WEB-INF/jsp/egovframework/com/utl/sys/htm/EgovComUtlHttpMonList.jsp:79:/utl/sys/htm/EgovComUtlHttpMonDetail.do
origin/main:src/main/webapp/WEB-INF/jsp/egovframework/com/utl/sys/htm/EgovComUtlHttpMonLogList.jsp:133:/utl/sys/htm/EgovComUtlHttpMonDetailLog.do
```

표의 모든 행에서 URL 을 그 행의 Controller method 에 매핑된 주소로 바꿨고, 두 상세조회 행의 Controller method·QueryID 와 두 목록 표의 건수 QueryID 는 컨트롤러와 DAO 의 이름으로 맞췄습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
