### PR TITLE
docs: CRUD Code Generation 가이드의 생성 파일명을 실제 출력 파일명에 맞춰 정정

### DIFF
--- a/egovframe-development/vscode-implementation-tool/vscode-code-generation.md
+++ b/egovframe-development/vscode-implementation-tool/vscode-code-generation.md
@@ -80,16 +80,16 @@ DDL 검증에 성공하면 에디터 아래에 **파싱된 테이블 정보**가
 | 옵션 | 설명 |
 |---|---|
 | VO Class | Value Object 클래스 (`TableNameVO.java`) |
-| Default VO Class | 기본 Value Object 클래스 (`DefaultVO.java`) |
+| Default VO Class | 기본 Value Object 클래스 (`TableNameDefaultVO.java`) |
 | Controller Class | 컨트롤러 클래스 (`TableNameController.java`) |
 | Service Interface | 서비스 인터페이스 (`TableNameService.java`) |
 | ServiceImpl Class | 서비스 구현 클래스 (`TableNameServiceImpl.java`) |
 | Mapper Interface | 매퍼 인터페이스 (`TableNameMapper.java`) |
 | MyBatis Mapper XML | MyBatis SQL 매핑 파일 (`TableName_SQL.xml`) |
 | Thymeleaf List Page | Thymeleaf 목록 페이지 (`TableNameList.html`) |
-| Thymeleaf Register Page | Thymeleaf 등록/수정 페이지 (`TableNameRegist.html`) |
+| Thymeleaf Register Page | Thymeleaf 등록/수정 페이지 (`TableNameRegister.html`) |
 | JSP List Page | JSP 목록 페이지 (`TableNameList.jsp`) |
-| JSP Register Page | JSP 등록/수정 페이지 (`TableNameRegist.jsp`) |
+| JSP Register Page | JSP 등록/수정 페이지 (`TableNameRegister.jsp`) |
 
 **Close Preview** 버튼을 클릭하면 미리보기 영역을 닫을 수 있다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

CRUD Code Generation 가이드의 미리보기 템플릿 표에서 Default VO Class와 Register 페이지 파일명이 VS Code 확장의 실제 출력 파일명과 달라 `TableNameDefaultVO.java`, `TableNameRegister.html`, `TableNameRegister.jsp`로 고쳤습니다.

```
$ git show origin/main:src/utils/codeGenerator.ts | grep -n "DefaultVO\|Register"
34:			outputPath: `src/main/java/${packagePath}/service/${tableName}DefaultVO.java`,
35:			fileName: `${tableName}DefaultVO.java`,
76:			outputPath: `src/main/resources/templates/thymeleaf/${tableNameCamelCase}/${tableNameCamelCase}Register.html`,
77:			fileName: `${tableNameCamelCase}Register.html`,
88:			outputPath: `src/main/webapp/WEB-INF/jsp/${packagePath}/${tableNameCamelCase}Register.jsp`,
89:			fileName: `${tableNameCamelCase}Register.jsp`,
$ git ls-tree -r origin/main --name-only -- templates/code/ | grep -i register
templates/code/sample-jsp-register.hbs
templates/code/sample-thymeleaf-register.hbs
```

바뀐 줄 6줄(3줄 추가, 3줄 삭제)

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
