### PR TITLE
docs: 접속 통계 가이드의 스케줄러 Bean id를 실제 sysLogScheduler 에 맞춰 정정

### DIFF
--- a/common-component/statistics-reporting/connection-statistics.md
+++ b/common-component/statistics-reporting/connection-statistics.md
@@ -120,7 +120,7 @@ public class EgovSysLogScheduling extends EgovAbstractServiceImpl {
 - 스케줄러 Bean 설정(src/main/resources/egovframework/spring/com/context-scheduling-sym-log-lgm.xml)
 
 ```xml
-<bean id="logSummaryScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+<bean id="sysLogScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
     <property name="triggers">
         <list>
             <ref bean="sysLogTrigger" />


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

접속 통계 가이드의 "스케줄러 Bean 설정" 예제에서 Bean id 가 `logSummaryScheduler` 로 적혀 있는데, 공통컴포넌트의 실제 파일(`context-scheduling-sym-log-lgm.xml`)에는 `sysLogScheduler` 로 정의돼 있어 그 값으로 고쳤습니다.

```
$ git -C egovframe-common-components show origin/main:src/main/resources/egovframework/spring/com/scheduling/context-scheduling-sym-log-lgm.xml | grep -n "bean id"
6:	<bean id="sysLogging" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
13:	<bean id="sysLogTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
22:	<bean id="sysLogScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
```

바뀐 줄 1줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
