### PR TITLE
docs: 메뉴생성관리 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/system-management/menu-creation.md
+++ b/common-component/system-management/menu-creation.md
@@ -136,7 +136,7 @@ flowchart LR
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
 | 조회 | /sym/mnu/mcm/EgovMenuCreatSiteMapSelect.do | selectMenuCreatSiteMap | "menuManageDAO.selectMenuCreatSiteMapList\_D" |
-| 등록 | /sym/mnu/mcm/EgovMenuCreatSiteMapInsert.do | selectMenuCreatSiteMapInsert | "menuManageDAO.selectMenuCreatSiteMapList\_D" |
+| 등록 | /sym/mnu/mcm/EgovMenuCreatSiteMapInsert.do | insertMenuCreatSiteMap | "menuManageDAO.selectMenuCreatSiteMapList\_D" |
 |  |  |  | "menuManageDAO.insertSiteMap\_S" |
 
  webapp의 절대path를 지정해야 한다. 변경대상 소스(/sym/mnu/mcm/EgovMenuCreatSiteMap.jsp)에서 수정해야한다.


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
메뉴생성관리(`common-component/system-management/menu-creation.md`) 문서의 "사이트맵 생성" 등록 액션에서 Controller method가 "selectMenuCreatSiteMapInsert"로 되어 있어 select와 Insert가 혼합된 비정상적인 명명이었습니다. 문서 내 다른 등록 액션들(`insertMenuCreatList` 등) 및 저장소 전체 캠페인에서 일관되게 확인된 `insert{기능명}` 명명 규칙과 대조하여 `insertMenuCreatSiteMap`으로 정정했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/system-management/menu-creation.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
동일 문서 내 등록 액션들과 저장소 전반의 명명 규칙 패턴을 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw