### PR TITLE
docs: 번호유효성체크 가이드의 외국인등록번호 체크 메서드명을 실제 checkForeignNumber에 맞춰 정정

### DIFF
--- a/common-component/elementary-technology/id-number-validation.md
+++ b/common-component/elementary-technology/id-number-validation.md
@@ -35,8 +35,8 @@ menu:
 | `boolean` | `checkBubinNumber(String bubin)` | 법인번호 유효성체크 | 법인번호(`-` 제외) 문자열을 입력받아 유효성 체크 |
 | `boolean` | `checkCompNumber(String c1, String c2, String c3)` | 사업자번호 유효성체크 | 사업자번호 앞, 중간, 뒤 문자열을 입력받아 유효성 체크 |
 | `boolean` | `checkCompNumber(String comp)` | 사업자번호 유효성체크 | 사업자번호(`-` 제외) 문자열을 입력받아 유효성 체크 |
-| `boolean` | `checkforeignNumber(String for1, String for2)` | 외국인번호 유효성체크 | 외국인등록번호 앞, 뒤 문자열을 입력받아 유효성 체크 |
-| `boolean` | `checkforeignNumber(String foreign)` | 외국인번호 유효성체크 | 외국인등록번호(`-` 제외) 문자열을 입력받아 유효성 체크 |
+| `boolean` | `checkForeignNumber(String for1, String for2)` | 외국인번호 유효성체크 | 외국인등록번호 앞, 뒤 문자열을 입력받아 유효성 체크 |
+| `boolean` | `checkForeignNumber(String foreign)` | 외국인번호 유효성체크 | 외국인등록번호(`-` 제외) 문자열을 입력받아 유효성 체크 |
 
 - **Input**: 해당하는 입력란의 `String` 형태의 번호
 - **Output**: `boolean` (유효 여부)
@@ -80,8 +80,8 @@ String foreign1 = "831231";
 String foreign2 = "576545";
 String foreign  = "831231576545";
 
-boolean isForeignValid1 = EgovNumberCheckUtil.checkforeignNumber(foreign1, foreign2);
-boolean isForeignValid2 = EgovNumberCheckUtil.checkforeignNumber(foreign);
+boolean isForeignValid1 = EgovNumberCheckUtil.checkForeignNumber(foreign1, foreign2);
+boolean isForeignValid2 = EgovNumberCheckUtil.checkForeignNumber(foreign);
 
 // ...
 ```


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

번호유효성체크 가이드의 메소드 표와 사용 예제에 적힌 외국인등록번호 체크 메서드명이 `checkforeignNumber`이나 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`)의 `EgovNumberCheckUtil.java`에 정의된 실제 메서드명은 `checkForeignNumber`여서 이에 맞춰 고쳤습니다.

```
# eGovFramework/egovframe-common-components 클론에서 실행
$ git grep -n 'checkforeignNumber' origin/main -- '*.java'
$ git grep -n 'public static boolean checkForeignNumber' origin/main -- '*.java'
origin/main:src/main/java/egovframework/com/utl/fcc/service/EgovNumberCheckUtil.java:233:	public static boolean checkForeignNumber(String foreign1, String foreign2) {
origin/main:src/main/java/egovframework/com/utl/fcc/service/EgovNumberCheckUtil.java:304:	public static boolean checkForeignNumber(String foreign) {
```

바뀐 줄 4줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
