### PR TITLE
docs: JTA Transaction Code Generation 가이드의 Transation 오탈자를 Transaction 으로 정정

### DIFF
--- a/egovframe-development/implementation-tool/code-generation-template-configuration-folder/config-gen-jta-transaction.md
+++ b/egovframe-development/implementation-tool/code-generation-template-configuration-folder/config-gen-jta-transaction.md
@@ -13,7 +13,7 @@ menu:
 
 ## 개요
 
-Code Generation 기능을 사용하여 "JTA를 이용한 Global Transation 관리 설정"을 쉽게 작성할 수 있다.
+Code Generation 기능을 사용하여 "JTA를 이용한 Global Transaction 관리 설정"을 쉽게 작성할 수 있다.
 
 ## 설명
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

`config-gen-jta-transaction.md` 개요 문단(16행)의 "Transation" 오탈자를 "Transaction" 으로 정정했습니다. 같은 문서의 title(2행)·H1(12행)은 모두 "Transaction" 으로 정확히 쓰여 있습니다.

```
$ git show origin/main:egovframe-development/implementation-tool/code-generation-template-configuration-folder/config-gen-jta-transaction.md | grep -n "Transaction Code Generation\|Transation"
2:title: JTA Transaction Code Generation
4:description: "JTA를 이용한 Global Transation 관리 설정"
12:# JTA Transaction Code Generation
16:Code Generation 기능을 사용하여 "JTA를 이용한 Global Transation 관리 설정"을 쉽게 작성할 수 있다.
```

바뀐 줄 1줄.

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [x] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
