### PR TITLE
docs: Flow 상속 가이드의 상속 불가 예시를 실제 State 타입 end-state 에 맞춰 정정

### DIFF
--- a/egovframe-runtime/business-logic-layer/swf-elements-flow-inheritance.md
+++ b/egovframe-runtime/business-logic-layer/swf-elements-flow-inheritance.md
@@ -47,7 +47,7 @@ Flow 수준 상속은 flow 내에 parent 속성을 이용하여 정의한다. �
 State 수준 상속은 Flow 수준 상속과 비슷하다. 유일한 차이점은 Flow 전체가 아니라 오직 해당 **State 하나만 상위로부터 상속**받는다.
 Flow 상속과 달리 오직 하나의 상위만 허용한다. 또한 상속받을 Flow State의 식별자가 반드시 정의되어 있어야 한다.
 Flow와 State 식별자는 #로 구분한다.
-**상위와 하위 State는 반드시 같은 타입이어야 한다.** 예를 들어 view-state는 ent-state를 상속받을 수 없다. 오직 view-state만 상속받을 수 있다
+**상위와 하위 State는 반드시 같은 타입이어야 한다.** 예를 들어 view-state는 end-state를 상속받을 수 없다. 오직 view-state만 상속받을 수 있다
 
 
 ```xml


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

State 수준 상속 예시에서 view-state가 상속받을 수 없다고 쓴 State 타입 `ent-state`를, 같은 문서의 병합 가능 엘리먼트 목록에 있는 실제 타입 `end-state`로 고쳤습니다.

```
$ grep -n 'ent-state\|end-state' egovframe-runtime/business-logic-layer/swf-elements-flow-inheritance.md
50:**상위와 하위 State는 반드시 같은 타입이어야 한다.** 예를 들어 view-state는 ent-state를 상속받을 수 없다. 오직 view-state만 상속받을 수 있다
92:- end-state: id
```

바뀐 줄 1줄.

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
