### PR TITLE
docs: 간부일정관리 문서 오염된 JSP 행 제거 및 VO 오타 수정

### DIFF
--- a/common-component/collaboration/executive-schedule.md
+++ b/common-component/collaboration/executive-schedule.md
@@ -46,7 +46,7 @@ menu:
 | Model | egovframework.com.cop.smt.lsm.service.LeaderSchdul.java | 간부일정관리를 위한 Model 클래스 |
 | Model | egovframework.com.cop.smt.lsm.service.LeaderSttus.java | 간부상태관리를 위한 Model 클래스 |
 | VO | egovframework.com.cop.smt.lsm.service.EmplyrVO.java | 사용자 관리를 위한 VO 클래스 |
-| VO | egovframework.com.cop.smt.lsm.service.LeaderSchdulVO.java | 검간부일정관리를 위한 VO 클래스 |
+| VO | egovframework.com.cop.smt.lsm.service.LeaderSchdulVO.java | 간부일정관리를 위한 VO 클래스 |
 | VO | egovframework.com.cop.smt.lsm.service.LeaderSttusVO.java | 간부상태관리를 위한 VO 클래스 |
 | DAO | egovframework.com.cop.smt.lsm.service.impl.LeaderSchdulDAO.java | 간부일정관리를 위한 데이터처리 클래스 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovEmplyrList.jsp | 사용자 목록조회를 위한 jsp페이지 |

--- a/common-component/collaboration/executive-schedule.md
+++ b/common-component/collaboration/executive-schedule.md
@@ -52,7 +52,6 @@ menu:
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovEmplyrList.jsp | 사용자 목록조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovEmplyrListPopup.jsp | 사용자 팝업 목록조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovLeaderSchdulList.jsp | 간부일정 목록조회를 위한 jsp페이지 |
-| JSP | /WEB-INF/jsp/egovframework/com/cop/smt/dsm/EgovDiaryManageDetail.jsp | 일지관리 수정 페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovLeaderSchdulMonthList.jsp | 월별 간부일정 목록조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovLeaderSchdulWeekList.jsp | 주별 간부일정 목록조회를 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovLeaderSchdulDailyList.jsp | 일별 간부일정 목록조회를 위한 jsp페이지 |


### PR DESCRIPTION
## 변경 사항

`common-component/collaboration/executive-schedule.md` 문서의 관련소스 표에서 두 가지 오류를 수정했습니다.

- "관련소스" 표에 일지관리(journal-management, `com/cop/smt/dsm` 패키지) 기능의 `EgovDiaryManageDetail.jsp` 행이 잘못 포함되어 있었습니다. 이 문서의 다른 모든 JSP 행은 `com/cop/smt/lsm` 패키지(간부일정관리)에 속하며, 해당 행만 완전히 무관한 기능의 파일을 가리키고 있어 삭제했습니다.
- `LeaderSchdulVO.java`의 설명에 불필요한 "검" 글자가 앞에 붙어("검간부일정관리를 위한 VO 클래스") 있던 오타를 "간부일정관리를 위한 VO 클래스"로 수정했습니다. (동일 표의 `LeaderSchdul.java`, `LeaderSttusVO.java` 등 다른 행과의 표기 일관성에 근거)

## 체크리스트

- [x] Frontmatter(`---` 블록)는 수정하지 않았습니다.
- [x] `python scripts/docs_lint.py common-component/collaboration` 실행 결과 findings 0건을 확인했습니다.
- [x] 수정 사항은 문서 내 다른 행들과의 패키지/명명 일관성에 근거했습니다.
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw