### PR TITLE
docs: 경조사 수정 표의 QueryID 를 실제 코드에 맞춰 정정

### DIFF
--- a/common-component/user-support/staff-event.md
+++ b/common-component/user-support/staff-event.md
@@ -156,7 +156,7 @@ flowchart LR
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 수정 | /uss/ion/ctn/updtCtsnnManage.do | updtCtsnnManage | "ctsnnManageDAO.updtCtsnnManage" |
+| 수정 | /uss/ion/ctn/updtCtsnnManage.do | updtCtsnnManage | "ctsnnManageDAO.updateCtsnnManage" |
 | 상세조회 | /uss/ion/ctn/EgovCtsnnManageDetail.do | selectCtsnnManage | "ctsnnManageDAO.selectCtsnnManage" |
 
  경조사의 속성정보를 변경한 후 저장한다. 다음 화면은 경조사 상세조회 화면과 동일하다.


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

직원경조사관리 가이드 경조사 수정 절의 표에 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`) `main` 의 코드와 다른 칸이 있습니다.

수정 요청 `updtCtsnnManage.do` 를 받는 컨트롤러 메서드 `updtCtsnnManage` 는 서비스의 `updtCtsnnManage` 를 부릅니다.

```
$ git show origin/main:src/main/java/egovframework/com/uss/ion/ctn/web/EgovCtsnnManageController.java | grep -n 'updtCtsnnManage[.(]'
227:	 @PostMapping("/uss/ion/ctn/updtCtsnnManage.do")
228:	 public String updtCtsnnManage(@Valid @ModelAttribute("ctsnnManageVO") CtsnnManageVO ctsnnManageVO,
256:	    	egovCtsnnManageService.updtCtsnnManage(ctsnnManageVO);
```

서비스 구현은 DAO 의 `updtCtsnnManage` 를 부르고, DAO 는 `ctsnnManageDAO.updateCtsnnManage` 로 수정합니다.

```
$ git show origin/main:src/main/java/egovframework/com/uss/ion/ctn/service/impl/EgovCtsnnManageServiceImpl.java | grep -n 'updtCtsnnManage('
130:	public void updtCtsnnManage(CtsnnManageVO ctsnnManageVO) throws Exception {
134:		ctsnnManageDAO.updtCtsnnManage(ctsnnManageVO);
$ git show origin/main:src/main/java/egovframework/com/uss/ion/ctn/service/impl/CtsnnManageDAO.java | grep -n -A1 'void updtCtsnnManage('
64:	public void updtCtsnnManage(CtsnnManageVO ctsnnManageVO) {
65-		update("ctsnnManageDAO.updateCtsnnManage", ctsnnManageVO);
```

코드에 맞춰 표의 수정 줄 QueryID 칸을 `"ctsnnManageDAO.updtCtsnnManage"` 에서 `"ctsnnManageDAO.updateCtsnnManage"` 로 고쳤습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
