### PR TITLE
docs: IoC 컨테이너 확장 가이드의 BeanFactoryPostProcesors 제목을 BeanFactoryPostProcessors로 정정

### DIFF
--- a/egovframe-runtime/foundation-layer-core/ioc-container-container_extension_points.md
+++ b/egovframe-runtime/foundation-layer-core/ioc-container-container_extension_points.md
@@ -83,7 +83,7 @@ public class InstantiationTracingBeanPostProcessor implements BeanPostProcessor 
 
  InstantiationTracingBeanPostProcessor는 단순히 정의된다. 비록 이름을 가지고 있지는 않지만 bean이기 때문에 다른 bean과 같이 종속성은 삽입될 수 있다.
 
-### BeanFactoryPostProcesors를 사용한 확장(Customizing configuration metadata with BeanFactoryPostProcessors)
+### BeanFactoryPostProcessors를 사용한 확장(Customizing configuration metadata with BeanFactoryPostProcessors)
 
  org.springframework.beans.factory.config.BeanFactoryPostProcessor는 BeanPostProcessor와 의미적으로 비슷하지만, 큰 차이점 중 하나는 BeanFactoryPostProcessors는 bean 설정 메타정보를 처리한다는 것이다. Spring IoC Container는 BeanFactoryPostProcessors가 설정 메타정보를 읽고, Container가 실제로 bean을 객체화 하기 전에 그 정보를 변경할 수 있도록 허용한다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

ioc-container-container_extension_points.md 의 제목에서 "BeanFactoryPostProcesors"로 잘못 적은 부분을, 같은 줄의 영문 병기 및 본문이 쓰는 BeanFactoryPostProcessors 로 정정했습니다.

```
$ git show origin/main:egovframe-runtime/foundation-layer-core/ioc-container-container_extension_points.md | grep -n "PostProces"
21:### BeanPostProcessors를 사용한 확장(Customizing beans using BeanPostProcessors)
23:BeanPostProcessors interface는 다수의 callback 메소드를 정의하고 있는데, 어플리케이션 개발자는 이들 메소드를 구현함으로써 자신만의 객체화 로직(instantiation logic), 종속성 해결 로직(dependency-resolution logic) 등을 제공할 수 있다.  
24:org.springframework.beans.factory.config.BeanPostProcessor interface는 두개의 callback 메소드로 구성되어 있다. 특정 class가 Container에 post-processor로 등록되면, post-processor는 Container에서 생성되는 각각의 bean 객체에 대해서, Container 객체화 메소드 전에 callback을 받는다.  
25:중요한 것은 BeanFactory는 post-processor를 다루는 방식에 있어서 ApplicationContext와는 조금 다르다. ApplicationContext는 BeanPostProcessor interface를 구현한 bean을 ***자동적으로 인식하고*** post-processor로 등록한다. 하지만 BeanFactory 구현을 사용하면 post-processor는 다음과 같이 명시적으로 등록되어야 한다.
30:// now register any needed BeanPostProcessor instances
31:MyBeanPostProcessor postProcessor = new MyBeanPostProcessor();
32:factory.addBeanPostProcessor(postProcessor);
39:#### Example: Hello World, BeanPostProcessor-style
46:import org.springframework.beans.factory.config.BeanPostProcessor;
49:public class InstantiationTracingBeanPostProcessor implements BeanPostProcessor {
78:    BeanPostProcessor implementation will output the fact to the system console
80:    <bean class="scripting.InstantiationTracingBeanPostProcessor"/>
84: InstantiationTracingBeanPostProcessor는 단순히 정의된다. 비록 이름을 가지고 있지는 않지만 bean이기 때문에 다른 bean과 같이 종속성은 삽입될 수 있다.
86:### BeanFactoryPostProcesors를 사용한 확장(Customizing configuration metadata with BeanFactoryPostProcessors)
88: org.springframework.beans.factory.config.BeanFactoryPostProcessor는 BeanPostProcessor와 의미적으로 비슷하지만, 큰 차이점 중 하나는 BeanFactoryPostProcessors는 bean 설정 메타정보를 처리한다는 것이다. Spring IoC Container는 BeanFactoryPostProcessors가 설정 메타정보를 읽고, Container가 실제로 bean을 객체화 하기 전에 그 정보를 변경할 수 있도록 허용한다.
```

바뀐 줄 1줄.

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
