### PR TITLE
docs: Bean Definition Profiles 가이드의 JDNI 오탈자를 JNDI 로 정정

### DIFF
--- a/egovframe-runtime/foundation-layer-core/ioc-container-bean-definition-profiles.md
+++ b/egovframe-runtime/foundation-layer-core/ioc-container-bean-definition-profiles.md
@@ -90,7 +90,7 @@ Profile의 설정방법에는 XML설정과 Annotation설정으로 나뉜다.
 
 \<jndi-datasource-config.xml>
 
-운영시점에 사용하는 "dataSource" bean을 정의하는 XML. Profile명은 "production"으로 정의하고 있으며 JDNI를 DataSource로 설정하고 있다. "production" Profile을 활성화시키면 해당 Bean이 동작한다.
+운영시점에 사용하는 "dataSource" bean을 정의하는 XML. Profile명은 "production"으로 정의하고 있으며 JNDI를 DataSource로 설정하고 있다. "production" Profile을 활성화시키면 해당 Bean이 동작한다.
 
 ```xml
 <beans profile="production">


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

ioc-container-bean-definition-profiles.md 에서 JNDI 를 "JDNI"로 잘못 적은 부분을, 같은 문서의 파일명·XML 태그가 일관되게 쓰는 JNDI 로 정정했습니다.

```
$ git show origin/main:egovframe-runtime/foundation-layer-core/ioc-container-bean-definition-profiles.md | grep -n 'JDNI\|jndi'
91:\<jndi-datasource-config.xml>
93:운영시점에 사용하는 "dataSource" bean을 정의하는 XML. Profile명은 "production"으로 정의하고 있으며 JDNI를 DataSource로 설정하고 있다. "production" Profile을 활성화시키면 해당 Bean이 동작한다.
97:    <jee:jndi-lookup id="dataSource" jndi-name="java:comp/env/jdbc/datasource"/>
128:        <jee:jndi-lookup id="dataSource" jndi-name="java:comp/env/jdbc/datasource"/>
```

바뀐 줄 1줄.

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
