### PR TITLE
docs: CommandMap 가이드의 클래스명·프레임워크명 오탈자를 실제 표기에 맞춰 정정

### DIFF
--- a/egovframe-runtime/presentation-layer/web-servlet-AnnotationCommandMapArgumentResolver.md
+++ b/egovframe-runtime/presentation-layer/web-servlet-AnnotationCommandMapArgumentResolver.md
@@ -9,21 +9,21 @@ menu:
         weight: 2
         parent: "bean_vaildation"
 ---
-# AnnotationCommandmapArgumentResolver
+# AnnotationCommandMapArgumentResolver
 
 ## 개요
 
 Controller에서 화면(JSP) 입력값을 받기 위해서 일반적으로 Command(Form Class) 객체를 사용하지만, Map 객체를 사용하는걸 선호할 수 있다.
-전자정부프레임워크 버전 3.0이전에서는 CommandMapArgumentResolver를 통해 Map객체를 사용할 수 있었다. 그러나 3.0부터는 @CommandMap과 AnnotationCommandmapArgumentResolver를 통해 Map객체를 사용할 수 있다.
+전자정부프레임워크 버전 3.0이전에서는 CommandMapArgumentResolver를 통해 Map객체를 사용할 수 있었다. 그러나 3.0부터는 @CommandMap과 AnnotationCommandMapArgumentResolver를 통해 Map객체를 사용할 수 있다.
 org.springframework.web.method.support.HandlerMethodArgumentResolver의 구현클래스인 AnnotationCommandMapArgumentResolver은 HTTP request 객체에 있는 파라미터이름과 값을 Map 객체에 담아 Controller에서 사용도록 제공한다.
 
 ## 설명
 
 ### HandlerMethodArgumentResolver
 
-Sping MVC의 `@Controller`의 메소드의 argument로 사용할 수 있는 유형(이에 관한 정보는 이곳을 참조하라.)은 기존의 계층형 Controller보다 다양해 졌지만,
+Spring MVC의 `@Controller`의 메소드의 argument로 사용할 수 있는 유형(이에 관한 정보는 이곳을 참조하라.)은 기존의 계층형 Controller보다 다양해 졌지만,
 필요에 따라 기본 유형외의 custom argument를 사용해야 할 때가 있을 것이다.
-Sping MVC는 Controller의 argument 유형을 customizing 할 수 있는 HandlerMethodArgumentResolver라는 interface를 제공한다.
+Spring MVC는 Controller의 argument 유형을 customizing 할 수 있는 HandlerMethodArgumentResolver라는 interface를 제공한다.
 기존 Spring web 3.1이전 버전에서는 WebArgumentResolver를 구현하여 AnnotationMethodHandlerAdapter에 등록하여 ArgumentResolver를 적용하였으나,
 3.1이후부터는 HandlerMethodArgumentResolver를 구현하여  RequestMappingHandlerAdapter에 등록하여 ArgumentResolver를 적용해야 한다.
 
@@ -134,7 +134,7 @@ public class AnnotationCommandMapArgumentResolver implements HandlerMethodArgume
 ```
 
 AnnotationCommandMapArgumentResolver를 사용하려면 EgovRequestMappingHandlerAdapter에 등록해야 한다. 보통의 경우는 RequestMappingHandlerAdapter를 등록하여 사용하면 되지만, Controller에 Map객체를 쓰기 위해 AnnotationCommandMapArgumentResolver를 등록하려면 egov3.0부터 제공하는 EgovRequestMappingHandlerAdapter를 사용해야 한다.
-만약 RequestMappingHAndlerAdapter를 이용하거나 `<mvc:annotation-driven>`을 사용할 경우에는 AnnotationCommandMapArgumentResolver를 사용할 수 없으므로 주의해야 한다.
+만약 RequestMappingHandlerAdapter를 이용하거나 `<mvc:annotation-driven>`을 사용할 경우에는 AnnotationCommandMapArgumentResolver를 사용할 수 없으므로 주의해야 한다.
 
 ```xml
 <bean class="egovframework.rte.ptl.mvc.bind.annotation.EgovRequestMappingHandlerAdapter">


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

CommandMap 가이드에 적힌 `RequestMappingHAndlerAdapter`, `AnnotationCommandmapArgumentResolver`, `Sping MVC` 표기가 같은 문서 안 다른 곳의 표기·실제 클래스 선언과 달라서, 각각 `RequestMappingHandlerAdapter`, `AnnotationCommandMapArgumentResolver`, `Spring MVC`로 고쳤습니다.

```
$ git show origin/main:egovframe-runtime/presentation-layer/web-servlet-AnnotationCommandMapArgumentResolver.md | grep -n "RequestMappingH[Aa]ndlerAdap"
28:3.1이후부터는 HandlerMethodArgumentResolver를 구현하여  RequestMappingHandlerAdapter에 등록하여 ArgumentResolver를 적용해야 한다.
72:만들어진 ArgumentResolver클래스는 RequestMappingHandlerAdapter의 customArgumentResolvers 프로퍼티에 등록하도록 한다. list유형 프로퍼티이므로 여러개의 ArgumentResolver클래스를 등록할 수 있다.
75:<bean class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter">
136:AnnotationCommandMapArgumentResolver를 사용하려면 EgovRequestMappingHandlerAdapter에 등록해야 한다. 보통의 경우는 RequestMappingHandlerAdapter를 등록하여 사용하면 되지만, Controller에 Map객체를 쓰기 위해 AnnotationCommandMapArgumentResolver를 등록하려면 egov3.0부터 제공하는 EgovRequestMappingHandlerAdapter를 사용해야 한다.
137:만약 RequestMappingHAndlerAdapter를 이용하거나 `<mvc:annotation-driven>`을 사용할 경우에는 AnnotationCommandMapArgumentResolver를 사용할 수 없으므로 주의해야 한다.
140:<bean class="egovframework.rte.ptl.mvc.bind.annotation.EgovRequestMappingHandlerAdapter">
$ git show origin/main:egovframe-runtime/presentation-layer/web-servlet-AnnotationCommandMapArgumentResolver.md | grep -n "AnnotationCommandmapArgumentResolver\|public class AnnotationCommandMapArgumentResolver"
12:# AnnotationCommandmapArgumentResolver
17:전자정부프레임워크 버전 3.0이전에서는 CommandMapArgumentResolver를 통해 Map객체를 사용할 수 있었다. 그러나 3.0부터는 @CommandMap과 AnnotationCommandmapArgumentResolver를 통해 Map객체를 사용할 수 있다.
102:public class AnnotationCommandMapArgumentResolver implements HandlerMethodArgumentResolver{
$ git show origin/main:egovframe-runtime/presentation-layer/web-servlet-AnnotationCommandMapArgumentResolver.md | grep -n "Sping MVC\|Spring Framework"
24:Sping MVC의 `@Controller`의 메소드의 argument로 사용할 수 있는 유형(이에 관한 정보는 이곳을 참조하라.)은 기존의 계층형 Controller보다 다양해 졌지만,
26:Sping MVC는 Controller의 argument 유형을 customizing 할 수 있는 HandlerMethodArgumentResolver라는 interface를 제공한다.
168:- [Spring Framework 6.2 - Web on Servlet Stack](https://docs.spring.io/spring-framework/reference/6.2/web.html)
```

바뀐 줄 5줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
