### PR TITLE
docs: 게시물 통계 Scheduling 클래스 상속 누락 수정

### DIFF
--- a/common-component/statistics-reporting/post-statistics.md
+++ b/common-component/statistics-reporting/post-statistics.md
@@ -76,7 +76,7 @@
 - 작업 클래스 생성(src/main/java/egovframework/com/sts/bst/service/EgovBbsStatsScheduling.java)
 
 ```java
-public class EgovBbsStatsScheduling {
+public class EgovBbsStatsScheduling extends EgovAbstractServiceImpl {
  
 	/** EgovBbsStatsService */
 	@Resource(name = "bbsStatsService")


### PR DESCRIPTION
## 변경 사항

`common-component/statistics-reporting/post-statistics.md` 문서의 환경설정 예제 코드 오류를 수정했습니다.

- `EgovBbsStatsScheduling` 클래스가 `EgovAbstractServiceImpl`을 상속하지 않고 있어, 캠페인 전반에서 반복 확인된 동일 패턴의 다른 Scheduling 클래스들(`EgovSysLogScheduling`, `EgovUserStatsScheduling` 등)과의 일관성이 깨져 있었습니다. `extends EgovAbstractServiceImpl`을 추가했습니다.

## 체크리스트

- [x] Frontmatter(`---` 블록)는 수정하지 않았습니다.
- [x] `python scripts/docs_lint.py common-component/statistics-reporting` 실행 결과 findings 0건을 확인했습니다.
- [x] 예제 코드 수정은 문서 내 타 Scheduling 클래스 및 캠페인 전반의 반복 확인된 패턴에 근거했습니다.
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw