### PR TITLE
docs: ItemReader 가이드의 고정길이 설정항목 이름을 실제 속성 columns 에 맞춰 정정

### DIFF
--- a/egovframe-runtime/batch-layer/batch-core-item_reader.md
+++ b/egovframe-runtime/batch-layer/batch-core-item_reader.md
@@ -422,7 +422,7 @@ SqlPagingQueryProviderFactoryBean는 환경 설정을 간단히 해주며 추천
 
 | EgovFlatFileItemReader 설정항목 | 내용                | 예시                                       |
 | --------------------------- | ----------------- | ---------------------------------------- |
-| column                      | 필드 경계의 범위를 나타낸다.  | 1-9,10-11                                |
+| columns                     | 필드 경계의 범위를 나타낸다.  | 1-9,10-11                                |
 | type                        | VO 클래스를 나타낸다.     | org.springframework.batch.CustomerCredit |
 | names                       | VO 클래스의 필드를 나타낸다. | name,credit                              |
 
@@ -455,7 +455,7 @@ EgovFixedByteLengthTokenizer는 기본적으로 FixedLengthTokenizer와 유사�
 
 | EgovFlatFileItemReader 설정항목 | 내용                      | 예시                                       |
 | --------------------------- | ----------------------- | ---------------------------------------- |
-| column                      | 필드 경계의 길이를 나타낸다.        | 1-9,10-11                                |
+| columns                     | 필드 경계의 길이를 나타낸다.        | 1-9,10-11                                |
 | byteEncoding                | byte 문자열의 인코딩 타입을 나타낸다. | utf-8                                    |
 | type                        | VO 클래스를 나타낸다.           | org.springframework.batch.CustomerCredit |
 | names                       | VO 클래스의 필드를 나타낸다.       | name,credit                              |


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

Fixed Length(고정길이)·ByteLength 방식 설정 표의 설정항목 `column` 을, `EgovFixedLengthTokenizer`·`EgovFixedByteLengthTokenizer` 의 setter `setColumns` 가 받는 속성 이름 `columns` 로 고쳤습니다.

```
$ git grep -n 'void setColumn' origin/main -- '*/EgovFixedLengthTokenizer.java' '*/EgovFixedByteLengthTokenizer.java'
origin/main:Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedByteLengthTokenizer.java:70:    public void setColumns(Range[] ranges) {
origin/main:Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedLengthTokenizer.java:60:    public void setColumns(Range[] ranges) {
```

바뀐 줄 2줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
