### PR TITLE
docs: Authorization 가이드의 requestMatcherType 기본값 주석을 regex로 정정

### DIFF
--- a/egovframe-runtime/foundation-layer/server-security-authorization.md
+++ b/egovframe-runtime/foundation-layer/server-security-authorization.md
@@ -46,7 +46,7 @@ Server Security에서는 Filter Security Interceptor에 의해 처리되며, DB�
  
 <beans:bean id="securedObjectService" class="org.egovframe.rte.fdl.security.secureobject.impl.SecuredObjectServiceImpl">
 	<beans:property name="securedObjectDAO" ref="securedObjectDAO"/>
-	<beans:property name="requestMatcherType" value="regex"/>	<!--  default : ant -->
+	<beans:property name="requestMatcherType" value="regex"/>	<!--  default : regex -->
 </beans:bean>
  
 <beans:bean id="securedObjectDAO" class="org.egovframe.rte.fdl.security.secureobject.impl.SecuredObjectDAO" >
@@ -245,7 +245,7 @@ resourceType을 pointcut으로 설정하여 securedObjectService의 getRolesAndP
 ```xml
 <beans:bean id="securedObjectService" class="org.egovframe.rte.fdl.security.secureobject.impl.SecuredObjectServiceImpl">
 	<beans:property name="securedObjectDAO" ref="securedObjectDAO"/>
-	<beans:property name="requestMatcherType" value="regex"/>	<!--  default : ant -->
+	<beans:property name="requestMatcherType" value="regex"/>	<!--  default : regex -->
 </beans:bean>
  
 <beans:bean id="securedObjectDAO" class="org.egovframe.rte.fdl.security.secureobject.impl.SecuredObjectDAO" >


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

requestMatcherType 설정 예제 옆 주석이 `default : ant`로 남아 있는데 SecuredObjectServiceImpl의 실제 기본값은 regex라 주석을 값에 맞춰 고쳤습니다.

```
$ git -C /Users/wantaek/orca/workspaces/egovframe-runtime show origin/main:Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/secureobject/impl/SecuredObjectServiceImpl.java | grep -n "requestMatcherType ="
49:    private String requestMatcherType = "regex";    // default
61:            this.requestMatcherType = config.getRequestMatcherType();
```

바뀐 줄 2줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
