### PR TITLE
docs: Custom Templates Generation 가이드의 radio 엘리먼트 예시를 실제 속성에 맞춰 정정

### DIFF
--- a/egovframe-development/implementation-tool/code-generation-template-custom.md
+++ b/egovframe-development/implementation-tool/code-generation-template-custom.md
@@ -123,14 +123,12 @@ checkbox :
 radio :
 
 ```xml
-<combo name="radio" label="View:" value="FreeMarker">
+<radio name="rdoConfigType" label="Configuration Type : " value="XML" required="true" listener="true">
     <elements>
-        <option value="freemarker">FreeMarker</option>
-        <option value="velocity">Velocity</option>
-        <option value="dispatcher">JSP</option>
-        <option value="xslt">XSLT</option>
+        <option>XML</option>
+        <option>Java</option>
     </elements>
-</combo>
+</radio>
 ```
 
 combo :


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

`radio :` 항목의 XML 예시가 바로 아래 `combo :` 항목과 동일한 `<combo>` 코드로 중복돼 있어, egovframe-development 소스의 실제 `<radio>` 사용례(`datasource/datasource.xml`)로 교체했습니다.

```
$ git grep -n "<radio\|<combo" -- egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/datasource/datasource.xml
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/datasource/datasource.xml:10:				<radio name="rdoConfigType" label="Configuration Type : " value="XML" required="true" listener="true">
egovframework.dev.imp.codegen.template.templates/eGovFrameTemplates/datasource/datasource.xml:24:				<combo name="rdoType" label="Driver Type: " value="DBCP" required="true">
```

바뀐 줄 10줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
