### PR TITLE
chore: docs_lint 를 매주 소스 저장소와 함께 돌리는 워크플로 추가

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,53 @@
+name: Docs Lint
+
+on:
+  schedule:
+    # 매주 월요일 00:00 UTC (KST 09:00)
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout egovframe-docs
+        uses: actions/checkout@v4
+
+      - name: Checkout egovframe-runtime
+        uses: actions/checkout@v4
+        with:
+          repository: eGovFramework/egovframe-runtime
+          path: _src/egovframe-runtime
+
+      - name: Checkout egovframe-common-components
+        uses: actions/checkout@v4
+        with:
+          repository: eGovFramework/egovframe-common-components
+          path: _src/egovframe-common-components
+
+      - name: Checkout egovframe-ai-rag
+        uses: actions/checkout@v4
+        with:
+          repository: eGovFramework/egovframe-ai-rag
+          path: _src/egovframe-ai-rag
+
+      - name: Run docs_lint
+        shell: bash
+        run: |
+          {
+            echo '## egovframe-runtime'
+            echo '```'
+            python3 scripts/docs_lint.py egovframe-runtime --src _src/egovframe-runtime --src _src/egovframe-ai-rag
+            echo '```'
+            echo '## common-component'
+            echo '```'
+            python3 scripts/docs_lint.py common-component --src _src/egovframe-common-components --src _src/egovframe-runtime
+            echo '```'
+            echo '## egovframe-development'
+            echo '```'
+            python3 scripts/docs_lint.py egovframe-development
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/docs_lint.md
+++ b/docs_lint.md
@@ -22,6 +22,7 @@ Python 3가 필요하며, 별도 패키지 설치는 필요하지 않습니다.<
 - 특정 디렉토리만 검사: `python3 scripts/docs_lint.py common-component`
 - 클래스 참조 검사(L5): `python3 scripts/docs_lint.py common-component --src <java-src-root>`
 - 결과 전체 JSON 출력: `--json` 옵션 추가
+- 정기 점검: `.github/workflows/docs-lint.yml`이 매주 월요일 실행환경·공통컴포넌트·AI RAG 소스를 받아 위 검사를 돌리고, 결과를 Actions 실행 요약(Summary)에 남깁니다. Actions 탭의 Run workflow로 바로 실행할 수도 있습니다.
 
 ### 3. 정합성 오류 목록
 #### L1 truncated-summary


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [ ] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [x] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

`scripts/docs_lint.py` 를 정기적으로 돌리는 워크플로 `.github/workflows/docs-lint.yml` 을 추가했습니다. L5·L5-name 은 소스 저장소가 있어야 돌기 때문에, 워크플로가 `egovframe-runtime`·`egovframe-common-components`·`egovframe-ai-rag` 를 함께 받아 `--src` 로 넘깁니다.

- 매주 월요일 00:00 UTC 에 돌고, Actions 탭의 Run workflow 로 바로 돌릴 수도 있습니다.
- 결과는 영역별로 Actions 실행 요약(Summary)에 남깁니다. 검출이 있어도 실패로 처리하지 않고, 스크립트 자체가 실패하면 단계가 실패합니다.
- 권한은 `contents: read` 만 씁니다.
- `docs_lint.md` 의 실행 방법에 정기 점검 설명을 한 줄 더했습니다.

`actionlint` 로 워크플로 문법을 확인했고, `Run docs_lint` 단계의 명령을 로컬 클론으로 그대로 돌려 끝까지 실행되는 것을 확인했습니다.

## 관련 이슈 (Related Issues)

Refs #1116

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [x] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [ ] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
