### PR TITLE
docs: 화면 통계 스케줄러 클래스/Bean 설정 오류 수정

### DIFF
--- a/common-component/statistics-reporting/screen-statistics.md
+++ b/common-component/statistics-reporting/screen-statistics.md
@@ -77,7 +77,7 @@
 
 ```java
 @Service("egovWebLogScheduling")
-public class EgovWebLogScheduling {
+public class EgovWebLogScheduling extends EgovAbstractServiceImpl {
 
 	@Resource(name="EgovWebLogService")
 	private EgovWebLogService webLogService;
@@ -110,7 +110,7 @@ public class EgovWebLogScheduling {
 - 트리거 Bean 설정(src/main/resources/egovframework/spring/com/scheduling/context-scheduling-sym-log-wlg.xml)
 
 ```xml
-<bean id="webLogTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+<bean id="webLogTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
     <property name="jobDetail" ref="webLogging" />
     <property name="startDelay" value="60000" />
     <property name="repeatInterval" value="3600000" />


### PR DESCRIPTION
## 변경 사항

`common-component/statistics-reporting/screen-statistics.md` 문서의 환경설정 예제 코드 오류를 수정했습니다.

- `EgovWebLogScheduling` 클래스가 `EgovAbstractServiceImpl`을 상속하지 않고 있어, 동일 패키지의 다른 Scheduling 클래스(`EgovSysLogScheduling`, `EgovTrsmrcvLogScheduling` 등)와의 일관성이 깨져 있었습니다. `extends EgovAbstractServiceImpl`을 추가했습니다.
- 트리거 Bean 설정에서 `org.springframework.scheduling.quartz.SimpleTriggerBean`은 실제 존재하지 않는 클래스로, 다른 문서들과 동일하게 `SimpleTriggerFactoryBean`으로 수정했습니다.

## 체크리스트

- [x] Frontmatter(`---` 블록)는 수정하지 않았습니다.
- [x] `python scripts/docs_lint.py common-component/statistics-reporting` 실행 결과 findings 0건을 확인했습니다.
- [x] 예제 코드 수정은 문서 내 타 Scheduling 클래스 및 캠페인 전반의 반복 확인된 패턴에 근거했습니다.
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw