### PR TITLE
chore: docs_lint L5 에서 --src 를 여러 번 받고 백틱 없는 Egov 클래스명도 대조

### DIFF
--- a/docs_lint.md
+++ b/docs_lint.md
@@ -61,8 +61,12 @@ Python 3가 필요하며, 별도 패키지 설치는 필요하지 않습니다.<
 #### L5 source-ref
 : 관련소스 클래스 참조가 실제 저장소에 없음 (`--src`로 소스 저장소 지정 시)
 - 문서의 백틱 클래스명(`egovframework.*`, `org.egovframe.*`)이 실제 Java 소스에 있는지 확인합니다.
-- `--src`를 지정하지 않으면 L5는 동작하지 않습니다.
+- `--src`를 지정하지 않으면 L5는 동작하지 않습니다. `--src`는 여러 번 줄 수 있고, 준 저장소들의 클래스를 합쳐 대조합니다.
 - 예시: `python3 scripts/docs_lint.py common-component --src ../egovframe-common-components`
+- 예시: `python3 scripts/docs_lint.py egovframe-runtime --src ../egovframe-runtime --src ../egovframe-ai-rag`
+- 검출 코드
+    - `L5`: 백틱 클래스명이 소스에 없습니다.
+    - `L5-name`: 본문·표에 쓴 `Egov`로 시작하는 클래스명(백틱 여부 무관, 코드블록 제외)이 소스에 없습니다. 예제용 이름이거나 `--src`로 주지 않은 저장소의 클래스일 수 있으니 확인 후 수정합니다.
 
 ## 결과
 ### 출력

--- a/scripts/docs_lint.py
+++ b/scripts/docs_lint.py
@@ -7,42 +7,44 @@ L2 broken-rel-link   : 상대링크 대상 파일 부재 (렌더링 사이트 �
 L3 frontmatter       : frontmatter 부재/title·url 누락 (README·docs/ 제외)
 L4 heading-level     : H1 부재 또는 레벨 건너뜀(h2→h4 등)
 L5 source-ref        : 관련소스 클래스 참조가 실제 저장소에 없음 (--src 로 소스 저장소 지정 시)
+L5-name              : 문서에 쓴 Egov 클래스명이 --src 저장소들에 없음 (확인 권장)
 
-사용법: python3 docs_lint.py <docs-root> [--src <java-src-root>] [--json]
+사용법: python3 docs_lint.py <docs-root> [--src <java-src-root>]... [--json]
 """
 import re, os, sys, glob, json, urllib.parse
 from collections import defaultdict
 
 
-USAGE = 'usage: python3 docs_lint.py <docs-root> [--src <java-src-root>] [--json]'
+USAGE = 'usage: python3 docs_lint.py <docs-root> [--src <java-src-root>]... [--json]'
 
 
 def parse_args(argv):
     if len(argv) < 2 or argv[1].startswith('-'):
         print(USAGE); sys.exit(2)
-    root = argv[1]; src = None; as_json = False
+    root = argv[1]; srcs = []; as_json = False
     if not os.path.isdir(root):
         print('error: not a directory: ' + root); print(USAGE); sys.exit(2)
-    if '--src' in argv:
-        i = argv.index('--src') + 1
-        if i >= len(argv):
-            print('error: --src requires a path'); print(USAGE); sys.exit(2)
-        src = argv[i]
+    for i, a in enumerate(argv):
+        if a == '--src':
+            if i + 1 >= len(argv) or argv[i + 1].startswith('--'):
+                print('error: --src requires a path'); print(USAGE); sys.exit(2)
+            srcs.append(argv[i + 1])
     if '--json' in argv: as_json = True
-    return root, src, as_json
+    return root, srcs, as_json
 
 
 def main():
-    ROOT, SRC, AS_JSON = parse_args(sys.argv)
+    ROOT, SRCS, AS_JSON = parse_args(sys.argv)
     findings = []
     mds = [m for m in glob.glob(ROOT + '/**/*.md', recursive=True) if '/.git/' not in m]
 
     cls_index = set()
-    if SRC:
-        for p in glob.glob(SRC + '/**/*.java', recursive=True):
+    for src in SRCS:
+        for p in glob.glob(src + '/**/*.java', recursive=True):
             if '/main/' in p:
                 rel = p.split('/src/main/java/')[-1][:-5]
                 cls_index.add(rel.replace('/', '.'))
+    simple_index = {c.split('.')[-1] for c in cls_index}
 
     for md in mds:
         rel = os.path.relpath(md, ROOT)
@@ -104,6 +106,10 @@ def main():
                     simple = ref.split('.')[-1]
                     if not any(c.endswith('.' + simple) for c in cls_index):
                         findings.append((rel, 0, 'L5', '실소스 부재 참조: ' + ref))
+            # 백틱 없이 쓴 Egov 클래스명 — 한글 조사가 바로 붙어도 잡고, EgovXxx_SQL_mysql.xml·EgovXxx.jsp 같은 파일명 조각과 패키지 경로 안의 이름은 뺀다
+            names = set(re.findall(r'(?<![A-Za-z0-9_./-])(Egov[A-Z][A-Za-z0-9]*)(?![A-Za-z0-9_/-]|\.(?:jsp|xml|js|css|html|properties|sql|vm|hbs|ts|tsx|md)\b)', body))
+            for name in sorted(names - simple_index):
+                findings.append((rel, 0, 'L5-name', '실소스 부재 클래스명: ' + name))
 
     by = defaultdict(int)
     for f in findings: by[f[2]] += 1


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [ ] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [x] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

`scripts/docs_lint.py` 의 L5 가 `--src` 를 여러 번 받아 클래스 색인을 합치고, 본문·표에 백틱 없이 쓴 `Egov` 로 시작하는 클래스명도 대조하게 했습니다. 새 검출 코드는 `L5-name` 이고, `docs_lint.md` 의 L5 설명에 추가했습니다.

- `--src` 를 주지 않으면 L5 는 지금처럼 돌지 않고, 나머지 검사 결과도 바뀌지 않습니다.
- 한글 조사가 바로 붙은 이름(`EgovFixedLineAggregator를`)도 잡고, `EgovXxx_SQL_mysql.xml`·`EgovXxx.jsp` 같은 파일명 조각과 패키지 경로 안의 이름은 뺍니다. 코드블록 안은 기존 L5 와 같이 대조하지 않습니다.

이 파일이 정정되기 전 커밋(`fce9fc65`)의 `egovframe-runtime/batch-layer` 로 돌린 결과입니다.

```
$ python3 scripts/docs_lint.py egovframe-runtime/batch-layer --src ../egovframe-runtime | grep EgovFixedLineAggregator
L5-name batch-core-item_writer.md:0 실소스 부재 클래스명: EgovFixedLineAggregator
```

## 관련 이슈 (Related Issues)

Closes #1116

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [x] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

`--src` 없이 저장소 전체를 돌린 `--json` 결과는 변경 전 스크립트와 같습니다.
