### PR TITLE
docs: 행정전문용어사전관리 내용수정 Action 라벨 오류 수정

### DIFF
--- a/common-component/user-support/admin-terminology.md
+++ b/common-component/user-support/admin-terminology.md
@@ -187,8 +187,8 @@ CREATE TABLE COMTECOPSEQ ( table_name varchar(16) NOT NULL,
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 등록화면 | /uss/olh/awm/updateAdministrationWordView.do | updateAdministrationWordView | "AdministrationWord" | "selectAdministrationWordDetail" |
-| 등록 | /uss/olh/awm/updateAdministrationWord.do | updateAdministrationWord | "AdministrationWord" | "updateAdministrationWord" |
+| 수정화면 | /uss/olh/awm/updateAdministrationWordView.do | updateAdministrationWordView | "AdministrationWord" | "selectAdministrationWordDetail" |
+| 수정 | /uss/olh/awm/updateAdministrationWord.do | updateAdministrationWord | "AdministrationWord" | "updateAdministrationWord" |
 
  ![image](./images/uss-adminterm-administrationword_updt.png)
 


### PR DESCRIPTION
## 변경 사항

`common-component/user-support/admin-terminology.md` 문서의 "행정전문용어사전관리 내용수정" 섹션 표에서 Action 라벨 오류를 수정했습니다.

- 해당 표는 수정(Update) 섹션임에도 불구하고 Action 컬럼이 "등록화면"/"등록"으로 표기되어 바로 위 등록(Insert) 섹션의 라벨이 복사된 것으로 보입니다. URL(`updateAdministrationWordView.do`, `updateAdministrationWord.do`), Controller method(`updateAdministrationWordView`, `updateAdministrationWord`), 섹션 제목("내용수정") 및 하단 설명("수정: 수정된 정보들이 수정 처리된다.")과의 일관성에 근거하여 "수정화면"/"수정"으로 수정했습니다.

## 체크리스트

- [x] Frontmatter(`---` 블록)는 수정하지 않았습니다.
- [x] `python scripts/docs_lint.py common-component/user-support` 실행 결과 findings 0건을 확인했습니다.
- [x] 수정 사항은 문서 내 URL/Controller method/섹션 제목과의 내부 일관성에 근거했습니다.
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw