### PR TITLE
docs: 메시지 처리 가이드의 getErrMsg 메서드명을 실제 getErrorMsg 에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/message-process.md
+++ b/common-component/elementary-technology/message-process.md
@@ -36,8 +36,8 @@ menu:
 | `String` | `getInfoMsg(String key, String[] params)` | 정보 파라미터 취득 | 메시지 키에 해당하는 정보 메시지에 파라미터 값을 대치하여 얻는 기능 |
 | `String` | `getWarnMsg(String key)` | 경고 메시지 취득 | 메시지 키에 해당하는 경고 메시지를 얻는 기능 |
 | `String` | `getWarnMsg(String key, String[] params)` | 경고 파라미터 취득 | 메시지 키에 해당하는 경고 메시지에 파라미터 값을 대치하여 얻는 기능 |
-| `String` | `getErrMsg(String key)` | 에러 메시지 취득 | 메시지 키에 해당하는 에러 메시지를 얻는 기능 |
-| `String` | `getErrMsg(String key, String[] params)` | 에러 파라미터 취득 | 메시지 키에 해당하는 에러 메시지에 파라미터 값을 대치하여 얻는 기능 |
+| `String` | `getErrorMsg(String key)` | 에러 메시지 취득 | 메시지 키에 해당하는 에러 메시지를 얻는 기능 |
+| `String` | `getErrorMsg(String key, String[] params)` | 에러 파라미터 취득 | 메시지 키에 해당하는 에러 메시지에 파라미터 값을 대치하여 얻는 기능 |
 | `String` | `getConfirmMsg(String key)` | 확인 메시지 취득 | 메시지 키에 해당하는 확인 메시지를 얻는 기능 |
 | `String` | `getConfirmMsg(String key, String[] params)` | 확인 파라미터 취득 | 메시지 키에 해당하는 확인 메시지에 파라미터 값을 대치하여 얻는 기능 |
 
@@ -90,7 +90,7 @@ String message = null;
 // 1. 일반 메시지 취득
 message = EgovMessageUtil.getInfoMsg("test.message");
 // message = EgovMessageUtil.getWarnMsg("test.message");
-// message = EgovMessageUtil.getErrMsg("test.message");
+// message = EgovMessageUtil.getErrorMsg("test.message");
 // message = EgovMessageUtil.getConfirmMsg("test.message");
 
 // 2. 파라미터 처리 메시지 취득 : String 배열의 값이 각각 {0}, {1}로 대치됨


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

메소드 표와 예제 코드에 있는 `getErrMsg`는 `EgovMessageUtil.java`에 존재하지 않는 메소드명이라, 실제 정의된 `getErrorMsg`로 고쳤습니다.

(egovframe-common-components 저장소의 EgovMessageUtil.java 기준)

```
$ git grep -n "getErrMsg\b" origin/main -- '*.java' '*.jsp'
$ git grep -n "getErrorMsg(" origin/main -- '*.java'
origin/main:src/main/java/egovframework/com/utl/cas/service/EgovMessageUtil.java:34:	public static String getErrorMsg(String strCode) {
origin/main:src/main/java/egovframework/com/utl/cas/service/EgovMessageUtil.java:46:	public static String getErrorMsg(String strCode, String[] arrParam) {
origin/main:src/test/java/egovframework/com/utl/message/TestMessage.java:75:		message1 = EgovMessageUtil.getErrorMsg("test.message");
origin/main:src/test/java/egovframework/com/utl/message/TestMessage.java:79:		message2 = EgovMessageUtil.getErrorMsg("param.message", new String[] {"Error", "No expected value."});
```

바뀐 줄 3줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
