### PR TITLE
docs: 쿠키/세션 가이드의 세션 메소드명을 실제 getSessionValuesString 에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/cookie-session.md
+++ b/common-component/elementary-technology/cookie-session.md
@@ -105,7 +105,7 @@ String safeGetParameter(HttpServletRequest request, String name) {
 | `void` | `setSessionAttribute(request, key, value)` | 세션 정보 생성 | `HttpSession`에 주어진 키 값으로 세션 정보를 생성하는 기능 |
 | `void` | `setSessionAttribute(request, key, obj)` | 세션 객체 생성 | `HttpSession`에 주어진 키 값으로 세션 객체를 생성하는 기능 |
 | `Object` | `getSessionAttribute(request, key)` | 세션 객체 취득 | `HttpSession`에 존재하는 주어진 키 값에 해당하는 세션 객체를 얻어오는 기능 |
-| `String` | `getSessionValues(request)` | 세션 객체 리스트 취득 | `HttpSession` 객체내의 모든 값을 호출하는 기능 |
+| `String` | `getSessionValuesString(request)` | 세션 객체 리스트 취득 | `HttpSession` 객체내의 모든 값을 호출하는 기능 |
 | `void` | `removeSessionAttribute(request, key)` | 세션 객체 삭제 | `HttpSession`에 존재하는 세션을 주어진 키 값으로 삭제하는 기능 |
 
 ##### Input


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

세션 메소드 표의 `getSessionValues(request)` 가 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`) `main` 의 실제 메소드명과 달라 `getSessionValuesString(request)` 로 고쳤습니다.

```
$ git -C egovframe-common-components grep -n "public static.*Session" origin/main -- src/main/java/egovframework/com/utl/cas/service/EgovSessionCookieUtil.java
origin/main:src/main/java/egovframework/com/utl/cas/service/EgovSessionCookieUtil.java:40:	public static void setSessionAttribute(HttpServletRequest request, String keyStr, String valStr) throws Exception {
origin/main:src/main/java/egovframework/com/utl/cas/service/EgovSessionCookieUtil.java:54:	public static void setSessionAttribute(HttpServletRequest request, String keyStr, Object obj) throws Exception {
origin/main:src/main/java/egovframework/com/utl/cas/service/EgovSessionCookieUtil.java:68:	public static Object getSessionAttribute(HttpServletRequest request, String keyStr) throws Exception {
origin/main:src/main/java/egovframework/com/utl/cas/service/EgovSessionCookieUtil.java:81:	public static String getSessionValuesString(HttpServletRequest request) throws Exception {
origin/main:src/main/java/egovframework/com/utl/cas/service/EgovSessionCookieUtil.java:101:	public static void removeSessionAttribute(HttpServletRequest request, String keyStr) throws Exception {
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
