### PR TITLE
docs: 메인메뉴 가이드의 parsFileByMenuChar 시그니처를 실제 basePath 인자에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/main-menu.md
+++ b/common-component/elementary-technology/main-menu.md
@@ -39,7 +39,7 @@ menu:
 <!-- markdownlint-disable MD013 -->
 | 결과값 | 메소드명 | 설명 | 내용 |
 | --- | --- | --- | --- |
-| Vector | `parsFileByMenuChar(String parFile, String parChar, int parField)` | 메뉴테이블형태 파싱 | 데이터를 받아 구분값·필드수에 맞추어 메뉴필드 형태로 나눈다 |
+| Vector | `parsFileByMenuChar(String basePath, String parFile, String parChar, int parField)` | 메뉴테이블형태 파싱 | 데이터를 받아 구분값·필드수에 맞추어 메뉴필드 형태로 나눈다 |
 | boolean | `setDataByDATFile(String parFile, String[] menuIDArray, String[] menuNameArray, String[] menuLevelArray, String[] menuURLArray)` | 메뉴 데이터 파일 생성 | 메뉴관리 화면의 데이터를 받아 서버 데이터 파일(DAT)을 생성한다 (수정·삭제 반영) |
 <!-- markdownlint-restore -->
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

메인메뉴 문서의 메소드 설명표에 있는 `parsFileByMenuChar` 시그니처가 실제 소스의 4개 인자(`basePath`, `parFile`, `parChar`, `parField`)와 달리 `basePath`가 빠져 있어 이를 추가했습니다.

```
$ git show origin/main:src/main/java/egovframework/com/utl/sim/service/EgovMenuGov.java | sed -n '61,62p'
	public static Vector<List<String>> parsFileByMenuChar(String basePath, String parFile, String parChar, int parField)
			throws Exception {
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
