### PR TITLE
docs: VS Code Property 설정 가이드의 JavaConfig 기본 클래스명을 실제 이름에 맞춰 정정

### DIFF
--- a/egovframe-development/vscode-implementation-tool/vscode-config-generation-property.md
+++ b/egovframe-development/vscode-implementation-tool/vscode-config-generation-property.md
@@ -36,7 +36,7 @@ Property 카테고리는 다음 1가지 설정 유형을 제공한다.
 | 형식 | 기본 파일명 / 클래스명 |
 |---|---|
 | XML | `context-properties` |
-| JavaConfig | `EgovPropertyConfig` |
+| JavaConfig | `EgovPropertiesConfig` |
 
 ### 설정 항목
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

New Property 지원 형식 표의 JavaConfig 기본 클래스명 `EgovPropertyConfig` 를, 확장의 Property 폼이 JavaConfig 선택 시 채우는 기본값 `EgovPropertiesConfig` 로 고쳤습니다.

```
$ curl -s https://raw.githubusercontent.com/eGovFramework/egovframe-vscode-initializr/v5.0.5/webview-ui/src/components/egov/forms/PropertyForm.tsx | grep -n -A1 'case ConfigGenerationType'
63:			case ConfigGenerationType.XML:
64-				return "context-properties"
65:			case ConfigGenerationType.JAVA_CONFIG:
66-				return "EgovPropertiesConfig"
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
