### PR TITLE
docs: 암복호화 가이드의 ARIACryptoService blockSize 예제값을 기본값 1024에 맞춰 정정

### DIFF
--- a/egovframe-runtime/foundation-layer/crypto-encryption-decryption.md
+++ b/egovframe-runtime/foundation-layer/crypto-encryption-decryption.md
@@ -221,7 +221,7 @@ location="classpath*:/META-INF/spring/crypto_config.properties,classpath*:/META-
  
 <bean id="ARIACryptoService" class="org.egovframe.rte.fdl.crypto.impl.EgovARIACryptoServiceImpl">
   <property name="passwordEncoder" ref="passwordEncoder" />
-  <property name="blockSize" value="1025" /><!-- default : 1024 -->
+  <property name="blockSize" value="1024" /><!-- default : 1024 -->
 </bean>
  
 <bean id="digestService" class="org.egovframe.rte.fdl.crypto.impl.EgovDigestServiceImpl">


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

ARIACryptoService 빈 예제의 blockSize 값이 1025로 되어 있어, 실행환경 저장소(`eGovFramework/egovframe-runtime`) `main` 의 EgovARIACryptoServiceImpl 기본값 1024 및 같은 문서 아래 generalCryptoService 빈 예제값 1024 에 맞춰 고쳤습니다.

```
$ git show origin/main:Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/impl/EgovARIACryptoServiceImpl.java | grep -n "private int blockSize"
39:    private int blockSize = 1024;
$ git show origin/main:egovframe-runtime/foundation-layer/crypto-encryption-decryption.md | grep -n "blockSize"
224:  <property name="blockSize" value="1025" /><!-- default : 1024 -->
235:  <property name="blockSize" value="1024" /><!-- default : 1024 -->
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
