### PR TITLE
docs: 개인정보보호정책확인 가이드의 Controller method 표기를 실제 메서드명에 맞춰 정정

### DIFF
--- a/common-component/user-support/privacy-policy.md
+++ b/common-component/user-support/privacy-policy.md
@@ -112,7 +112,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('INDVDL_INFO_ID', 1);
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 목록조회 | /uss/sam/ipm/listIndvdlInfoPolicy.do | EgovIndvdlInfoPolicyList | "IndvdlInfoPolicy" | "selectIndvdlInfoPolicy" |
+| 목록조회 | /uss/sam/ipm/listIndvdlInfoPolicy.do | egovIndvdlInfoPolicyList | "IndvdlInfoPolicy" | "selectIndvdlInfoPolicy" |
 |  |  |  | "IndvdlInfoPolicy" | "selectIndvdlInfoPolicyCnt" |
 
  ![image](./images/uss-privacy-개인정보_목록.jpg)
@@ -134,8 +134,8 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('INDVDL_INFO_ID', 1);
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 상세조회 | /uss/sam/ipm/detailIndvdlInfoPolicy.do | EgovIndvdlInfoPolicyDetail | "IndvdlInfoPolicy" | "selectIndvdlInfoPolicyDetail" |
-| 삭제 | /uss/sam/ipm/detailIndvdlInfoPolicy.do | EgovIndvdlInfoPolicyDetail | "IndvdlInfoPolicy" | "deleteIndvdlInfoPolicy" |
+| 상세조회 | /uss/sam/ipm/detailIndvdlInfoPolicy.do | egovIndvdlInfoPolicyDetail | "IndvdlInfoPolicy" | "selectIndvdlInfoPolicyDetail" |
+| 삭제 | /uss/sam/ipm/detailIndvdlInfoPolicy.do | egovIndvdlInfoPolicyDetail | "IndvdlInfoPolicy" | "deleteIndvdlInfoPolicy" |
 
  ![image](./images/uss-privacy-개인정보_상세.jpg)
 
@@ -157,7 +157,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('INDVDL_INFO_ID', 1);
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 등록 | /uss/sam/ipm/registIndvdlInfoPolicy.do | EgovIndvdlInfoPolicyRegist | "IndvdlInfoPolicy" | "insertIndvdlInfoPolicy" |
+| 등록 | /uss/sam/ipm/registIndvdlInfoPolicy.do | egovIndvdlInfoPolicyRegist | "IndvdlInfoPolicy" | "insertIndvdlInfoPolicy" |
 
  ![image](./images/uss-privacy-개인정보_등록.jpg)
 
@@ -178,7 +178,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('INDVDL_INFO_ID', 1);
 
 | Action | URL | Controller method | SQL Namespace | SQL QueryID |
 | --- | --- | --- | --- | --- |
-| 수정 | /uss/sam/ipm/updtIndvdlInfoPolicy.do | EgovIndvdlInfoPolicyModify | "IndvdlInfoPolicy" | "updateIndvdlInfoPolicy" |
+| 수정 | /uss/sam/ipm/updtIndvdlInfoPolicy.do | egovIndvdlInfoPolicyModify | "IndvdlInfoPolicy" | "updateIndvdlInfoPolicy" |
 
  ![image](./images/uss-privacy-개인정보_수정.jpg)
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

`privacy-policy.md` 의 Controller method 칸이 대문자로 시작하는 반환 뷰 이름(`EgovIndvdlInfoPolicyList` 등)을 적고 있어, 공통컴포넌트 저장소(`eGovFramework/egovframe-common-components`) `main` 의 `EgovIndvdlInfoPolicyController` 실제 메서드명인 소문자 시작 이름으로 고쳤습니다.

```
$ git show origin/main:src/main/java/egovframework/com/uss/sam/ipm/web/EgovIndvdlInfoPolicyController.java | grep -n "RequestMapping(\"\|PostMapping(\"\|public String egov"
76:	@RequestMapping("/uss/sam/ipm/listIndvdlInfoPolicy.do")
77:	public String egovIndvdlInfoPolicyList(@ModelAttribute("searchVO") ComDefaultVO searchVO,
121:	@PostMapping("/uss/sam/ipm/detailIndvdlInfoPolicy.do")
122:	public String egovIndvdlInfoPolicyDetail(@ModelAttribute("searchVO") ComDefaultVO searchVO,
158:	@PostMapping("/uss/sam/ipm/updtIndvdlInfoPolicyView.do")
159:	public String egovIndvdlInfoPolicyModify(@ModelAttribute("searchVO") ComDefaultVO searchVO,
188:	@PostMapping("/uss/sam/ipm/updtIndvdlInfoPolicy.do")
190:	public String egovIndvdlInfoPolicyModify(@ModelAttribute("searchVO") ComDefaultVO searchVO,
228:	@PostMapping("/uss/sam/ipm/registIndvdlInfoPolicyView.do")
229:	public String egovIndvdlInfoPolicyRegist(@ModelAttribute("searchVO") ComDefaultVO searchVO,
254:	@PostMapping("/uss/sam/ipm/registIndvdlInfoPolicy.do")
256:	public String egovIndvdlInfoPolicyRegist(@ModelAttribute("searchVO") ComDefaultVO searchVO,
```

바뀐 줄 5줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
