### PR TITLE
docs: 파일파싱 가이드의 parsFileByChar 시그니처를 실제 basePath 인자에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/file-parsing.md
+++ b/common-component/elementary-technology/file-parsing.md
@@ -40,12 +40,13 @@ menu:
 <!-- markdownlint-disable MD013 -->
 | 결과값 | 메소드명 | 설명 | 내용 |
 | --- | --- | --- | --- |
-| Vector | `parsFileByChar(String parFile, String parChar, int parField)` | 특정구분자 파일파싱 | 파일을 특정 구분자(콤마, 파이프, TAB)로 파싱한다 |
+| Vector | `parsFileByChar(String basePath, String parFile, String parChar, int parField)` | 특정구분자 파일파싱 | 파일을 특정 구분자(콤마, 파이프, TAB)로 파싱한다 |
 | Vector | `parsFileBySize(String parFile, int[] parLen, int parLine)` | 일정길이 파일파싱 | 파일을 필드별 일정 길이로 파싱한다 |
 <!-- markdownlint-restore -->
 
 #### 파라미터 정의 (Input)
 
+- `basePath`: String 타입의 파일 접근을 허용할 기준 경로 (미지정 시 `Globals.fileStorePath` 사용)
 - `parFile`: String 타입의 절대경로를 포함한 파일명 (예: `/user/com/test/file1.txt`)
 - `parChar`: String 타입의 파싱 구분자 (예: `,`)
 - `parField`: int 타입의 파싱 필드수 (예: `3`)
@@ -65,8 +66,9 @@ import java.util.Vector;
 import egovframework.com.utl.sim.service.EgovFileTool;
 
 // 1. 특정 구분자 파일파싱
+String basePath = null;
 String parFile = "/user/com/test/file1.txt";
-Vector<List<String>> result1 = EgovFileTool.parsFileByChar(parFile, ",", 3);
+Vector<List<String>> result1 = EgovFileTool.parsFileByChar(basePath, parFile, ",", 3);
 
 // 2. 일정 길이 파일파싱
 int[] parLen = {3, 3, 3};


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

파일파싱 가이드의 `parsFileByChar` 메소드 시그니처와 사용 예제가 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`) `main` 의 소스와 달라 첫 인자로 `basePath` 를 추가해 고쳤습니다.

```
$ git grep -n 'parsFileByChar' origin/main -- 'src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java'
origin/main:src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java:349:	public static Vector<List<String>> parsFileByChar(String basePath, String parFile, String parChar, int parField) throws Exception {
```

바뀐 줄 6줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
