### PR TITLE
docs: Entity Operation 가이드의 setDeptId 대입문을 메소드 호출로 정정

### DIFF
--- a/egovframe-runtime/persistence-layer/orm-entity_operation.md
+++ b/egovframe-runtime/persistence-layer/orm-entity_operation.md
@@ -101,7 +101,7 @@ public void testDeleteDepartment() throws Exception {
 public void testDeleteDepartment() throws Exception {
  
    Department department = new Department();
-   department.setDeptId = "DEPT_1";
+   department.setDeptId("DEPT_1");
  
    // 2. delete a Department information
    em.remove(em.getReference(Department.class, department.getDeptId()));


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

삭제 섹션 샘플 코드의 `department.setDeptId = "DEPT_1";`가 메소드에 값을 대입하는 잘못된 Java 문법이라, 같은 문서의 입력·배치입력 섹션과 동일한 메소드 호출 형태인 `department.setDeptId("DEPT_1");`로 고쳤습니다.

```
$ grep -n "setDeptId" egovframe-runtime/persistence-layer/orm-entity_operation.md
24:   department.setDeptId(DepartmentId);
104:   department.setDeptId = "DEPT_1";
124:      department.setDeptId(DeptId);
```

바뀐 줄 1줄.

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
