### PR TITLE
docs: Gradle 빌드환경 전환 가이드의 위저드 이름을 실제 plugin.xml 에 맞춰 정정

### DIFF
--- a/egovframe-development/deployment-tool/to-gradle.md
+++ b/egovframe-development/deployment-tool/to-gradle.md
@@ -18,7 +18,7 @@ menu:
 
 2. Sample 프로젝트 생성
    * 개발환경 > eGovFrame > New Web Project > [프로젝트 정보 입력-Next] > Generate Example 체크 [Finish] (또는)
-   * 개발환경 > file > New > eGovfroame Web Project > [프로젝트 정보 입력-Next] > Generate Example 체크 [Finish]
+   * 개발환경 > file > New > eGovFrame Web Project > [프로젝트 정보 입력-Next] > Generate Example 체크 [Finish]
 
      ![생성 프로젝트 선택](./images/gradle-sample-1.png)
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

Gradle 빌드환경 전환 가이드의 Sample 프로젝트 생성 메뉴 경로에 위저드 이름이 `eGovfroame Web Project` 로 적혀 있어, 개발환경 저장소(`eGovFramework/egovframe-development`) `main` 의 `plugin.xml` 에 선언된 이름 `eGovFrame Web Project` 로 고쳤습니다.

```
$ git grep -n "eGovFrame Web Project" origin/main -- egovframework.dev.imp.ide/plugin.xml
origin/main:egovframework.dev.imp.ide/plugin.xml:13:            name="eGovFrame Web Project"
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
