### PR TITLE
docs: subflow-state 가이드의 종료 태그를 실제 요소명에 맞춰 정정

### DIFF
--- a/egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md
+++ b/egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md
@@ -231,7 +231,7 @@ subflow-state 구성요소를 사용해서 하위 Flow 호출을 하게 된다.
 		<evaluate expression="booking.guests.add(currentEvent.attributes.guest)" />
 	</transition>
 	<transition on="creationCancelled" to="reviewBooking" />
-</subfow-state>
+</subflow-state>
 ```
 
 이 예제에서는 createGuest Flow를 호출한다. guestCreated 출력이 반환되면, 새로운 손님이 예약 손님 리스트에 추가된다.
@@ -244,7 +244,7 @@ input 구성요소를 사용하면 하위 Flow에 입력값을 건낼 수 있다
 <subflow-state id="addGuest" subflow="createGuest">
 	<input name="booking" />
 	<transition to="reviewBooking" />
-</subfow-state>
+</subflow-state>
 ```
 
 ##### subflow output 매핑
@@ -294,7 +294,7 @@ input 구성요소를 사용하면 하위 Flow에 입력값을 건낼 수 있다
 			<evaluate expression="booking.guests.add(currentEvent.attributes.guest)" />
 		</transition>
 		<transition on="creationCancelled" to="reviewBooking" />
-	</subfow-state>
+	</subflow-state>
  
 	<end-state id="bookingConfirmed">
 		<output name="bookingId" value="booking.id" />


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

subflow-state 가이드의 예제 3곳에서 종료 태그가 시작 태그와 다르게 `</subfow-state>`로 적혀 있어 `</subflow-state>`로 맞췄습니다.

```
$ git grep -n 'subfow-state\|subflow-state' origin/main -- egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md
origin/main:egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md:224:##### subflow-state
origin/main:egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md:226:subflow-state 구성요소를 사용해서 하위 Flow 호출을 하게 된다.
origin/main:egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md:229:<subflow-state id="addGuest" subflow="createGuest">
origin/main:egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md:234:</subfow-state>
origin/main:egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md:244:<subflow-state id="addGuest" subflow="createGuest">
origin/main:egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md:247:</subfow-state>
origin/main:egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md:255:<subflow-state  ..>
origin/main:egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md:292:	<subflow-state id="addGuest" subflow="createGuest">
origin/main:egovframe-runtime/business-logic-layer/swf-elements-flow-definiton.md:297:	</subfow-state>
```

바뀐 줄 3줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
