### PR TITLE
docs: 외부 추가 컴포넌트 가이드의 LDAP 설정 프로퍼티 키를 실제 이름에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/external-components.md
+++ b/common-component/elementary-technology/external-components.md
@@ -78,10 +78,10 @@ LDAP(Lightweight Directory Access Protocol) 서버와 연동하여 조직도 정
 
 ```properties
 # LDAP 서버 설정
-Globals.ldap.url      = ldap://ldap.example.go.kr:389
-Globals.ldap.baseDn   = dc=example,dc=go,dc=kr
-Globals.ldap.userDn   = cn=admin,dc=example,dc=go,dc=kr
-Globals.ldap.password = {ldap_password}
+ldap.url      = ldap://ldap.example.go.kr:389
+ldap.rootDn   = dc=example,dc=go,dc=kr
+ldap.username = cn=admin,dc=example,dc=go,dc=kr
+ldap.password = {ldap_password}
 ```
 
 ## 참고자료


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

외부 추가 컴포넌트 가이드의 LDAP 환경 설정 예시가 `Globals.ldap.url`·`Globals.ldap.baseDn`·`Globals.ldap.userDn`·`Globals.ldap.password` 로 적고 있으나 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `context-ldap.xml` 이 참조하는 프로퍼티 키는 `Globals.` 접두어 없이 `ldap.url`·`ldap.rootDn`·`ldap.username`·`ldap.password` 여서 이에 맞춰 고쳤습니다.

```
$ git grep -n "ldap\.url\|ldap\.baseDn\|ldap\.userDn\|ldap\.rootDn\|ldap\.username\|ldap\.password\|Globals\.ldap" origin/main -- '*.java' '*.xml' '*.properties'
origin/main:src/main/java/egovframework/com/ext/ldapumt/web/EgovOrgManageLdapController.java:283:		model.addAttribute("baseDn", EgovProperties.getProperty("ldap.rootDn"));
origin/main:src/main/java/egovframework/com/ext/ldapumt/web/EgovOrgManageLdapController.java:305:		String rootDn = EgovProperties.getProperty("ldap.rootDn");
origin/main:src/main/resources/egovframework/egovProps/globals.properties:182:ldap.url = ldaps://localhost:10389
origin/main:src/main/resources/egovframework/egovProps/globals.properties:183:ldap.rootDn = c=kr
origin/main:src/main/resources/egovframework/egovProps/globals.properties:184:ldap.username = uid=admin,ou=system
origin/main:src/main/resources/egovframework/egovProps/globals.properties:185:ldap.password = ******
origin/main:src/main/resources/egovframework/spring/com/context-ldap.xml:7:    <ldap:context-source url="${ldap.url}" base="${ldap.rootDn}" username="${ldap.username}" password="${ldap.password}" />
origin/main:src/test/resources/egovframework/egovProps/globals.properties:188:ldap.url = ldap://localhost:10389
origin/main:src/test/resources/egovframework/egovProps/globals.properties:189:ldap.rootDn = c=kr
origin/main:src/test/resources/egovframework/egovProps/globals.properties:190:ldap.username = uid=admin,ou=system
origin/main:src/test/resources/egovframework/egovProps/globals.properties:191:ldap.password = ******
```

바뀐 줄 4줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
