### PR TITLE
docs: Boot 프로젝트 Gradle 전환 가이드의 마법사 이름을 실제 plugin.xml 이름에 맞춰 정정

### DIFF
--- a/egovframe-development/deployment-tool/boot-to-gradle.md
+++ b/egovframe-development/deployment-tool/boot-to-gradle.md
@@ -19,7 +19,7 @@ menu:
 2. Sample 프로젝트 생성
 
    * 개발환경 > eGovFrame > New Boot Web Project > [프로젝트 정보 입력-Next] > Generate Example 체크 [Finish] (또는)
-   * 개발환경 > file > New > eGovframe Boot Web Project > [프로젝트 정보 입력-Next] > Generate Example 체크 [Finish]
+   * 개발환경 > file > New > eGovFrame Boot Web Project > [프로젝트 정보 입력-Next] > Generate Example 체크 [Finish]
 
      ![생성 프로젝트 선택](./images/boot-gradle-sample-1.png)
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

Sample 프로젝트 생성 단계의 `file > New` 경로에 적힌 마법사 이름 `eGovframe Boot Web Project` 가 개발환경 저장소(`eGovFramework/egovframe-development`) `main` 의 `egovframework.boot.dev.imp.ide/plugin.xml` 에 등록된 이름과 달라 `eGovFrame Boot Web Project` 로 고쳤습니다.

```
$ git show origin/main:egovframework.boot.dev.imp.ide/plugin.xml | grep -n -e 'org.eclipse.ui.newWizards' -e 'name="eGovFrame Boot Web Project"'
5:         point="org.eclipse.ui.newWizards">
13:            name="eGovFrame Boot Web Project"
```

바뀐 줄 1줄.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
