### PR TITLE
docs: Integration 서비스 Metadata 가이드의 표준여부 컬럼명을 실제 매핑에 맞춰 정정

### DIFF
--- a/egovframe-runtime/integration-layer/integration-service-metadata.md
+++ b/egovframe-runtime/integration-layer/integration-service-metadata.md
@@ -602,7 +602,7 @@ Integration 서비스 Metadata의 물리ERD 및 Table 설명은 다음과 같다
   <tr>
     <td style="text-align: center;">5</td>
     <td style="text-align: center;"></td>
-    <td>STANDARD_YN</td>
+    <td>SYSTEM_STANDARD_YN</td>
     <td>표준여부</td>
     <td>Boolean</td>
     <td>CHAR(1)</td>
@@ -722,7 +722,7 @@ Integration 서비스 Metadata의 물리ERD 및 Table 설명은 다음과 같다
   <tr>
     <td style="text-align: center;">8</td>
     <td style="text-align: center;"></td>
-    <td>STANDARD_YN</td>
+    <td>SERVICE_STANDARD_YN</td>
     <td>표준여부</td>
     <td>Boolean</td>
     <td>CHAR(1)</td>


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

물리 모델 Table 설명의 SYSTEM·SERVICE 표에 표준여부 컬럼명이 `STANDARD_YN` 으로 적혀 있어, Hibernate 매핑에 선언된 실제 컬럼명 `SYSTEM_STANDARD_YN`·`SERVICE_STANDARD_YN` 으로 고쳤습니다. 아래는 실행환경 저장소(`eGovFramework/egovframe-runtime`)의 `main` 에서 돌린 것입니다.

```
$ git grep -n "STANDARD_YN" origin/main -- "Integration/*.hbm.xml"
origin/main:Integration/org.egovframe.rte.itl.integration/src/main/resources/org/egovframe/rte/itl/integration/metadata/dao/hibernate/ServiceDefinition.hbm.xml:46:                  column="SERVICE_STANDARD_YN"/>
origin/main:Integration/org.egovframe.rte.itl.integration/src/main/resources/org/egovframe/rte/itl/integration/metadata/dao/hibernate/SystemDefinition.hbm.xml:30:                  column="SYSTEM_STANDARD_YN"
```

바뀐 줄 2줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
