### PR TITLE
docs: Docker 가이드의 메뉴·체크박스 표기를 실제 개발환경 라벨에 맞춰 정정

### DIFF
--- a/egovframe-development/deployment-tool/docker.md
+++ b/egovframe-development/deployment-tool/docker.md
@@ -90,7 +90,7 @@ $ docker version
 
 #### Step 1. 표준프레임워크 개발환경에서 제공하는 템플릿 웹 응용프로그램 제작
 
-##### 1. 개발환경에서 eGovframe &gt; Start &gt; New Web Project 선택한다.
+##### 1. 개발환경에서 eGovFrame &gt; Start &gt; New Web Project 선택한다.
 
 ![새 웹 프로젝트](./images/03-new-web-pro.png)
 
@@ -98,7 +98,7 @@ $ docker version
 
 ![프로젝트 이름](./images/04-pro-name.png)
 
-##### 3. “Generate Exmple”을 선택 후 하단의 “Finish” 버튼을 클릭하여 템플릿 프로잭트를 생성한다.
+##### 3. “Generate Example”을 선택 후 하단의 “Finish” 버튼을 클릭하여 템플릿 프로잭트를 생성한다.
 
 ![예제 생성](./images/05-gen-example.png)
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

`docker.md` 에 적힌 메뉴 이름(`eGovframe`)과 체크박스 이름(`Generate Exmple`)이 `eGovFramework/egovframe-development` 저장소에 있는 개발환경 플러그인의 라벨과 달라 각각 `eGovFrame`, `Generate Example` 로 고쳤습니다.

```
$ git grep -n -E 'label="(eGovFrame|Start)"' origin/main -- egovframework.dev.imp.core/plugin.xml
origin/main:egovframework.dev.imp.core/plugin.xml:18:               label="eGovFrame"
origin/main:egovframework.dev.imp.core/plugin.xml:22:                  label="Start"
origin/main:egovframework.dev.imp.core/plugin.xml:75:            label="eGovFrame"
$ git grep -n 'wizardspagesSelectSamplePage2' origin/main -- egovframework.dev.imp.ide/src
origin/main:egovframework.dev.imp.ide/src/egovframework/dev/imp/ide/common/IdeMessages.java:86:    public static String wizardspagesSelectSamplePage2;
origin/main:egovframework.dev.imp.ide/src/egovframework/dev/imp/ide/common/messages.properties:31:wizardspagesSelectSamplePage2 = Generate Example
origin/main:egovframework.dev.imp.ide/src/egovframework/dev/imp/ide/common/messages_ko.properties:22:wizardspagesSelectSamplePage2 = Generate Example
origin/main:egovframework.dev.imp.ide/src/egovframework/dev/imp/ide/wizards/pages/SelectExamplePage.java:93:            .setText(IdeMessages.wizardspagesSelectSamplePage2);
```

바뀐 줄 2줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
