### PR TITLE
docs: 빌드 Lifecycle 가이드의 mvn compile 명령어 오타 정정

### DIFF
--- a/egovframe-development/deployment-tool/build-lifecycle.md
+++ b/egovframe-development/deployment-tool/build-lifecycle.md
@@ -27,7 +27,7 @@ Maven 생명 주기 단계는 각각의 플러그인과 바인딩 되어 플러�
 ![](./images/build-lifecycle-1.gif)![](./images/build-lifecycle-2.gif)
 
 
-> 예) 자바 컴파일: `$mvn complile` 명령을 실행한다.
+> 예) 자바 컴파일: `$mvn compile` 명령을 실행한다.
 
 ### 메이븐2 기본 생명주기 단계
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

컴파일 예시 명령이 `$mvn complile`로 잘못 표기되어 있어 `$mvn compile`로 고쳤습니다.

```
$ git show origin/main:egovframe-development/deployment-tool/build-lifecycle.md | grep -n 'complile\|compile'
24:> 예) `mvn install` 명령을 실행하면 generate-sources 단계부터 compile, test 명령 등을 거쳐 install 명령을 실행한다.  
30:> 예) 자바 컴파일: `$mvn complile` 명령을 실행한다.
42:| compile                 | 소스 코드를 컴파일한다. 컴파일된 클래스들은 타깃 디렉터리 트리 구조에 저장된다.                                                                           |
48:| test-compile            | 단위 테스트 소스 코드를 컴파일한다.                                                                                                                       |
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [x] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
