### PR TITLE
docs: 우편번호 관리 가이드의 context-excel.xml 예제를 실제 sqlSessionTemplate 빈 설정에 맞춰 정정

### DIFF
--- a/common-component/system-management/zipcode-management.md
+++ b/common-component/system-management/zipcode-management.md
@@ -92,15 +92,13 @@ flowchart LR
 
 ```xml
     <bean id="excelZipService"	class="org.egovframe.rte.fdl.excel.impl.EgovExcelServiceImpl">
-       <property name="propertyPath" value="excelInfo.xml" />
        <property name="mapClass" value="egovframework.com.sym.ccm.zip.service.impl.EgovCcmExcelZipMapping" />
-       <property name="sqlMapClient" ref="egov.sqlMapClient" />
+       <property name="sqlSessionTemplate" ref="egov.sqlSessionTemplate" />
     </bean>
  
     <bean id="excelRdnmadZipService"	class="org.egovframe.rte.fdl.excel.impl.EgovExcelServiceImpl">
-        <property name="propertyPath" value="excelInfo.xml" />
         <property name="mapClass" value="egovframework.com.sym.ccm.zip.service.impl.EgovCcmExcelRdnmadZipMapping" />
-        <property name="sqlMapClient" ref="egov.sqlMapClient" />
+        <property name="sqlSessionTemplate" ref="egov.sqlSessionTemplate" />
     </bean>
 ```
 


### PR DESCRIPTION
## 변경 유형 (Type of Change)

<!-- 해당하는 항목에 [x] 표시해주세요. -->

- [ ] 신규 문서 추가 (docs/new)
- [ ] 기존 문서 보완 (docs/update)
- [x] 문서 오류 수정 (fix)
- [ ] 이미지 추가/수정 (assets)
- [ ] 빌드/설정/기타 (chore)

## 변경 내용 (Description)

<!-- 이 PR에서 무엇을, 왜 변경했는지 설명해주세요. -->

우편번호 관리 문서의 context-excel.xml 예제에 실제 빈 설정에는 없는 propertyPath 속성과 존재하지 않는 sqlMapClient 참조가 적혀 있어, 실제 설정대로 propertyPath를 지우고 sqlMapClient를 sqlSessionTemplate로 고쳤습니다.

```
$ git show origin/main:src/main/resources/egovframework/spring/com/context-excel.xml
<?xml version="1.0" encoding="UTF-8"?>
<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

	<bean id="excelZipService" class="org.egovframe.rte.fdl.excel.impl.EgovExcelServiceImpl">
		<property name="mapClass" value="egovframework.com.sym.ccm.zip.service.impl.EgovCcmExcelZipMapping" />
		<property name="sqlSessionTemplate" ref="egov.sqlSessionTemplate" />
	</bean>
	
	<bean id="excelRdnmadZipService" class="org.egovframe.rte.fdl.excel.impl.EgovExcelServiceImpl">
		<property name="mapClass" value="egovframework.com.sym.ccm.zip.service.impl.EgovCcmExcelRdnmadZipMapping" />
		<property name="sqlSessionTemplate" ref="egov.sqlSessionTemplate" />
	</bean>

</beans>
```

바뀐 줄 6줄

## 관련 이슈 (Related Issues)

<!-- 관련 이슈가 있다면 연결해주세요. 예) Closes #123 -->

없습니다.

## 변경 영역 (Affected Areas)

<!-- 변경이 영향을 주는 영역에 [x] 표시해주세요. -->

- [ ] 개발환경 (`egovframe-development/`)
- [ ] 실행환경 (`egovframe-runtime/`)
- [x] 공통컴포넌트 (`common-component/`)
- [ ] 기타 (`README`, 설정 파일 등)

## 체크리스트 (Checklist)

- [x] Push 전에 Pull을 했습니다.
- [x] frontmatter의 `title`, `url`, `menu`, `weight` 등을 검토했습니다.
- [ ] 오탈자 및 맞춤법을 검토했습니다.
- [ ] 이미지 및 링크 경로가 올바른지 확인했습니다.
- [x] 변경 영역 외 디렉토리에 불필요한 변경이 포함되지 않았습니다.

## 추가 참고 사항 (Additional Notes)

<!-- 리뷰어가 알아야 할 내용이 있다면 자유롭게 작성해주세요. -->

없습니다.
