### PR TITLE
docs: Property Service 가이드의 messageSource 리소스 경로를 실제 패키지 경로에 맞춰 정정

### DIFF
--- a/egovframe-runtime/foundation-layer/property-service.md
+++ b/egovframe-runtime/foundation-layer/property-service.md
@@ -42,8 +42,8 @@ Property Service 는 시스템의 설치 환경에 관련된 정보나, 잦은 �
 	<property name="basenames">
 		<list>
 			<value>classpath:/message/message-common</value>
-			<value>classpath:/egovframework/rte/fdl/idgnr/messages/idgnr</value>
-			<value>classpath:/egovframework/rte/fdl/property/messages/properties</value>
+			<value>classpath:/org/egovframe/rte/fdl/idgnr/messages/idgnr</value>
+			<value>classpath:/org/egovframe/rte/fdl/property/messages/properties</value>
 		</list>
 	</property>
 	<property name="cacheSeconds">


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

Property Service 가이드의 messageSource Bean 설정에서 idgnr·property 리소스 경로가 `classpath:/egovframework/rte/fdl/...` 로 돼 있어, `eGovFramework/egovframe-runtime` 저장소의 실제 경로인 `classpath:/org/egovframe/rte/fdl/...` 로 고쳤습니다.

```
$ git ls-tree -r --name-only origin/main | grep -E "org/egovframe/rte/fdl/idgnr/messages/idgnr\.properties\$|org/egovframe/rte/fdl/property/messages/properties\.properties\$"
Foundation/org.egovframe.rte.fdl.idgnr/src/main/resources/org/egovframe/rte/fdl/idgnr/messages/idgnr.properties
Foundation/org.egovframe.rte.fdl.property/src/main/resources/org/egovframe/rte/fdl/property/messages/properties.properties
```

바뀐 줄 2줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
