### PR TITLE
docs: 로그인 시간관리 쿠키 설명 순서 오류 수정

### DIFF
--- a/common-component/security/login_session_management.md
+++ b/common-component/security/login_session_management.md
@@ -125,7 +125,7 @@ public ModelAndView refreshSessionTimeout(@RequestParam Map<String, Object> comm
 
 ### 로그인 시간관리 남은시간 표시
 
- 쿠키로부터 만료 예정시간(egovLatestServerTime), 서버현재시간(egovExpireSessionTime)을 구하여 그 차이를 계산하여 로그인 남은 시간을 표시한다.
+ 쿠키로부터 서버현재시간(egovLatestServerTime), 만료 예정시간(egovExpireSessionTime)을 구하여 그 차이를 계산하여 로그인 남은 시간을 표시한다.
 
 #### 관련코드
 


### PR DESCRIPTION
## 변경 사항

`common-component/security/login_session_management.md` 문서의 "로그인 시간관리 남은시간 표시" 절에서 쿠키 설명 순서 오류를 수정했습니다.

- "쿠키로부터 만료 예정시간(egovLatestServerTime), 서버현재시간(egovExpireSessionTime)을 구하여..."라는 문장이 문서 상단의 "필터 쿠키값 설정" 표와 반대로 되어 있었습니다. 해당 표에 따르면 `egovLatestServerTime`은 "서버의 최근 시간", `egovExpireSessionTime`은 "세션 만료 시간"입니다. 이 근거에 따라 "서버현재시간(egovLatestServerTime), 만료 예정시간(egovExpireSessionTime)"으로 순서를 바로잡았습니다.

## 체크리스트

- [x] Frontmatter(`---` 블록)는 수정하지 않았습니다.
- [x] `python scripts/docs_lint.py common-component/security` 실행 결과 findings 0건을 확인했습니다.
- [x] 수정 사항은 문서 상단 "필터 쿠키값 설정" 표와의 내부 일관성에 근거했습니다.
- [x] 2026 전자정부 표준프레임워크 컨트리뷰션(대학생 부문) 제출 문서입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjPX5WTU6uBTHucRGGWrsw