### PR TITLE
docs: 부서일정관리 Message properties 설명 오염 수정

### DIFF
--- a/common-component/collaboration/department-schedule.md
+++ b/common-component/collaboration/department-schedule.md
@@ -54,8 +54,8 @@ menu:
 | Query XML | resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_postgres.xml | 부서일정관리를 위한 PostgreSQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_tibero.xml | 부서일정관리를 위한 Tibero용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_goldilocks.xml | 부서일정관리를 위한 Goldilocks용 Query XML |
-| Message properties | resources/egovframework/message/com/cop/smt/sdm/message_ko.properties | 마이페이지 Message properties(한글) |
-| Message properties | resources/egovframework/message/com/cop/smt/sdm/message_en.properties | 마이페이지 Message properties(영문) |
+| Message properties | resources/egovframework/message/com/cop/smt/sdm/message_ko.properties | 부서일정관리 Message properties(한글) |
+| Message properties | resources/egovframework/message/com/cop/smt/sdm/message_en.properties | 부서일정관리 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-deptSchdulManage.xml | 부서일정관리 Id생성 Idgen XML |
 
 ### 클래스 다이어그램


### PR DESCRIPTION
## 변경 사항

`common-component/collaboration/department-schedule.md` 문서의 관련소스 표에서 Message properties 설명 오류를 수정했습니다.

- Message properties 두 행의 설명이 "마이페이지 Message properties(한글)/(영문)"로 되어 있어, 같은 표의 다른 모든 행(부서일정관리 Controller/Service/DAO 등)과 일관되지 않았습니다. 이는 캠페인 전반에서 이미 확인된 바 있는 설명 텍스트 오염 패턴(다른 기능의 설명이 잘못 복사된 경우)과 동일한 유형으로, "부서일정관리 Message properties(한글)/(영문)"로 수정했습니다.

## 체크리스트

- [x] Frontmatter(`---` 블록)는 수정하지 않았습니다.
- [x] `python scripts/docs_lint.py common-component/collaboration` 실행 결과 findings 0건을 확인했습니다.
- [x] 수정 사항은 같은 표 내 다른 행들과의 일관성에 근거했습니다.
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw