### PR TITLE
docs: 장애신청관리 요청취소 QueryID 복사 오류 수정

### DIFF
--- a/common-component/system-management/error-application.md
+++ b/common-component/system-management/error-application.md
@@ -163,7 +163,7 @@ stateDiagram-v2
 | 상세조회 | /sym/tbm/tbr/getTroblReqst.do | selectTroblReqst | "troblReqstDAO.selectTroblReqst" |
 | 삭제 | /sym/tbm/tbr/removeTroblReqst.do | deleteTroblReqst | "troblReqstDAO.deleteTroblReqst" |
 | 요청 | /sym/tbm/tbr/requstTroblReqst.do | requstTroblReqst | "troblReqstDAO.requstTroblReqst" |
-| 요청취소 | /sym/tbm/tbr/requstTroblReqstCancl.do | requstTroblReqstCancl | "troblReqstDAO.requstTroblReqst" |
+| 요청취소 | /sym/tbm/tbr/requstTroblReqstCancl.do | requstTroblReqstCancl | "troblReqstDAO.requstTroblReqstCancl" |
 
  장애신청의 속성정보를 조회한다.
 


### PR DESCRIPTION
## 변경 사항

`common-component/system-management/error-application.md` 문서의 "장애신청 상세조회" 표에서 QueryID 오류를 수정했습니다.

- "요청취소" 행의 QueryID가 바로 위 "요청" 행과 동일하게 `troblReqstDAO.requstTroblReqst`로 표기되어 있었습니다. 같은 표의 다른 모든 행은 Controller method명과 QueryID명이 일치하는 패턴(`selectTroblReqst`/`selectTroblReqst`, `deleteTroblReqst`/`deleteTroblReqst`, `requstTroblReqst`/`requstTroblReqst`)을 따르고 있어, 이 근거에 따라 "요청취소" 행의 Controller method명 `requstTroblReqstCancl`에 맞춰 QueryID를 `troblReqstDAO.requstTroblReqstCancl`로 수정했습니다.

## 체크리스트

- [x] Frontmatter(`---` 블록)는 수정하지 않았습니다.
- [x] `python scripts/docs_lint.py common-component/system-management` 실행 결과 findings 0건을 확인했습니다.
- [x] 수정 사항은 같은 표 내 다른 행들과의 명명 일관성에 근거했습니다.
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw