### PR TITLE
docs: 선언적 유효성 검증 가이드의 LocalValidatiorFactoryBean 오탈자를 LocalValidatorFactoryBean으로 정정

### DIFF
--- a/egovframe-runtime/presentation-layer/web-servlet-declarative-validation.md
+++ b/egovframe-runtime/presentation-layer/web-servlet-declarative-validation.md
@@ -80,7 +80,7 @@ public class MemberVO{
 
 `@NotNull`은 빈문자열을 검증하지 못하기 때문에 `@Size(min=1)`을 사용하여 빈 문자열을 확인해야 한다.
 
-위와같은 제약조건 애노테이션을 사용해 검증을 수행하기 위해서는 LocalValidatiorFactoryBean을 빈으로 등록해 줘야 한다. LocalValidatiorFactoryBean은 JSR-303의 검증기능을 스프링의 Validator처럼 사용할 수 있게 해주는 일종의 어댑터다. LocalValidatiorFactoryBean을 빈으로 등록하면 컨트롤러에서 Validator타입으로 DI 받아서 @InitBinder에서 WebDataBinder에 설정하거나 코드에서 직접 Validator처럼 사용할 수 있다.
+위와같은 제약조건 애노테이션을 사용해 검증을 수행하기 위해서는 LocalValidatorFactoryBean을 빈으로 등록해 줘야 한다. LocalValidatorFactoryBean은 JSR-303의 검증기능을 스프링의 Validator처럼 사용할 수 있게 해주는 일종의 어댑터다. LocalValidatorFactoryBean을 빈으로 등록하면 컨트롤러에서 Validator타입으로 DI 받아서 @InitBinder에서 WebDataBinder에 설정하거나 코드에서 직접 Validator처럼 사용할 수 있다.
 
 ```xml
 <bean id="validator" class="org.springframework.validation.beanvalidation.LocalValidatorFactoryBean" />


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

본문에서 LocalValidatiorFactoryBean으로 표기되어 있었으나, 같은 문서의 XML 예제에는 org.springframework.validation.beanvalidation.LocalValidatorFactoryBean으로 되어 있어 이에 맞춰 정정했습니다.

```
$ git show origin/main:egovframe-runtime/presentation-layer/web-servlet-declarative-validation.md | grep -n "LocalValidat"
83:위와같은 제약조건 애노테이션을 사용해 검증을 수행하기 위해서는 LocalValidatiorFactoryBean을 빈으로 등록해 줘야 한다. LocalValidatiorFactoryBean은 JSR-303의 검증기능을 스프링의 Validator처럼 사용할 수 있게 해주는 일종의 어댑터다. LocalValidatiorFactoryBean을 빈으로 등록하면 컨트롤러에서 Validator타입으로 DI 받아서 @InitBinder에서 WebDataBinder에 설정하거나 코드에서 직접 Validator처럼 사용할 수 있다.
86:<bean id="validator" class="org.springframework.validation.beanvalidation.LocalValidatorFactoryBean" />
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
