### PR TITLE
docs: 접속통계 가이드 구조화 및 가독성 개선

### DIFF
--- a/common-component/statistics-reporting/connection-statistics.md
+++ b/common-component/statistics-reporting/connection-statistics.md
@@ -77,7 +77,7 @@
 
 ```java
 @Service("egovSysLogScheduling")
-public class EgovSysLogScheduling {
+public class EgovSysLogScheduling extends EgovAbstractServiceImpl {
 
 	@Resource(name="EgovSysLogService")
 	private EgovSysLogService sysLogService;
@@ -110,7 +110,7 @@ public class EgovSysLogScheduling {
 - 트리거 Bean 설정(src/main/resources/egovframework/spring/com/context-scheduling-sym-log-lgm.xml)
 
 ```xml
-<bean id="sysLogTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+<bean id="sysLogTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
     <property name="jobDetail" ref="sysLogging" />
     <property name="startDelay" value="60000" />
     <property name="repeatInterval" value="3600000" />


### PR DESCRIPTION
## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

## Description
접속통계(`common-component/statistics-reporting/connection-statistics.md`) 문서에서 확인한 오류 2건을 수정했습니다.
- `EgovSysLogScheduling` 클래스가 `EgovAbstractServiceImpl`을 상속하지 않고 있었습니다. 동일 클래스를 다루는 다른 로그관리 Scheduling 문서들(로그관리, 사용로그관리, 웹로그관리, 송수신로그관리 등)에서 검증된 패턴과 대조하여 `extends EgovAbstractServiceImpl`을 추가했습니다.
- 스케줄러 등록 예제의 트리거 빈 클래스가 `SimpleTriggerBean`으로 되어 있어 다른 검증된 Scheduling 문서들의 `SimpleTriggerFactoryBean`과 불일치 → 정정

## Related Issues
N/A

## Affected Areas
- common-component/statistics-reporting/connection-statistics.md

## Checklist
- [x] 문서 빌드/lint(`scripts/docs_lint.py`) 통과 확인
- [x] Frontmatter 변경 없음
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

## Additional Notes
동일 저장소 내 여러 로그/모니터링 Scheduling 문서에서 반복적으로 검증된 두 가지 패턴을 근거로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw