### PR TITLE
docs: 문자메시지서비스 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/collaboration/sms-service.md
+++ b/common-component/collaboration/sms-service.md
@@ -163,7 +163,7 @@ globals.properties에 관련된 내용은 요소기술 [프로퍼티 및 명령�
   <property name="concurrent" value="false" />
 </bean>
 
-<bean id="smsInfoReceiverTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+<bean id="smsInfoReceiverTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
   <property name="jobDetail" ref="smsInfoReceiver" />
   <!-- 시작하고 1분후에 실행한다. (milisecond) -->
   <property name="startDelay" value="60000" />


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
문자메시지서비스(`common-component/collaboration/sms-service.md`) 문서의 스케줄러 등록 예제에서 트리거 빈 클래스가 `SimpleTriggerBean`으로 되어 있어, 저장소 내 다른 검증된 Scheduling 문서들이 공통으로 사용하는 `SimpleTriggerFactoryBean`과 불일치했습니다. 정정했습니다.

## Related Issues
N/A

## Affected Areas
- common-component/collaboration/sms-service.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
동일 저장소 내 검증된 Scheduling 문서 패턴(로그관리, 모니터링 문서군 등)과의 비교를 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw