### PR TITLE
docs: 암호화/복호화 가이드의 crypto 모듈 좌표를 실제 Maven 좌표에 맞춰 정정

### DIFF
--- a/common-component/security/encrypt_decrypt.md
+++ b/common-component/security/encrypt_decrypt.md
@@ -21,7 +21,7 @@
 
 ## 전제조건
 
- 암복호화 기능을 사용하기 위해서는 전자정부 표준프레임워크 실행환경중 egovframework.rte.fdl.crypto-x.x.x.jar 라이브러리를 필요로 한다.
+ 암복호화 기능을 사용하기 위해서는 전자정부 표준프레임워크 실행환경중 egovframe-rte-fdl-crypto-x.x.x.jar 라이브러리를 필요로 한다.
 
  보다 자세한 사항은 실행환경의 [암호화/복호화](/egovframe-runtime/foundation-layer/crypto-encryption-decryption.md) 서비스를 참조한다.
 
@@ -64,8 +64,8 @@ flowchart LR
 
 ```xml
 <dependency>
-    <groupId>egovframework.rte</groupId>
-    <artifactId>egovframework.rte.fdl.crypto</artifactId>
+    <groupId>org.egovframe.rte</groupId>
+    <artifactId>egovframe-rte-fdl-crypto</artifactId>
     <version>${egovframework.rte.version}</version>
 </dependency>
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

암호화/복호화 문서의 crypto 라이브러리 jar 파일명과 pom.xml dependency 예시가 egovframe-common-components의 실제 Maven 좌표와 달라(옛 dotted 이름 egovframework.rte.fdl.crypto), 실제 좌표인 org.egovframe.rte / egovframe-rte-fdl-crypto로 고쳤습니다.

```
$ git show origin/main:pom.xml | grep -B2 -A2 fdl-crypto
		<dependency>
			<groupId>org.egovframe.rte</groupId>
			<artifactId>egovframe-rte-fdl-crypto</artifactId>
		</dependency>
		<dependency>
```

바뀐 줄 3줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
