### PR TITLE
docs: 약식결재 반려 표의 QueryID 를 실제 statement 에 맞춰 정정

### DIFF
--- a/common-component/collaboration/brief-approval.md
+++ b/common-component/collaboration/brief-approval.md
@@ -261,7 +261,7 @@ infrmlSanctn = infrmlSanctnService.updateInfrmlSanctnReturn(converToInfrmlSanctn
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 반려 | /uss/ion/ism/EgovReturnPopup.do | selectReturnPopup | "InfrmlSanctnDAO.updateInfrmlSanctnReturn" |
+| 반려 | /uss/ion/ism/EgovReturnPopup.do | selectReturnPopup | "InfrmlSanctnDAO.updateInfrmlSanctnConfm" |
 
  약식결재의 속성정보를 변경한 후 저장한다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

약식결재 가이드의 약식결재 반려 표에서 QueryID 칸의 `"InfrmlSanctnDAO.updateInfrmlSanctnReturn"` 은 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`) `main` 의 DAO·매퍼에 없는 statement 입니다.

반려 서비스 `updateInfrmlSanctnReturn` 은 승인구분을 `R` 로 바꾼 뒤 승인과 같은 DAO 메서드 `updateInfrmlSanctnConfm` 을 부릅니다.

```
$ git show origin/main:src/main/java/egovframework/com/uss/ion/ism/service/impl/EgovInfrmlSanctnServiceImpl.java | grep -n 'public InfrmlSanctn updateInfrmlSanctn\(Confm\|Return\)\|setConfmAt("[CR]")\|infrmlSanctnDAO\.updateInfrmlSanctnConfm'
92:	public InfrmlSanctn updateInfrmlSanctnConfm(InfrmlSanctn infrmlSanctn) throws Exception{
93:		infrmlSanctn.setConfmAt("C");
94:		infrmlSanctnDAO.updateInfrmlSanctnConfm(infrmlSanctn);
106:	public InfrmlSanctn updateInfrmlSanctnReturn(InfrmlSanctn infrmlSanctn) throws Exception{
107:		infrmlSanctn.setConfmAt("R");
108:		infrmlSanctnDAO.updateInfrmlSanctnConfm(infrmlSanctn);
```

DAO 의 update QueryID 는 `"InfrmlSanctnDAO.updateInfrmlSanctn"` 과 `"InfrmlSanctnDAO.updateInfrmlSanctnConfm"` 이고, DB별 매퍼에서도 `update` 로 시작하는 statement id 는 이 둘뿐입니다.

```
$ git show origin/main:src/main/java/egovframework/com/uss/ion/ism/service/impl/InfrmlSanctnDAO.java | grep -n '"InfrmlSanctnDAO\.update'
66:		update("InfrmlSanctnDAO.updateInfrmlSanctn", infrmlSanctn);
76:		update("InfrmlSanctnDAO.updateInfrmlSanctnConfm", infrmlSanctn);
$ git grep -h -o -e 'namespace="[^"]*"' -e 'id="update[^"]*"' origin/main -- src/main/resources/egovframework/mapper/com/uss/ion/ism/ | sort | uniq -c
   8 id="updateInfrmlSanctn"
   8 id="updateInfrmlSanctnConfm"
   8 namespace="InfrmlSanctnDAO"
```

반려 표 QueryID 칸을 `"InfrmlSanctnDAO.updateInfrmlSanctnConfm"` 으로 고쳤습니다. 이 행의 URL 은 팝업이지만, 같은 문서 승인 표의 팝업 행(`common-component/collaboration/brief-approval.md:251`)도 QueryID 칸에 승인 서비스가 쓰는 statement 를 적고 있어 그 방식에 맞췄습니다.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
