### PR TITLE
docs: 공통컴포넌트 축약어 가이드의 메뉴관리 코드를 실제 mnu 패키지명에 맞춰 정정

### DIFF
--- a/common-component/intro/terms.md
+++ b/common-component/intro/terms.md
@@ -111,7 +111,7 @@ menu:
 |         |             |             | tlg     | trans and rec log             | 송/수신로그관리        |
 |         |             |             | ulg     | user log                      | 사용자로그관리         |
 |         |             |             | wlg     | web log                       | 웹로그관리           |
-|         |             | mmu         |         | main menu service             | 메뉴관리            |
+|         |             | mnu         |         | main menu service             | 메뉴관리            |
 |         |             |             | bmm     | bookmark menu management      | 바로가기메뉴관리        |
 |         |             |             | mcm     | menu create management        | 메뉴생성관리          |
 |         |             |             | mpm     | menu and program manage       | 메뉴관리            |


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

공통컴포넌트 축약어 가이드의 메뉴관리 3단계 코드가 `mmu`로 적혀 있는데, 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)에는 `mmu` 패키지가 없고 하위 `bmm`·`mcm`·`mpm`·`stm`에 해당하는 실제 패키지명은 `mnu`라 `mnu`로 고쳤습니다.

```
$ git grep -c 'com\.sym\.mmu\|com/sym/mmu' origin/main | wc -l
       0
$ git grep -c 'com\.sym\.mnu\b' origin/main | wc -l
      77
```

바뀐 줄 1줄.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
