### PR TITLE
docs: 약식결재 반려 QueryID 복사 오류 수정

### DIFF
--- a/common-component/collaboration/brief-approval.md
+++ b/common-component/collaboration/brief-approval.md
@@ -261,7 +261,7 @@ infrmlSanctn = infrmlSanctnService.updateInfrmlSanctnReturn(converToInfrmlSanctn
 
 | Action | URL | Controller method | QueryID |
 | --- | --- | --- | --- |
-| 반려 | /uss/ion/ism/EgovReturnPopup.do | selectReturnPopup | "InfrmlSanctnDAO.updateInfrmlSanctnConfm" |
+| 반려 | /uss/ion/ism/EgovReturnPopup.do | selectReturnPopup | "InfrmlSanctnDAO.updateInfrmlSanctnReturn" |
 
  약식결재의 속성정보를 변경한 후 저장한다.
 


### PR DESCRIPTION
## 변경 사항

`common-component/collaboration/brief-approval.md` 문서의 "약식결재 반려" 표에서 SQL QueryID 오류를 수정했습니다.

- 반려(Reject) Action 행의 QueryID가 바로 위 승인(Approve) 행과 동일하게 `InfrmlSanctnDAO.updateInfrmlSanctnConfm`으로 표기되어 있었습니다. 문서 상단 "사용방법" 섹션(반려 메소드 삽입 안내, `infrmlSanctnService.updateInfrmlSanctnReturn(...)`)에서 승인과 반려가 서로 다른 메소드(`updateInfrmlSanctnConfm` vs `updateInfrmlSanctnReturn`)임을 명시하고 있어, 이 근거에 따라 반려 행의 QueryID를 `InfrmlSanctnDAO.updateInfrmlSanctnReturn`으로 수정했습니다.

## 체크리스트

- [x] Frontmatter(`---` 블록)는 수정하지 않았습니다.
- [x] `python scripts/docs_lint.py common-component/collaboration` 실행 결과 findings 0건을 확인했습니다.
- [x] 수정 사항은 문서 내 "사용방법" 섹션에 명시된 서비스 메소드명과의 내부 일관성에 근거했습니다.
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw