### PR TITLE
docs: 양력/음력 변환 가이드의 toSolar 설명을 실제 변환 방향에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/solar-lunar-conversion.md
+++ b/common-component/elementary-technology/solar-lunar-conversion.md
@@ -27,7 +27,7 @@ menu:
 
 | 메서드 | 반환형 | 설명 |
 | --- | --- | --- |
-| `toSolar(String sDate, int iLeapMonth)` | `String` | 입력받은 양력일자를 변환하여 음력일자로 반환 |
+| `toSolar(String sDate, int iLeapMonth)` | `String` | 입력받은 음력일자를 변환하여 양력일자로 반환 |
 
 ## 입력값 (Input)
 
@@ -41,7 +41,7 @@ menu:
 ## 사용 예
 
 ```java
-String lunar = EgovDateUtil.toSolar("20260711", 0); // 양력 → 음력 변환
+String solar = EgovDateUtil.toSolar("20260711", 0); // 음력 → 양력 변환
 ```
 
 ## 참고자료


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

`toSolar()` 메서드 설명과 사용 예의 변환 방향이 실제 소스(Javadoc)와 반대로 적혀 있어 바로잡았습니다.

```
	/**
	 * 입력받은 음력일자를 변환하여 양력일자로 반환
	 * 
	 * @param sDate      음력일자
	 * @param iLeapMonth 음력윤달여부(IS_LEAP_MONTH)
	 * @return 양력일자
	 */
	public static String toSolar(String sDate, int iLeapMonth) {
```

바뀐 줄 4줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
