### PR TITLE
docs: Template Context 가이드의 javaType 예시를 실제 java.lang.String 매핑에 맞춰 정정

### DIFF
--- a/egovframe-development/vscode-implementation-tool/vscode-code-generation-template-context.md
+++ b/egovframe-development/vscode-implementation-tool/vscode-code-generation-template-context.md
@@ -66,7 +66,7 @@ menu:
   "ccName": "boardId",
   "pcName": "BoardId",
   "dataType": "VARCHAR",
-  "javaType": "String",
+  "javaType": "java.lang.String",
   "isPrimaryKey": true
 }
 ```
@@ -77,7 +77,7 @@ menu:
 | `ccName` | `string` | camelCase로 변환된 컬럼명. Java 필드명, MyBatis 파라미터명으로 사용된다. 예) `boardId` |
 | `pcName` | `string` | PascalCase로 변환된 컬럼명. getter/setter 메서드명 생성에 사용된다. 예) `BoardId` |
 | `dataType` | `string` | SQL 데이터 타입. 예) `VARCHAR`, `INT`, `DATETIME` |
-| `javaType` | `string` | 매핑된 Java 타입. 예) `String`, `int`, `java.util.Date` |
+| `javaType` | `string` | 매핑된 Java 타입. 예) `java.lang.String`, `java.lang.Integer`, `java.util.Date` |
 | `isPrimaryKey` | `boolean` | `PRIMARY KEY` 여부 |
 
 ## 활용 예시
@@ -113,7 +113,7 @@ CREATE TABLE BOARD (
       "ccName": "boardId",
       "pcName": "BoardId",
       "dataType": "VARCHAR",
-      "javaType": "String",
+      "javaType": "java.lang.String",
       "isPrimaryKey": true
     },
     {
@@ -121,7 +121,7 @@ CREATE TABLE BOARD (
       "ccName": "title",
       "pcName": "Title",
       "dataType": "VARCHAR",
-      "javaType": "String",
+      "javaType": "java.lang.String",
       "isPrimaryKey": false
     },
     {
@@ -129,7 +129,7 @@ CREATE TABLE BOARD (
       "ccName": "content",
       "pcName": "Content",
       "dataType": "TEXT",
-      "javaType": "String",
+      "javaType": "java.lang.String",
       "isPrimaryKey": false
     },
     {
@@ -147,7 +147,7 @@ CREATE TABLE BOARD (
       "ccName": "boardId",
       "pcName": "BoardId",
       "dataType": "VARCHAR",
-      "javaType": "String",
+      "javaType": "java.lang.String",
       "isPrimaryKey": true
     }
   ]


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

Template Context JSON 구조 예시의 `javaType` 값이 VARCHAR/TEXT 컬럼에 대해 `String`으로 적혀 있으나, VS Code 확장의 `dataTypes.ts`는 해당 타입들을 완전정규화된 `java.lang.String`으로 매핑하고 `ddlParser.ts`가 그 값을 그대로 `javaType` 필드에 쓰므로 예시값을 `java.lang.String`으로 고쳤다. 같은 근거로 타입 설명 표의 INT 컬럼 예시값 `int`도 `dataTypes.ts`의 `INT: "java.lang.Integer"` 매핑에 맞춰 `java.lang.Integer`로 고쳤다.

```
$ grep -n "VARCHAR:\|TEXT:" src/shared/dataTypes.ts
7:	VARCHAR: "java.lang.String",
9:	NVARCHAR: "java.lang.String",
13:	TEXT: "java.lang.String",
14:	MEDIUMTEXT: "java.lang.String",
53:	TINYTEXT: "java.lang.String",
54:	LONGTEXT: "java.lang.String",
$ grep -n "javaType: getJavaClassName" src/shared/ddlParser.ts
377:			javaType: getJavaClassName(rawDataType),
$ grep -n "VARCHAR\|TEXT" webview-ui/src/utils/__tests__/dataTypes.spec.ts
6:		expect(getJavaClassName("VARCHAR")).toBe("java.lang.String")
7:		expect(getJavaClassName("VARCHAR2")).toBe("java.lang.String")
9:		expect(getJavaClassName("TEXT")).toBe("java.lang.String")
10:		expect(getJavaClassName("MEDIUMTEXT")).toBe("java.lang.String")
$ grep -n "^\tINT:" src/shared/dataTypes.ts
19:	INT: "java.lang.Integer",
```

바뀐 줄 6줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
