### PR TITLE
docs: VS Code Cache 설정 가이드의 기본 파일명·클래스명을 실제 폼 기본값에 맞춰 정정

### DIFF
--- a/egovframe-development/vscode-implementation-tool/vscode-config-generation-cache.md
+++ b/egovframe-development/vscode-implementation-tool/vscode-config-generation-cache.md
@@ -34,7 +34,7 @@ Ehcache 기반의 일반 캐시 설정 파일을 생성한다. 기본 캐시(def
 
 | 형식 | 기본 파일명 |
 |---|---|
-| XML | `ehcache` |
+| XML | `ehcache-default` |
 
 ### 설정 항목
 
@@ -42,7 +42,7 @@ Ehcache 기반의 일반 캐시 설정 파일을 생성한다. 기본 캐시(def
 
 | 항목 | 필수 | 설명 |
 |---|:---:|---|
-| File Name | ✓ | 생성될 XML 파일명 (기본값: `ehcache`) |
+| File Name | ✓ | 생성될 XML 파일명 (기본값: `ehcache-default`) |
 
 #### Configuration
 
@@ -83,7 +83,7 @@ Spring 환경에서 `CacheManager`에 Ehcache 설정 파일 경로를 제공하�
 | 형식 | 기본 파일명 / 클래스명 |
 |---|---|
 | XML | `context-cache` |
-| JavaConfig | `EgovCacheConfig` |
+| JavaConfig | `EgovEhcacheSpringConfig` |
 
 ### 설정 항목
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

New Cache 기본 파일명 `ehcache`(지원 형식 표와 File Name 기본값)와 New Ehcache Configuration 의 JavaConfig 기본 클래스명 `EgovCacheConfig` 를, 확장의 폼이 채우는 기본값 `ehcache-default`·`EgovEhcacheSpringConfig` 로 고쳤습니다.

```
$ curl -s https://raw.githubusercontent.com/eGovFramework/egovframe-vscode-initializr/v5.0.6/webview-ui/src/components/egov/forms/CacheForm.tsx | grep -n 'txtFileName: "ehcache'
18:		txtFileName: "ehcache-default",
$ curl -s https://raw.githubusercontent.com/eGovFramework/egovframe-vscode-initializr/v5.0.6/webview-ui/src/components/egov/forms/EhcacheForm.tsx | grep -n 'txtFileName: type'
86:			txtFileName: type === ConfigGenerationType.JAVA_CONFIG ? "EgovEhcacheSpringConfig" : "context-cache",
```

바뀐 줄 3줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
