### PR TITLE
docs: 디렉토리속성정보체크 가이드의 SHELL.UNIX 프로퍼티 키를 실제 globals.properties 값에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/directory-attribute-check.md
+++ b/common-component/elementary-technology/directory-attribute-check.md
@@ -91,7 +91,7 @@ menu:
 #1. getOwner 메소드에 해당되는 쉘 스크립트
 SHELL.UNIX.getDrctryOwner = /product/jeus/egovProps/prg/getDrctryOwner.sh
 #2. getAccess 메소드에 해당되는 쉘 스크립트
-SHELL.UNIX.getMoryInfo = /product/jeus/egovProps/prg/getDrctryAccess.sh
+SHELL.UNIX.getDrctryAccess = /product/jeus/egovProps/prg/getDrctryAccess.sh
 ```
 
 #### getDrctryOwner.sh (유닉스용 디렉토리 소유자 조회 스크립트)


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

디렉토리속성정보체크 문서의 globals.properties 설정 예시에서 getAccess 메소드용 프로퍼티 키가 `SHELL.UNIX.getMoryInfo`로 적혀 있는데, 공통컴포넌트 소스의 실제 키는 `SHELL.UNIX.getDrctryAccess`라 이 이름으로 고쳤습니다.

```
$ git show origin/main:src/main/resources/egovframework/egovProps/globals.properties | grep -n "getDrctry"
124:SHELL.WINDOWS.getDrctryByOwner = prg/getDrctryByOwner.bat
125:SHELL.WINDOWS.getDrctryOwner   = prg/getDrctryOwner.bat
134:SHELL.UNIX.getDrctryByOwner = prg/getDrctryByOwner.sh
135:SHELL.UNIX.getDrctryOwner   = prg/getDrctryOwner.sh
136:SHELL.UNIX.getDrctryAccess  = prg/getDrctryAccess.sh
```

바뀐 줄 1줄.

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
