### PR TITLE
docs: resultMap 가이드의 클래스명 표기를 EmpDeptSimpleCompositeVO 에 맞춰 정정

### DIFF
--- a/egovframe-runtime/persistence-layer/dataaccess-resultmap.md
+++ b/egovframe-runtime/persistence-layer/dataaccess-resultmap.md
@@ -340,7 +340,7 @@ public class EmpDeptSimpleCompositeVO implements Serializable {
     }
 ```
 
- extends 없이 모든 매핑 요소를 simple 하게 모두 정의한 resultMap 을 이용한 결과 객체 매핑을 처리하는 selectEmpDeptSimpleCompositeUsingResultMap 에 대해 조회 처리하고 있는 테스트 케이스이다. 위의 테스트 검증을 통해 EmpDeptSimpleCompositeV 의 결과 객체로 조회 결과가 잘 반영되었음을 확인할 수 있다.
+ extends 없이 모든 매핑 요소를 simple 하게 모두 정의한 resultMap 을 이용한 결과 객체 매핑을 처리하는 selectEmpDeptSimpleCompositeUsingResultMap 에 대해 조회 처리하고 있는 테스트 케이스이다. 위의 테스트 검증을 통해 EmpDeptSimpleCompositeVO 의 결과 객체로 조회 결과가 잘 반영되었음을 확인할 수 있다.
 
  위의 비교 구현을 통해 join 조회를 통해 얻어지는 결과 객체가 단순 composite VO 형태인 경우 resultMap extends 을 사용하면 좀더 쉽게 매핑 처리할 수 있을 것으로 보여진다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

dataaccess-resultmap.md 343행의 EmpDeptSimpleCompositeV 표기는 같은 문서 233·273·320행에서 쓰는 EmpDeptSimpleCompositeVO 의 마지막 글자 O 가 빠진 것이어서 EmpDeptSimpleCompositeVO 로 고쳤습니다.

```
$ cd /Users/wantaek/orca/workspaces/egovframe-docs && git show origin/main:egovframe-runtime/persistence-layer/dataaccess-resultmap.md | grep -n "EmpDeptSimpleCompositeV[^O]"
343: extends 없이 모든 매핑 요소를 simple 하게 모두 정의한 resultMap 을 이용한 결과 객체 매핑을 처리하는 selectEmpDeptSimpleCompositeUsingResultMap 에 대해 조회 처리하고 있는 테스트 케이스이다. 위의 테스트 검증을 통해 EmpDeptSimpleCompositeV 의 결과 객체로 조회 결과가 잘 반영되었음을 확인할 수 있다.
$ cd /Users/wantaek/orca/workspaces/egovframe-docs && git show origin/main:egovframe-runtime/persistence-layer/dataaccess-resultmap.md | sed -n "233p;273p;320p"
public class EmpDeptSimpleCompositeVO implements Serializable {
	<typeAlias alias="empDeptSimpleCompositeVO" type="org.egovframe.rte.psl.dataaccess.vo.EmpDeptSimpleCompositeVO" />
        EmpDeptSimpleCompositeVO resultVO =
```

바뀐 줄 1줄.

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
