### PR TITLE
docs: 메인이미지관리 가이드의 삭제 URL 을 실제 컨트롤러 매핑에 맞춰 정정

### DIFF
--- a/common-component/user-support/main-image.md
+++ b/common-component/user-support/main-image.md
@@ -170,7 +170,7 @@ menu:
 | --- | --- | --- | --- | --- |
 | 상세조회 | /uss/ion/msi/getMainImage.do | selectMainImage | "mainImageDAO" | "selectMainImage" |
 | 수정 | /uss/ion/msi/updtMainImage.do | updateMainImage | "mainImageDAO" | "updateMainImage" |
-| 삭제 | /uss/ion/msi/removeMainImageList.do | deleteMainImage | "mainImageDAO" | "deleteMainImage" |
+| 삭제 | /uss/ion/msi/removeMainImage.do | deleteMainImage | "mainImageDAO" | "deleteMainImage" |
 
  다음 화면은 메인이미지 상세조회 화면과 동일하다.
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [x] 문서 오류 수정 (fix)

## 변경 내용 (Description)

메인이미지관리 가이드의 메인이미지 수정 표에서 삭제 행의 URL이 `/uss/ion/msi/removeMainImageList.do`로 돼 있는데, 같은 행의 Controller method 칸에 있는 `deleteMainImage`를 처리하는 실제 URL은 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`) `main`의 컨트롤러 기준 `/uss/ion/msi/removeMainImage.do`입니다.

```
$ git -C /Users/wantaek/orca/workspaces/egovframe-common-components show origin/main:src/main/java/egovframework/com/uss/ion/msi/web/EgovMainImageController.java | grep -n 'removeMainImage\|public String delete'
202:	@PostMapping("/uss/ion/msi/removeMainImage.do")
203:	public String deleteMainImage(@RequestParam("imageId") String imageId,
216:	@PostMapping("/uss/ion/msi/removeMainImageList.do")
217:	public String deleteMainImageList(@RequestParam("imageIds") String imageIds,
```

표의 URL 칸을 실제 URL에 맞춰 고쳤습니다. 바뀐 줄 1줄.

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [x] 공통컴포넌트 (`common-component/`)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
