### PR TITLE
docs: 소셜 로그인 가이드의 getOAuthURL 호출을 실제 시그니처에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/social_login_naver_google_kakao.md
+++ b/common-component/elementary-technology/social_login_naver_google_kakao.md
@@ -112,21 +112,22 @@ Social Login은 다음과 같은 기능을 제공한다.
 
 ```java
 @RequestMapping(value = "/uat/uia/oauthLoginUsr", method = RequestMethod.GET)
-public String login(Model model) throws Exception {
+public String login(Model model, HttpSession session) throws Exception {
 	LOGGER.debug("===>>> OAuth Login .....");
- 
+
+	// 콜백에서 대조할 CSRF 방어용 state를 1회 생성해 세션에 보관하고 모든 제공자 인가 URL에 부착한다.
+	String state = generateState();
+	session.setAttribute(OAUTH_STATE_SESSION_KEY, state);
+
 	OAuthLogin naverLogin = new OAuthLogin(naverAuthVO);
-	LOGGER.debug("naverLogin.getOAuthURL() = "+naverLogin.getOAuthURL());
-	model.addAttribute("naver_url", naverLogin.getOAuthURL());
- 
+	model.addAttribute("naver_url", naverLogin.getOAuthURL(state));
+
 	OAuthLogin googleLogin = new OAuthLogin(googleAuthVO);
-	LOGGER.debug("googleLogin.getOAuthURL() = "+googleLogin.getOAuthURL());
-	model.addAttribute("google_url", googleLogin.getOAuthURL());
- 
+	model.addAttribute("google_url", googleLogin.getOAuthURL(state));
+
 	OAuthLogin kakaoLogin = new OAuthLogin(kakaoAuthVO);
-	LOGGER.debug("kakaoLogin.getOAuthURL() = "+kakaoLogin.getOAuthURL());
-	model.addAttribute("kakao_url", kakaoLogin.getOAuthURL());
- 
+	model.addAttribute("kakao_url", kakaoLogin.getOAuthURL(state));
+
 	return "egovframework/com/uat/uia/EgovLoginUsrOauth";
 }
 ```


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

소셜 로그인 가이드의 예제 코드가 인자 없는 `getOAuthURL()`을 호출하는데, 실제 `OAuthLogin`에는 CSRF 방어용 state 파라미터를 받는 `getOAuthURL(String state)`만 존재해 예제를 실제 호출 형태에 맞춰 정정했습니다.

```
$ git grep -n "getOAuthURL" origin/main -- .
origin/main:src/main/java/egovframework/com/ext/oauth/service/OAuthLogin.java:54:	public String getOAuthURL(String state) {
origin/main:src/main/java/egovframework/com/ext/oauth/web/EgovSignupController.java:104:		model.addAttribute("naver_url", naverLogin.getOAuthURL(state));
origin/main:src/main/java/egovframework/com/ext/oauth/web/EgovSignupController.java:107:		model.addAttribute("google_url", googleLogin.getOAuthURL(state));
origin/main:src/main/java/egovframework/com/ext/oauth/web/EgovSignupController.java:110:		model.addAttribute("kakao_url", kakaoLogin.getOAuthURL(state));
```

바뀐 줄 23줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
