### PR TITLE
docs: VS Code 프로젝트 구동 가이드의 Maven 메뉴 이름을 실제 Reload Project 에 맞춰 정정

### DIFF
--- a/egovframe-development/development-etcdevtool-guide/vscode-usage-projects.md
+++ b/egovframe-development/development-etcdevtool-guide/vscode-usage-projects.md
@@ -78,7 +78,7 @@ JDK 목록은 다음 내용들로 자동으로 구성된다.
 
 ![Rebuild Project](./images/vscode-usage-projects-05-rebuild-project.png)
 
-2. VS Code 탐색기창 하단 JAVA Projects 뷰 → 대상 프로젝트 우클릭 → Maven → Reroad Project
+2. VS Code 탐색기창 하단 JAVA Projects 뷰 → 대상 프로젝트 우클릭 → Maven → Reload Project
 
 ![Reload Project](./images/vscode-usage-projects-06-reload-project.png)
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

문서의 Maven 하위 메뉴 항목 `Reroad Project` 를, JAVA PROJECTS 뷰에 이 메뉴를 넣는 `microsoft/vscode-java-dependency` 확장(0.27.6)의 명령 제목 `Reload Project` 로 고쳤습니다.

```
$ curl -s https://raw.githubusercontent.com/microsoft/vscode-java-dependency/0.27.6/package.json | grep -n -A2 -e '"javaProject.maven": \[' -e '"id": "javaProject.maven"'
878:      "javaProject.maven": [
879-        {
880-          "command": "java.project.update",
--
971:        "id": "javaProject.maven",
972-        "label": "Maven"
973-      },
$ curl -s https://raw.githubusercontent.com/microsoft/vscode-java-dependency/0.27.6/package.nls.json | grep -n 'java.project.update"'
14:  "contributes.commands.java.project.update": "Reload Project",
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
