### PR TITLE
docs: 지식맵(조직별)관리 가이드의 Query XML 파일명을 실제 EgovDamMapTeamMapTeam_SQL_* 에 맞춰 정정

### DIFF
--- a/common-component/digital-asset-management/org-knowledge-map-management.md
+++ b/common-component/digital-asset-management/org-knowledge-map-management.md
@@ -41,14 +41,14 @@ menu:
 | JSP | /WEB-INF/jsp/egovframework/com/dam/map/tea/EgovComDamMapTeamRegist.jsp | 지식맵(조직별) 등록을 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/dam/map/tea/EgovComDamMapTeamModify.jsp | 지식맵(조직별) 수정을 위한 jsp페이지 |
 | JSP | /WEB-INF/jsp/egovframework/com/dam/map/tea/EgovComDamMapTeamDetail.jsp | 등록된 지식맵(조직별)을 조회하기 위한 jsp페이지 |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_altibase.xml | 지식맵(조직별) 관리를 위한 Altibase용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_cubrid.xml | 지식맵(조직별) 관리를 위한 Cubrid용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_maria.xml | 지식맵(조직별) 관리를 위한 MariaDB용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_mysql.xml | 지식맵(조직별) 관리를 위한 MySQL용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_oracle.xml | 지식맵(조직별) 관리를 위한 Oracle용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_postgres.xml | 지식맵(조직별) 관리를 위한 PostgreSQL용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_tibero.xml | 지식맵(조직별) 관리를 위한 Tibero용 Query XML |
-| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_goldilocks.xml | 지식맵(조직별) 관리를 위한 Goldilocks용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_altibase.xml | 지식맵(조직별) 관리를 위한 Altibase용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_cubrid.xml | 지식맵(조직별) 관리를 위한 Cubrid용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_maria.xml | 지식맵(조직별) 관리를 위한 MariaDB용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_mysql.xml | 지식맵(조직별) 관리를 위한 MySQL용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_oracle.xml | 지식맵(조직별) 관리를 위한 Oracle용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_postgres.xml | 지식맵(조직별) 관리를 위한 PostgreSQL용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_tibero.xml | 지식맵(조직별) 관리를 위한 Tibero용 Query XML |
+| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam\_SQL\_goldilocks.xml | 지식맵(조직별) 관리를 위한 Goldilocks용 Query XML |
 | Message properties | resources/egovframework/message/com/dam/map/tea/message\_en.properties | 지식맵(조직별) 관리를 위한 Message properties(영문) |
 | Message properties | resources/egovframework/message/com/dam/map/tea/message\_ko.properties | 지식맵(조직별) 관리를 위한 Message properties(한글) |
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

지식맵(조직별)관리 문서의 관련소스 표에 적힌 Query XML 파일명 8개가 실제 소스의 `EgovDamMapTeamMapTeam_SQL_*.xml` 과 달라 `EgovDamMapTeam_SQL_*.xml` 로 적혀 있던 것을 실제 파일명으로 고쳤습니다.

```
$ git -C egovframe-common-components ls-tree -r --name-only origin/main | grep "mapper/com/dam/map/tea"
src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_altibase.xml
src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_cubrid.xml
src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_goldilocks.xml
src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_maria.xml
src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_mysql.xml
src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_oracle.xml
src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_postgres.xml
src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_tibero.xml

$ git -C egovframe-docs show origin/main:common-component/digital-asset-management/org-knowledge-map-management.md | grep -n "EgovDamMapTeam"
44:| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_altibase.xml | 지식맵(조직별) 관리를 위한 Altibase용 Query XML |
45:| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_cubrid.xml | 지식맵(조직별) 관리를 위한 Cubrid용 Query XML |
46:| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_maria.xml | 지식맵(조직별) 관리를 위한 MariaDB용 Query XML |
47:| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_mysql.xml | 지식맵(조직별) 관리를 위한 MySQL용 Query XML |
48:| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_oracle.xml | 지식맵(조직별) 관리를 위한 Oracle용 Query XML |
49:| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_postgres.xml | 지식맵(조직별) 관리를 위한 PostgreSQL용 Query XML |
50:| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_tibero.xml | 지식맵(조직별) 관리를 위한 Tibero용 Query XML |
51:| Query XML | resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeam\_SQL\_goldilocks.xml | 지식맵(조직별) 관리를 위한 Goldilocks용 Query XML |
```

바뀐 줄 16줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
