### PR TITLE
docs: SVN Repositories View 가이드의 메뉴 이름을 실제 메뉴 라벨에 맞춰 정정

### DIFF
--- a/egovframe-development/implementation-tool/server-connection-management-svn.md
+++ b/egovframe-development/implementation-tool/server-connection-management-svn.md
@@ -25,7 +25,7 @@ menu:
 
 1. 사용자의 eclipse 개발환경에서 Perspective를 eGovFrame으로 변경한다.
 
-2. eGovFrame 통합메뉴 > Configuration > ServerConnection Management > Show SVN Repositories View 를 클릭한다.
+2. eGovFrame 통합메뉴 > Configuration > Server Connection Management > Show SVN Repositories View 를 클릭한다.
 
    ![SVN 메뉴](./images/svn-menu.jpg)
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

SVN Repositories View 가이드의 사용법 2단계가 메뉴 경로의 하위 메뉴를 `ServerConnection Management` 로 적고 있으나 개발환경 저장소(`eGovFramework/egovframe-development`)의 메뉴 라벨은 `Server Connection Management` 여서 이에 맞춰 고쳤습니다.

```
$ git grep -n -e 'ide.menu.configuration' -e 'Server Connection Management' -e 'Show SVN Repositories View' origin/main -- egovframework.dev.imp.ide/plugin.xml
origin/main:egovframework.dev.imp.ide/plugin.xml:87:            name="Show SVN Repositories View">
origin/main:egovframework.dev.imp.ide/plugin.xml:187:            locationURI="menu:egovframework.dev.imp.ide.menu.configuration?after=additions">
origin/main:egovframework.dev.imp.ide/plugin.xml:194:               label="Server Connection Management"
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
