### PR TITLE
docs: 배치 테스트 마법사 가이드의 jobParameters 타입을 실제 Properties 에 맞춰 정정

### DIFF
--- a/egovframe-development/test-tool/batch-job-test-wizard.md
+++ b/egovframe-development/test-tool/batch-job-test-wizard.md
@@ -122,7 +122,7 @@ public class testFile{
 		jobParametersBuilder.addString("name", "eGovframe");
  
  
-		String jobParameters = egovBatchRunner.convertJobParametersToString(jobParametersBuilder.toJobParameters());
+		Properties jobParameters = egovBatchRunner.convertJobParametersToString(jobParametersBuilder.toJobParameters());
  
 		long executionId = egovBatchRunner.start(jobName, jobParameters);
  


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

배치 테스트 마법사 가이드의 예제 코드가 `convertJobParametersToString` 의 반환값을 `String` 타입 변수에 담고 있어, 실행환경 저장소(`eGovFramework/egovframe-runtime`) `main` 에서 실제 반환 타입이자 뒤이은 `start(String, Properties)` 호출과 일치하는 `Properties` 로 고쳤습니다.

```
$ git show origin/main:Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/launch/support/EgovBatchRunner.java | grep -n 'public Long start\|public Properties convertJobParametersToString'
115:    public Long start(String jobName, Properties jobParameters) throws NoSuchJobException, JobParametersInvalidException, JobInstanceAlreadyExistsException {
173:    public Properties convertJobParametersToString(JobParameters jobParameters) {
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 개발환경 (`egovframe-development/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
