### PR TITLE
docs: 코드 검사 도구 가이드의 AvoidArrayLoops 설명을 실제 규칙 설명에 맞춰 정정

### DIFF
--- a/egovframe-development/implementation-tool/code-inspection-tool.md
+++ b/egovframe-development/implementation-tool/code-inspection-tool.md
@@ -193,7 +193,7 @@ public class StaticField {
 
 ### Rule#05. AvoidArrayLoops
 
-* 설명: static 필드의 잘못된 사용
+* 설명: 배열의 값을 루프문을 이용하여 복사하는 것 보다, System.arraycopy() 메소드를 이용하여 복사하는 것이 효율적이며 수행 속도가 빠름
 * 오류코드:
 
 ```java


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

Code Inspection Tool 가이드의 Rule#05(AvoidArrayLoops) 설명이 바로 위 Rule#04(AssignmentToNonFinalStatic)의 설명을 그대로 담고 있어, 같은 규칙의 권장방안 및 `code-inspection.md` 5번 행과 같은 텍스트로 고쳤습니다.

```
$ git diff -U2 origin/main -- egovframe-development/implementation-tool/code-inspection-tool.md
diff --git a/egovframe-development/implementation-tool/code-inspection-tool.md b/egovframe-development/implementation-tool/code-inspection-tool.md
index e4380b97..6c761e0e 100644
--- a/egovframe-development/implementation-tool/code-inspection-tool.md
+++ b/egovframe-development/implementation-tool/code-inspection-tool.md
@@ -194,5 +194,5 @@ public class StaticField {
 ### Rule#05. AvoidArrayLoops
 
-* 설명: static 필드의 잘못된 사용
+* 설명: 배열의 값을 루프문을 이용하여 복사하는 것 보다, System.arraycopy() 메소드를 이용하여 복사하는 것이 효율적이며 수행 속도가 빠름
 * 오류코드:
```

바뀐 줄 2줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
