### PR TITLE
docs: 일지관리 가이드의 Message properties 경로를 실제 dsm 전용 파일에 맞춰 정정

### DIFF
--- a/common-component/collaboration/journal-management.md
+++ b/common-component/collaboration/journal-management.md
@@ -57,8 +57,8 @@ flowchart LR
 | Query XML | resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_postgres.xml | 일지관리를 위한 PostgreSQL용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_tibero.xml | 일지관리를 위한 Tibero용 Query XML |
 | Query XML | resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_goldilocks.xml | 일지관리를 위한 Goldilocks용 Query XML |
-| Message properties | resources/egovframework/message/com/message-common_ko.properties | 일지관리 Message properties(한글) |
-| Message properties | resources/egovframework/message/com/message-common_en.properties | 일지관리 Message properties(영문) |
+| Message properties | resources/egovframework/message/com/cop/smt/dsm/message_ko.properties | 일지관리 Message properties(한글) |
+| Message properties | resources/egovframework/message/com/cop/smt/dsm/message_en.properties | 일지관리 Message properties(영문) |
 | Idgen XML | resources/egovframework/spring/com/idgn/context-idgn-diaryManage.xml | 일지관리 Id생성 Idgen XML |
 
 ### 클래스 다이어그램


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

`journal-management.md` 의 Message properties 경로가 공용 `message-common_ko/en.properties` 로 적혀 있는데, 일지관리 전용 메시지 파일은 `com/cop/smt/dsm/message_ko/en.properties` 로 따로 있어 그 경로로 고쳤습니다.

아래 확인은 구현 저장소인 egovframe-common-components 기준입니다.

```
$ git ls-tree -r --name-only origin/main | grep "com/cop/smt/dsm/" | grep -i message
src/main/resources/egovframework/message/com/cop/smt/dsm/message_en.properties
src/main/resources/egovframework/message/com/cop/smt/dsm/message_ko.properties
$ git show origin/main:src/main/resources/egovframework/message/com/message-common_ko.properties | grep -n "comCopSmtDsm"; echo "grep exit: $?"
grep exit: 1
$ grep -n "spring:message code=\"comCopSmtDsm.title\"" src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/dsm/EgovDiaryManageList.jsp
28:<c:set var="pageTitle"><spring:message code="comCopSmtDsm.title"/></c:set>
```

바뀐 줄 2줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
