### PR TITLE
docs: History Management 가이드의 시간 필드 타입 표기를 실제 java.time.LocalDateTime 에 맞춰 정정

### DIFF
--- a/egovframe-runtime/batch-layer/batch-core-history_management.md
+++ b/egovframe-runtime/batch-layer/batch-core-history_management.md
@@ -33,11 +33,11 @@ menu:
 | JobExecution 속성 | 설명 |
 | --- | --- |
 | status | BatchStatus는 실행 상태를 나타내는 객체이다, 실행하는 동안에는 BatchStatus,STARTED, 실행이 실패한 경우 BatchStatus.FAILED, 실행이 성공적으로 종료됐을 경우 BatchStatus.COMPLETED가 된다. |
-| startTime | Execution이 시작되는 현재 시스템 시간을 java.Util.Data로 저장 |
-| endTime | Execution의 성공/실패 여부와 관계없이 종료되는 현재 시스템 시간을 java.Util.Data로 저장 |
+| startTime | Execution이 시작되는 현재 시스템 시간을 java.time.LocalDateTime로 저장 |
+| endTime | Execution의 성공/실패 여부와 관계없이 종료되는 현재 시스템 시간을 java.time.LocalDateTime로 저장 |
 | exitStatus | ExitStatus는 실행의 결과를 나타낸다. 호출자에게 반환될 exit code를 포함한다. |
-| createTime | JobExecution이 최초 생성 된 현재 시스템 시간을 java.Util.Data로 저장 |
-| lastUpdated | JobExecution이 마지막으로 생성 된 현재 시스템 시간을 java.Util.Data로 저장 |
+| createTime | JobExecution이 최초 생성 된 현재 시스템 시간을 java.time.LocalDateTime로 저장 |
+| lastUpdated | JobExecution이 마지막으로 생성 된 현재 시스템 시간을 java.time.LocalDateTime로 저장 |
 | executionContext | execution간 지속돼야 할 모든 데이터를 포함하는 '프로퍼티 백' |
 | failureExceptions | Job이 실행되는 동안 발생한 익셉션 리스트 |
 
@@ -58,8 +58,8 @@ menu:
 | StepExecution 속성 | 설명 |
 | --- | --- |
 | status | BatchStatus는 실행 상태를 나타내는 객체이다, 실행하는 동안에는 BatchStatus,STARTED, 실행이 실패한 경우 BatchStatus.FAILED, 실행이 성공적으로 종료됐을 경우 BatchStatus.COMPLETED가 된다. |
-| startTime | Execution이 시작되는 현재 시스템 시간을 java.Util.Data로 저장 |
-| endTime | Execution의 성공/실패 여부와 관계없이 종료되는 현재 시스템 시간을 java.Util.Data로 저장 |
+| startTime | Execution이 시작되는 현재 시스템 시간을 java.time.LocalDateTime로 저장 |
+| endTime | Execution의 성공/실패 여부와 관계없이 종료되는 현재 시스템 시간을 java.time.LocalDateTime로 저장 |
 | exitStatus | ExitStatus는 실행의 결과를 나타낸다. 호출자에게 반환될 exit code를 포함한다. |
 | executionContext | execution간 지속돼야 할 모든 데이터를 포함하는 '프로퍼티 백' |
 | readCount | 성공적으로 읽은 item 개수 |


### PR DESCRIPTION
## 변경 유형 (Type of Change)

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

History Management 문서의 JobExecution/StepExecution 시간 필드 설명에 있는 java.Util.Data 표기를 Spring Batch(5.2.3)의 실제 필드 타입인 java.time.LocalDateTime 으로 고쳤습니다.

```
$ javap -private -cp ~/.m2/repository/org/springframework/batch/spring-batch-core/5.2.3/spring-batch-core-5.2.3.jar org.springframework.batch.core.JobExecution org.springframework.batch.core.StepExecution 2>/dev/null | grep -E "class|startTime|endTime|createTime|lastUpdated"
public class org.springframework.batch.core.JobExecution extends org.springframework.batch.core.Entity {
  private volatile java.time.LocalDateTime startTime;
  private volatile java.time.LocalDateTime createTime;
  private volatile java.time.LocalDateTime endTime;
  private volatile java.time.LocalDateTime lastUpdated;
public class org.springframework.batch.core.StepExecution extends org.springframework.batch.core.Entity {
  private volatile java.time.LocalDateTime startTime;
  private volatile java.time.LocalDateTime createTime;
  private volatile java.time.LocalDateTime endTime;
  private volatile java.time.LocalDateTime lastUpdated;
```

바뀐 줄 6줄

## 관련 이슈 (Related Issues)

없습니다.

## 변경 영역 (Affected Areas)

- [ ] 개발환경 (`egovframe-development/`)
- [x] 실행환경 (`egovframe-runtime/`)
- [ ] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [x] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

없습니다.
