### PR TITLE
docs: Mapper Editor 가이드의 편집기·버튼·메뉴 이름을 실제 UI 에 맞춰 정정

### DIFF
--- a/egovframe-development/implementation-tool/dbio-editor-mapper-editor.md
+++ b/egovframe-development/implementation-tool/dbio-editor-mapper-editor.md
@@ -202,7 +202,7 @@ Package Explorer에서 해당 Mapper File을 선택하고 더블클릭하거나 
 
    ![Mapper Editor의 Query Test 화면](./images/mappereditor-querytest.png)
 
-6. SqlMap Editor의 Test 탭에서 "Binding Variables" 목록 우측에 있는 "Test Query" 버튼을 누르면 하단에 Result View가 자동으로 보이면서 쿼리결과를 보여준다.
+6. Mapper Editor의 Test 탭에서 "Binding Variables" 목록 우측에 있는 "Query Test" 버튼을 누르면 하단에 Result View가 자동으로 보이면서 쿼리결과를 보여준다.
 
    ![Mapper Editor의 Query Test 결과 화면](./images/mappereditor-queryresult.png)
 
@@ -239,7 +239,7 @@ Package Explorer에서 해당 Mapper File을 선택하고 더블클릭하거나 
 ### 신규 ResultMap 생성
 
 1. Mapper Editor 화면 중 좌측에 있는 Mapper Tree에서 마우스 오른쪽 키를 누르면 context menu가 나타난다.
-2. context menu에서 "Add ResultMap"을 선택한다.
+2. context menu에서 "Add resultMap"을 선택한다.
 3. 신규로 생성한 ResultMap 편집화면이 Mapper Tree 우측에 나타난다.
 4. ResultMap ID를 수정하거나, ResultMap Type를 지정할 수 있다. ResultMap Type이 기본형인 경우 선택항목에서 선택이 가능하다. 기본형이 아닌 경우 "Browse" 버튼을 사용하여 해당 클래스를 검색할 수 있으며 기존에 없는 경우에는 "Type *"를 눌러 신규로 클래스를 생성해야 한다.
 5. Property를 추가하려면 Property 목록 우측에 있는 "Add"버튼을 사용하여 추가 Property 값을 입력할 수 있다.


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

쿼리 테스트 6단계의 SqlMap Editor와 `Test Query` 버튼, 신규 ResultMap 생성 2단계의 `Add ResultMap` 메뉴가 개발환경 저장소(`eGovFramework/egovframe-development`) `main` 의 소스와 달라 Mapper Editor, `Query Test`, `Add resultMap` 으로 고쳤습니다.

```
$ git grep -n -e '"Query Test"' -e '"Add resultMap"' origin/main -- 'egovframework.dev.imp.dbio/src/egovframework/dev/imp/dbio/editor/*/Mapper*.java'
origin/main:egovframework.dev.imp.dbio/src/egovframework/dev/imp/dbio/editor/actions/MapperAddResultMapAction.java:53:		super(viewer, "Add resultMap");
origin/main:egovframework.dev.imp.dbio/src/egovframework/dev/imp/dbio/editor/parts/MapperQueryDetailsPart.java:512:		Button testQueryButton = toolkit.createButton(btnComposite, "Query Test", SWT.NONE);
```

바뀐 줄 2줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
