### PR TITLE
docs: Buildship 설정 가이드의 소제목 오탈자를 Eclipse 로 정정

### DIFF
--- a/egovframe-development/deployment-tool/gradle-buildship.md
+++ b/egovframe-development/deployment-tool/gradle-buildship.md
@@ -50,7 +50,7 @@ eclipse에서 제공하는 Buildship은 Help > Install New Software 에서 아�
 
   > Neon : [http://download.eclipse.org/releases/neon](http://download.eclipse.org/releases/neon)
 
-### Eclispe 설정
+### Eclipse 설정
 
 * Eclipse Preferences 설정창에서 Gradle의 실행 모듈의 위치를 지정할 수 있다.
   


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

`egovframe-development/deployment-tool/gradle-buildship.md`의 소제목이 `Eclispe`로 오기되어 있어, 같은 문서에서 4번 일관되게 쓰인 철자대로 `Eclipse`로 고쳤습니다.

```
$ git show origin/main:egovframe-development/deployment-tool/gradle-buildship.md | grep -n 'Eclipse\|Eclispe'
17:Buildship 플러그인은 Eclipse에서 제공하는 플러그인으로서 Gradle 프로젝트 개발의 편의성을 제공하고 있다.
31:* Eclipse Mars update site : [http://download.eclipse.org/buildship/updates/e45/releases/1.0](http://download.eclipse.org/buildship/updates/e45/releases/1.0)
34:* Eclipse Mars(4.5) 이전버전의 경우 다음 배포사이트 참고
53:### Eclispe 설정
55:* Eclipse Preferences 설정창에서 Gradle의 실행 모듈의 위치를 지정할 수 있다.
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
