### PR TITLE
docs: ID Generation 설정 가이드의 항목 이름·ID Type 선택지를 실제 폼 라벨에 맞춰 정정

### DIFF
--- a/egovframe-development/vscode-implementation-tool/vscode-config-generation-id-generation.md
+++ b/egovframe-development/vscode-implementation-tool/vscode-config-generation-id-generation.md
@@ -54,9 +54,9 @@ ID Generation 카테고리는 다음 3가지 설정 유형을 제공한다.
 
 | 항목 | 필수 | 설명 |
 |---|:---:|---|
-| ID Service Name | ✓ | ID 생성 서비스 빈 이름. 예) `egovIdGnrService` |
-| DataSource Name | ✓ | 데이터소스 빈 이름. 예) `dataSource` |
-| ID Type | ✓ | 생성할 ID의 Java 타입: `Long` / `String` |
+| Bean Name (ID Generation Service Name) | ✓ | ID 생성 서비스 빈 이름. 예) `egovIdGnrService` |
+| Data Source Name | ✓ | 데이터소스 빈 이름. 예) `dataSource` |
+| ID Type | ✓ | 생성할 ID의 Java 타입: `Default` / `BigDecimal` |
 | Query | | Sequence 조회 SQL. 예) `SELECT NEXTVAL('SEQ_ID')` |
 | Strategy Name | | ID 가공 전략 빈 이름 |
 | Prefix | | ID 앞에 붙일 접두사 |
@@ -90,11 +90,10 @@ ID Generation 카테고리는 다음 3가지 설정 유형을 제공한다.
 
 | 항목 | 필수 | 설명 |
 |---|:---:|---|
-| ID Service Name | ✓ | ID 생성 서비스 빈 이름. 예) `egovIdGnrService` |
-| DataSource Name | ✓ | 데이터소스 빈 이름. 예) `dataSource` |
-| ID Type | ✓ | 생성할 ID의 Java 타입: `Long` / `String` |
-| Table | | ID 채번 테이블 이름. 예) `IDS` |
-| Table Name Field Value | | 채번 테이블 내 ID 식별자 값 |
+| Bean Name (ID Generation Service Name) | ✓ | ID 생성 서비스 빈 이름. 예) `egovIdGnrService` |
+| Data Source Name | ✓ | 데이터소스 빈 이름. 예) `dataSource` |
+| Table Name | | ID 채번 테이블 이름. 예) `IDS` |
+| TABLE_NAME Column's Value | | 채번 테이블 내 ID 식별자 값 |
 | Block Size | | 한 번에 채번할 블록 크기. 예) `10` |
 | Strategy Name | | ID 가공 전략 빈 이름 |
 | Prefix | | ID 앞에 붙일 접두사 |
@@ -126,5 +125,5 @@ UUID(Universally Unique Identifier) 알고리즘을 사용하여 전역 고유 I
 
 | 항목 | 필수 | 설명 |
 |---|:---:|---|
-| ID Service Name | ✓ | ID 생성 서비스 빈 이름. 예) `egovIdGnrService` |
+| Bean Name (ID Generation Service Name) | ✓ | ID 생성 서비스 빈 이름. 예) `egovIdGnrService` |
 | Address | | UUID 생성에 사용할 MAC 주소 또는 IP 주소. 예) `00:00:00:00:00:00` |


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

ID Generation Configuration 표의 항목 이름 `ID Service Name`·`DataSource Name`·`Table`·`Table Name Field Value` 와 New Sequence ID Generation 의 ID Type 선택지 `Long` / `String` 이 확장의 ID Generation 폼과 달라, 폼의 라벨 `Bean Name (ID Generation Service Name)`·`Data Source Name`·`Table Name`·`TABLE_NAME Column's Value` 와 선택지 `Default` / `BigDecimal` 로 고치고, New Table ID Generation 폼에는 ID Type 항목이 없어 그 표의 ID Type 행을 지웠습니다.

```
$ curl -s https://raw.githubusercontent.com/eGovFramework/egovframe-vscode-initializr/v5.0.6/webview-ui/src/components/egov/forms/IdGenerationForm.tsx | grep -n -E 'label="(Bean Name|Data Source Name|Table Name|TABLE_NAME)'
387:							label="Bean Name (ID Generation Service Name)"
398:								label="Data Source Name"
438:									label="Table Name"
448:									label="TABLE_NAME Column's Value"
$ curl -s https://raw.githubusercontent.com/eGovFramework/egovframe-vscode-initializr/v5.0.6/webview-ui/src/components/egov/forms/IdGenerationForm.tsx | grep -n -A6 'label="ID Type"'
421:									label="ID Type"
422-									name="idType"
423-									value={formData.rdoIdType}
424-									onChange={(value: string) => handleInputChange("rdoIdType", value)}
425-									options={[
426-										{ value: "Base", label: "Default" },
427-										{ value: "BigDecimal", label: "BigDecimal" },
```

바뀐 줄 8줄, 지운 줄 1줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
