### PR TITLE
docs: 스크랩관리 가이드의 ID 생성 prefix 값을 실제 SCRIP_ 에 맞춰 정정

### DIFF
--- a/common-component/collaboration/scrap-management.md
+++ b/common-component/collaboration/scrap-management.md
@@ -90,7 +90,7 @@ INSERT INTO COMTECOPSEQ ( TABLE_NAME, NEXT_ID ) VALUES ('SCRAP_ID', 1);
 </bean>
 <bean name="scrapStrategy"
       class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
-      <property name="prefix" value="SCRAP_" />
+      <property name="prefix" value="SCRIP_" />
       <property name="cipers" value="14" />
       <property name="fillChar" value="0" />
 </bean>


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

`common-component/collaboration/scrap-management.md`의 ID Generation Service 설정 예제에서 `scrapStrategy`의 `prefix` 값이 `SCRAP_`으로 되어 있으나, 별도 저장소 egovframe-common-components의 `src/main/resources/egovframework/spring/com/idgn/context-idgn-Scrap.xml` 설정은 `SCRIP_`이어서 이에 맞춰 정정했습니다. 아래는 그 저장소의 origin/main 기준 확인 결과입니다.

```
$ git grep -n -A3 'name="scrapStrategy"' origin/main -- '*.xml'
origin/main:src/main/resources/egovframework/spring/com/idgn/context-idgn-Scrap.xml:12:    <bean name="scrapStrategy" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
origin/main:src/main/resources/egovframework/spring/com/idgn/context-idgn-Scrap.xml-13-        <property name="prefix"   value="SCRIP_" />
origin/main:src/main/resources/egovframework/spring/com/idgn/context-idgn-Scrap.xml-14-        <property name="cipers"   value="14" />
origin/main:src/main/resources/egovframework/spring/com/idgn/context-idgn-Scrap.xml-15-        <property name="fillChar" value="0" />
```

바뀐 줄 1줄입니다.

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
